### PR TITLE
Phase 2: Add operator controls for scheduler and consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,25 @@ Flow:
    Expected events:
    `goal.created`, `goal.activated`, `task.created`, `task.started`, `task.failed`, `task.retried`, `task.failed`, `task.poison.detected`, `goal.escalation_pending`, `goal.hitl_approved`
 
+## Operator Controls
+
+The dashboard now includes an `Operator Controls` section for supervised Phase 2 operations.
+
+- `Age Queue`
+  Ages every queued or active queue entry once and updates `wait_cycles` and effective priority.
+- `Pick Next Goal`
+  Runs the scheduler pick logic and activates the highest-priority queued goal.
+- `Drain Events`
+  Manually runs one consumer batch and marks pending events as processed for the given consumer id.
+- `Reclaim Stuck`
+  Resets timed-out `processing` entries back to `pending` for the given consumer id.
+
+The queue table in this section shows:
+- goal state
+- queue status
+- wait cycles
+- base vs. effective priority
+
 ## Run The Test Suite
 
 ```powershell
@@ -140,7 +159,7 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 Current result during implementation:
 
 ```text
-19 passed
+24 passed
 ```
 
 ## Troubleshooting

--- a/goal_ops_console/routers/system.py
+++ b/goal_ops_console/routers/system.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
 
-from goal_ops_console.config import MAX_TOTAL_RETRIES_PER_CYCLE, SPEC_VERSION
+from goal_ops_console.config import CONSUMER_BATCH_SIZE, MAX_TOTAL_RETRIES_PER_CYCLE, SPEC_VERSION
 from goal_ops_console.services import AppServices, get_services
 
 router = APIRouter(tags=["system"])
@@ -24,6 +24,7 @@ def system_health(services: AppServices = Depends(get_services)) -> dict:
     total_tasks = services.db.fetch_scalar("SELECT COUNT(*) FROM task_state") or 0
     return {
         "spec_version": SPEC_VERSION,
+        "default_consumer_id": services.settings.consumer_id,
         "totals": {
             "events": int(total_events),
             "goals": int(total_goals),
@@ -34,3 +35,61 @@ def system_health(services: AppServices = Depends(get_services)) -> dict:
         "stuck_events": services.event_bus.stuck_events(),
         "invariant_violations": services.state_manager.find_invariant_violations(),
     }
+
+
+@router.get("/system/queue")
+def queue_snapshot(services: AppServices = Depends(get_services)) -> list[dict]:
+    rows = services.db.fetch_all(
+        """SELECT g.goal_id,
+                  g.title,
+                  g.state,
+                  q.status AS queue_status,
+                  q.base_priority,
+                  q.priority,
+                  q.wait_cycles,
+                  q.force_promoted,
+                  q.created_at,
+                  q.updated_at
+           FROM goal_queue q
+           JOIN goals g ON g.goal_id = q.goal_id
+           ORDER BY q.priority DESC, q.created_at ASC"""
+    )
+    return [dict(row) for row in rows]
+
+
+@router.post("/system/scheduler/age")
+def age_scheduler_queue(services: AppServices = Depends(get_services)) -> dict:
+    aged = [goal for goal in services.scheduler.age_queue() if goal]
+    return {"aged_count": len(aged), "goals": aged}
+
+
+@router.post("/system/scheduler/pick")
+def pick_next_goal(services: AppServices = Depends(get_services)) -> dict:
+    picked = services.scheduler.pick_next_goal()
+    return {"picked_goal": picked}
+
+
+@router.post("/system/consumers/{consumer_id}/drain")
+def drain_consumer(
+    consumer_id: str,
+    batch_size: int = CONSUMER_BATCH_SIZE,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    handled: list[str] = []
+    processed = services.event_bus.consume_batch(
+        consumer_id,
+        lambda event: handled.append(event["event_id"]),
+        batch_size=batch_size,
+    )
+    return {
+        "consumer_id": consumer_id,
+        "batch_size": batch_size,
+        "processed_count": processed,
+        "processed_event_ids": handled,
+    }
+
+
+@router.post("/system/consumers/{consumer_id}/reclaim")
+def reclaim_consumer(consumer_id: str, services: AppServices = Depends(get_services)) -> dict:
+    reclaimed = services.event_bus.reclaim_stuck_processing(consumer_id)
+    return {"consumer_id": consumer_id, "reclaimed_count": reclaimed}

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -1,6 +1,7 @@
 const stateClass = (value) => `state-${String(value || "").replaceAll(" ", "_")}`;
 
 let selectedGoalId = "";
+let defaultConsumerId = "goal_ops_console";
 
 async function api(path, options = {}) {
   const response = await fetch(path, {
@@ -169,6 +170,11 @@ function renderEvents(events) {
 }
 
 function renderHealth(health) {
+  defaultConsumerId = health.default_consumer_id || defaultConsumerId;
+  const consumerInput = document.getElementById("consumer-id");
+  if (consumerInput && !consumerInput.value.trim()) {
+    consumerInput.value = defaultConsumerId;
+  }
   document.getElementById("health-cards").innerHTML = `
     <div class="card"><span class="meta">Events</span><strong>${health.totals.events}</strong></div>
     <div class="card"><span class="meta">Goals</span><strong>${health.totals.goals}</strong></div>
@@ -192,11 +198,51 @@ function renderHealth(health) {
     : `<div class="meta">No invariant violations detected.</div>`;
 }
 
+function renderQueue(goals) {
+  const container = document.getElementById("queue-table");
+  if (!goals.length) {
+    container.innerHTML = `<div class="meta">No queue entries yet.</div>`;
+    return;
+  }
+  container.innerHTML = `<div class="table-scroll"><table>
+    <thead>
+      <tr>
+        <th>Goal</th>
+        <th>State</th>
+        <th>Queue</th>
+        <th>Wait</th>
+        <th>Priority</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${goals.map((goal) => `
+        <tr>
+          <td>
+            <div><span class="inline-link" data-select-goal="${goal.goal_id}">${goal.title}</span></div>
+            <div class="meta">${goal.goal_id}</div>
+          </td>
+          <td><span class="pill ${stateClass(goal.state)}">${goal.state}</span></td>
+          <td>${goal.queue_status}</td>
+          <td>${goal.wait_cycles}</td>
+          <td>
+            <div>base ${Number(goal.base_priority || 0).toFixed(2)} / effective ${Number(goal.priority || 0).toFixed(2)}</div>
+            <div class="priority-track"><div class="priority-fill" style="width:${Math.round((goal.priority || 0) * 100)}%"></div></div>
+          </td>
+        </tr>`).join("")}
+    </tbody>
+  </table></div>`;
+}
+
 async function refreshGoals() {
   const goals = await api("/goals");
   renderGoals(goals);
   const selectedLabel = selectedGoalId ? `Selected goal: ${selectedGoalId}` : "No goal selected.";
   document.getElementById("selected-goal-label").textContent = selectedLabel;
+}
+
+async function refreshQueue() {
+  const queue = await api("/system/queue");
+  renderQueue(queue);
 }
 
 async function refreshTasks() {
@@ -223,7 +269,32 @@ async function refreshHealth() {
 }
 
 async function refreshAll() {
-  await Promise.all([refreshGoals(), refreshTasks(), refreshEvents(), refreshHealth()]);
+  await Promise.all([refreshGoals(), refreshTasks(), refreshEvents(), refreshHealth(), refreshQueue()]);
+}
+
+async function runOperatorAction(action) {
+  const consumerId = document.getElementById("consumer-id").value.trim() || defaultConsumerId;
+  const batchSize = Number(document.getElementById("consumer-batch-size").value || 50);
+  let result;
+  if (action === "age") {
+    result = await api("/system/scheduler/age", { method: "POST" });
+    document.getElementById("system-feedback").textContent = `Aged ${result.aged_count} queue entries.`;
+  } else if (action === "pick") {
+    result = await api("/system/scheduler/pick", { method: "POST" });
+    const picked = result.picked_goal;
+    document.getElementById("system-feedback").textContent = picked
+      ? `Activated goal ${picked.goal_id}.`
+      : "No queued goal was available to pick.";
+  } else if (action === "drain") {
+    result = await api(`/system/consumers/${encodeURIComponent(consumerId)}/drain?batch_size=${batchSize}`, {
+      method: "POST",
+    });
+    document.getElementById("system-feedback").textContent = `Consumer ${consumerId} processed ${result.processed_count} events.`;
+  } else if (action === "reclaim") {
+    result = await api(`/system/consumers/${encodeURIComponent(consumerId)}/reclaim`, { method: "POST" });
+    document.getElementById("system-feedback").textContent = `Consumer ${consumerId} reclaimed ${result.reclaimed_count} stuck events.`;
+  }
+  await refreshAll();
 }
 
 document.getElementById("goal-form").addEventListener("submit", async (event) => {
@@ -282,6 +353,7 @@ document.getElementById("event-filter-form").addEventListener("submit", async (e
 document.getElementById("refresh-goals").addEventListener("click", refreshGoals);
 document.getElementById("refresh-tasks").addEventListener("click", refreshTasks);
 document.getElementById("refresh-events").addEventListener("click", refreshEvents);
+document.getElementById("refresh-queue").addEventListener("click", refreshQueue);
 
 document.addEventListener("click", async (event) => {
   const goalAction = event.target.dataset.goalAction;
@@ -290,8 +362,13 @@ document.addEventListener("click", async (event) => {
   const taskId = event.target.dataset.taskId;
   const correlation = event.target.dataset.correlation;
   const selectGoal = event.target.dataset.selectGoal;
+  const operatorAction = event.target.dataset.operatorAction;
 
   try {
+    if (operatorAction) {
+      await runOperatorAction(operatorAction);
+    }
+
     if (goalAction && goalId) {
       await api(`/goals/${goalId}/${goalAction}`, { method: "POST" });
       selectedGoalId = goalId;
@@ -331,7 +408,7 @@ document.addEventListener("click", async (event) => {
       document.getElementById("selected-goal-label").textContent = `Selected goal: ${selectGoal}`;
     }
   } catch (error) {
-    const target = goalAction ? "goal-error" : "task-error";
+    const target = operatorAction ? "system-feedback" : goalAction ? "goal-error" : "task-error";
     showError(target, error);
   }
 });

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -271,6 +271,34 @@
     </section>
 
     <section class="wide">
+      <h2><span>Operator Controls</span><button class="secondary" id="refresh-queue">Refresh Queue</button></h2>
+      <div class="grid-two">
+        <div class="card">
+          <span class="meta">Scheduler</span>
+          <div class="actions" style="margin-top:0.75rem;">
+            <button type="button" data-operator-action="age">Age Queue</button>
+            <button type="button" data-operator-action="pick">Pick Next Goal</button>
+          </div>
+        </div>
+        <div class="card">
+          <span class="meta">Consumer</span>
+          <form id="consumer-form" style="margin:0.75rem 0 0;">
+            <div class="split">
+              <input id="consumer-id" placeholder="Consumer ID">
+              <input id="consumer-batch-size" type="number" min="1" max="500" value="50" placeholder="Batch size">
+            </div>
+            <div class="actions">
+              <button type="button" data-operator-action="drain">Drain Events</button>
+              <button type="button" class="secondary" data-operator-action="reclaim">Reclaim Stuck</button>
+            </div>
+          </form>
+        </div>
+      </div>
+      <div class="error" id="system-feedback"></div>
+      <div id="queue-table"></div>
+    </section>
+
+    <section class="wide">
       <h2><span>Event Log</span><button class="secondary" id="refresh-events">Refresh</button></h2>
       <form id="event-filter-form">
         <div class="split">

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -331,3 +331,81 @@ def test_19_flow_trace_lists_all_attempts_by_goal_prefix(client):
     assert goal["goal_id"] in correlation_ids
     assert f"{goal['goal_id']}:{task['task_id']}:0" in correlation_ids
     assert f"{goal['goal_id']}:{task['task_id']}:1" in correlation_ids
+
+
+def test_20_queue_endpoint_returns_priority_order(client):
+    low = client.post(
+        "/goals",
+        json={"title": "Low", "description": "check", "urgency": 0.2, "value": 0.2, "deadline_score": 0.1},
+    ).json()
+    high = client.post(
+        "/goals",
+        json={"title": "High", "description": "check", "urgency": 0.9, "value": 0.8, "deadline_score": 0.4},
+    ).json()
+    queue = client.get("/system/queue").json()
+    assert [item["goal_id"] for item in queue] == [high["goal_id"], low["goal_id"]]
+    assert queue[0]["queue_status"] == "queued"
+
+
+def test_21_scheduler_age_endpoint_increments_wait_cycles(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Age me", "description": "check", "urgency": 0.5, "value": 0.5, "deadline_score": 0.0},
+    ).json()
+    before = client.get(f"/goals/{goal['goal_id']}").json()
+    response = client.post("/system/scheduler/age")
+    after = client.get(f"/goals/{goal['goal_id']}").json()
+    assert response.status_code == 200
+    assert response.json()["aged_count"] == 1
+    assert after["wait_cycles"] == before["wait_cycles"] + 1
+    assert after["priority"] > before["priority"]
+
+
+def test_22_scheduler_pick_endpoint_activates_highest_priority_goal(client):
+    client.post(
+        "/goals",
+        json={"title": "Low", "description": "check", "urgency": 0.2, "value": 0.2, "deadline_score": 0.0},
+    )
+    high = client.post(
+        "/goals",
+        json={"title": "High", "description": "check", "urgency": 0.9, "value": 0.8, "deadline_score": 0.4},
+    ).json()
+    response = client.post("/system/scheduler/pick")
+    picked = response.json()["picked_goal"]
+    assert picked["goal_id"] == high["goal_id"]
+    assert picked["state"] == "active"
+
+
+def test_23_consumer_drain_endpoint_processes_pending_events(client):
+    services = client.app.state.services
+    event_id = services.event_bus.record_event("probe.event", "entity-1", "goal-1")
+    response = client.post("/system/consumers/manual/drain?batch_size=10")
+    row = services.db.fetch_one(
+        "SELECT status FROM event_processing WHERE event_id = ? AND consumer_id = ?",
+        event_id,
+        "manual",
+    )
+    assert response.status_code == 200
+    assert response.json()["processed_count"] == 1
+    assert row["status"] == "processed"
+
+
+def test_24_consumer_reclaim_endpoint_resets_stuck_processing(client):
+    services = client.app.state.services
+    event_id = services.event_bus.record_event("probe.event", "entity-1", "goal-1")
+    services.db.execute(
+        "INSERT INTO event_processing "
+        "(event_id, consumer_id, status, processing_started_at, version) "
+        "VALUES (?, ?, 'processing', datetime('now', '-120 seconds'), 1)",
+        event_id,
+        "manual",
+    )
+    response = client.post("/system/consumers/manual/reclaim")
+    row = services.db.fetch_one(
+        "SELECT status FROM event_processing WHERE event_id = ? AND consumer_id = ?",
+        event_id,
+        "manual",
+    )
+    assert response.status_code == 200
+    assert response.json()["reclaimed_count"] == 1
+    assert row["status"] == "pending"


### PR DESCRIPTION
## Summary
This PR adds a supervised Phase-2 operator layer to Goal Ops Console.

### API additions
- GET /system/queue
- POST /system/scheduler/age
- POST /system/scheduler/pick
- POST /system/consumers/{consumer_id}/drain
- POST /system/consumers/{consumer_id}/reclaim
- GET /system/health now includes default_consumer_id

### Dashboard additions
- New Operator Controls section with Age Queue, Pick Next Goal, Drain Events, Reclaim Stuck
- Queue visibility table (state, queue status, wait cycles, base/effective priority)
- Improved feedback routing for operator actions

### Tests
- Added tests 20-24 for queue and operator flows
- Full suite passes: 24 passed

## Why
This makes scheduler/event-processing behavior operable from the UI and API in supervised mode, without changing the existing thin-slice behavior.