### PR TITLE
Add CI pytest checks for PR guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - codex/**
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Pytest (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.11"
+          - "3.12"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ".[test]"
+
+      - name: Run test suite
+        run: python -m pytest -q

--- a/README.md
+++ b/README.md
@@ -162,6 +162,26 @@ Current result during implementation:
 24 passed
 ```
 
+## CI And PR Guardrails
+
+GitHub Actions now runs `pytest` automatically for:
+
+- pushes to `master`
+- pull requests targeting `master`
+- manual dispatch (`workflow_dispatch`)
+
+Workflow file:
+[ci.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/ci.yml)
+
+Recommended branch protection on `master`:
+
+1. Open repository settings on GitHub.
+2. Go to `Branches` -> `Branch protection rules`.
+3. Add/update rule for `master`:
+4. Enable `Require a pull request before merging`.
+5. Enable `Require status checks to pass before merging`.
+6. Select required check: `Pytest (Python 3.11)` and `Pytest (Python 3.12)`.
+
 ## Troubleshooting
 
 ### Path With Spaces


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow at .github/workflows/ci.yml
- run pytest on push to master/codex branches and on pull requests to master
- test matrix: Python 3.11 and 3.12
- add README section for CI + branch protection setup

## Why
This introduces baseline CI guardrails so PRs are automatically tested before merge.