### PR TITLE
Add event retention and backpressure safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,26 @@ The dashboard now includes an `Operator Controls` section for supervised Phase 2
   Manually runs one consumer batch and marks pending events as processed for the given consumer id.
 - `Reclaim Stuck`
   Resets timed-out `processing` entries back to `pending` for the given consumer id.
+- `Run Retention Cleanup`
+  Removes old `events`, `event_processing` and `failure_log` rows based on retention policy.
 
 The queue table in this section shows:
 - goal state
 - queue status
 - wait cycles
 - base vs. effective priority
+
+Backpressure behavior:
+
+- Event writes are throttled when pending backlog reaches the configured cap.
+- Goal creation is throttled when the goal queue reaches its entry limit.
+- API returns `429` with `Retry-After` and `retry_after_seconds` for throttled operations.
+- Scheduler operations (`/system/scheduler/age` and `/system/scheduler/pick`) are also protected by backlog checks.
+
+Retention + backpressure endpoints:
+
+- `GET /system/backpressure`
+- `POST /system/maintenance/retention`
 
 ## Run The Test Suite
 
@@ -159,7 +173,7 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 Current result during implementation:
 
 ```text
-24 passed
+30 passed
 ```
 
 ## CI And PR Guardrails

--- a/goal_ops_console/config.py
+++ b/goal_ops_console/config.py
@@ -28,6 +28,12 @@ OL_MAX_RETRIES = 3
 OL_BASE_BACKOFF_MS = 10
 MAX_TOTAL_RETRIES_PER_CYCLE = 100
 
+# Backpressure
+MAX_PENDING_EVENTS = 1_000
+MAX_GOAL_QUEUE_ENTRIES = 500
+MAX_CONSUMER_DRAIN_BATCH_SIZE = 500
+BACKPRESSURE_RETRY_AFTER_SECONDS = 10
+
 # Event Processing
 PROCESSING_TIMEOUT_SECONDS = 30
 CONSUMER_BATCH_SIZE = 50
@@ -41,6 +47,9 @@ ERROR_HASH_ESCALATION_WINDOW_MINUTES = 30
 # Maintenance
 EPHEMERAL_CLEANUP_INTERVAL_SECONDS = 300
 EPHEMERAL_MAX_ROWS = 10_000
+EVENTS_RETENTION_DAYS = 30
+EVENT_PROCESSING_RETENTION_DAYS = 30
+FAILURE_LOG_RETENTION_DAYS = 90
 
 # The sandbox in this workspace rejects file-backed SQLite locks, so the
 # persistent `goal_ops.db` path should be supplied via GOAL_OPS_DATABASE_URL.
@@ -60,3 +69,10 @@ GOAL_QUEUE_STATUS_MAP = {
 class Settings:
     database_url: str = DEFAULT_DATABASE_URL
     consumer_id: str = DEFAULT_CONSUMER_ID
+    max_pending_events: int = MAX_PENDING_EVENTS
+    max_goal_queue_entries: int = MAX_GOAL_QUEUE_ENTRIES
+    max_consumer_drain_batch_size: int = MAX_CONSUMER_DRAIN_BATCH_SIZE
+    backpressure_retry_after_seconds: int = BACKPRESSURE_RETRY_AFTER_SECONDS
+    events_retention_days: int = EVENTS_RETENTION_DAYS
+    event_processing_retention_days: int = EVENT_PROCESSING_RETENTION_DAYS
+    failure_log_retention_days: int = FAILURE_LOG_RETENTION_DAYS

--- a/goal_ops_console/event_bus.py
+++ b/goal_ops_console/event_bus.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from goal_ops_console.config import CONSUMER_BATCH_SIZE, PROCESSING_TIMEOUT_SECONDS
 from goal_ops_console.database import Database, Transaction, new_id, now_utc
+from goal_ops_console.models import BackpressureError
 
 
 def make_payload(data: dict[str, Any] | None = None) -> str:
@@ -11,9 +12,26 @@ def make_payload(data: dict[str, Any] | None = None) -> str:
 
 
 class EventBus:
-    def __init__(self, db: Database, processing_timeout_seconds: int = PROCESSING_TIMEOUT_SECONDS):
+    def __init__(
+        self,
+        db: Database,
+        processing_timeout_seconds: int = PROCESSING_TIMEOUT_SECONDS,
+        *,
+        default_consumer_id: str,
+        max_pending_events: int,
+        backpressure_retry_after_seconds: int,
+        events_retention_days: int,
+        event_processing_retention_days: int,
+        failure_log_retention_days: int,
+    ):
         self.db = db
         self.processing_timeout_seconds = processing_timeout_seconds
+        self.default_consumer_id = default_consumer_id
+        self.max_pending_events = max_pending_events
+        self.backpressure_retry_after_seconds = backpressure_retry_after_seconds
+        self.events_retention_days = events_retention_days
+        self.event_processing_retention_days = event_processing_retention_days
+        self.failure_log_retention_days = failure_log_retention_days
 
     def record_event(
         self,
@@ -25,6 +43,7 @@ class EventBus:
         event_id: str | None = None,
         tx: Transaction | None = None,
     ) -> str:
+        self.ensure_within_backpressure(tx=tx)
         identifier = event_id or new_id()
         runner = tx or self.db
         runner.execute(
@@ -39,6 +58,83 @@ class EventBus:
             now_utc(),
         )
         return identifier
+
+    def pending_backlog_count(
+        self,
+        consumer_id: str | None = None,
+        *,
+        tx: Transaction | None = None,
+    ) -> int:
+        consumer = consumer_id or self.default_consumer_id
+        runner = tx or self.db
+        value = runner.fetch_scalar(
+            """SELECT COUNT(*)
+               FROM events e
+               LEFT JOIN event_processing ep
+                 ON e.event_id = ep.event_id AND ep.consumer_id = ?
+               WHERE ep.event_id IS NULL
+                  OR ep.status IN ('pending', 'failed', 'processing')""",
+            consumer,
+        )
+        return int(value or 0)
+
+    def backpressure_snapshot(self, consumer_id: str | None = None) -> dict[str, Any]:
+        consumer = consumer_id or self.default_consumer_id
+        pending = self.pending_backlog_count(consumer)
+        return {
+            "consumer_id": consumer,
+            "pending_events": pending,
+            "max_pending_events": self.max_pending_events,
+            "is_throttled": pending >= self.max_pending_events,
+            "retry_after_seconds": self.backpressure_retry_after_seconds,
+        }
+
+    def ensure_within_backpressure(
+        self,
+        consumer_id: str | None = None,
+        *,
+        tx: Transaction | None = None,
+    ) -> int:
+        consumer = consumer_id or self.default_consumer_id
+        pending = self.pending_backlog_count(consumer, tx=tx)
+        if pending >= self.max_pending_events:
+            raise BackpressureError(
+                (
+                    f"Event backlog limit reached for consumer '{consumer}' "
+                    f"({pending}/{self.max_pending_events}). Drain events and retry."
+                ),
+                retry_after_seconds=self.backpressure_retry_after_seconds,
+            )
+        return pending
+
+    def run_retention_cleanup(self) -> dict[str, int]:
+        with self.db.transaction() as tx:
+            event_processing_deleted = tx.execute(
+                """DELETE FROM event_processing
+                   WHERE status = 'processed'
+                   AND processed_at IS NOT NULL
+                   AND processed_at < datetime('now', ? || ' days')""",
+                f"-{self.event_processing_retention_days}",
+            )
+            events_deleted = tx.execute(
+                """DELETE FROM events
+                   WHERE emitted_at < datetime('now', ? || ' days')
+                   AND NOT EXISTS (
+                       SELECT 1 FROM event_processing ep
+                       WHERE ep.event_id = events.event_id
+                   )""",
+                f"-{self.events_retention_days}",
+            )
+            failures_deleted = tx.execute(
+                """DELETE FROM failure_log
+                   WHERE created_at < datetime('now', ? || ' days')""",
+                f"-{self.failure_log_retention_days}",
+            )
+        return {
+            "events_deleted": events_deleted,
+            "event_processing_deleted": event_processing_deleted,
+            "failure_log_deleted": failures_deleted,
+        }
 
     def list_events(
         self,

--- a/goal_ops_console/main.py
+++ b/goal_ops_console/main.py
@@ -27,7 +27,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     @app.exception_handler(DomainError)
     async def handle_domain_error(_: Request, exc: DomainError) -> JSONResponse:
-        return JSONResponse(status_code=exc.status_code, content={"detail": exc.message})
+        content = {"detail": exc.message}
+        headers: dict[str, str] = {}
+        retry_after = getattr(exc, "retry_after_seconds", None)
+        if isinstance(retry_after, int) and retry_after > 0:
+            content["retry_after_seconds"] = retry_after
+            headers["Retry-After"] = str(retry_after)
+        return JSONResponse(status_code=exc.status_code, content=content, headers=headers)
 
     return app
 

--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -54,6 +54,14 @@ class RetryBudgetExceeded(DomainError):
     status_code = 429
 
 
+class BackpressureError(DomainError):
+    status_code = 429
+
+    def __init__(self, message: str, *, retry_after_seconds: int):
+        super().__init__(message)
+        self.retry_after_seconds = retry_after_seconds
+
+
 class GoalCreateRequest(BaseModel):
     title: str = Field(min_length=1, max_length=200)
     description: str | None = Field(default=None, max_length=1_000)

--- a/goal_ops_console/routers/system.py
+++ b/goal_ops_console/routers/system.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
 
 from goal_ops_console.config import CONSUMER_BATCH_SIZE, MAX_TOTAL_RETRIES_PER_CYCLE, SPEC_VERSION
+from goal_ops_console.models import BackpressureError
 from goal_ops_console.services import AppServices, get_services
 
 router = APIRouter(tags=["system"])
@@ -22,6 +23,7 @@ def system_health(services: AppServices = Depends(get_services)) -> dict:
     total_events = services.db.fetch_scalar("SELECT COUNT(*) FROM events") or 0
     total_goals = services.db.fetch_scalar("SELECT COUNT(*) FROM goals") or 0
     total_tasks = services.db.fetch_scalar("SELECT COUNT(*) FROM task_state") or 0
+    backpressure = services.event_bus.backpressure_snapshot()
     return {
         "spec_version": SPEC_VERSION,
         "default_consumer_id": services.settings.consumer_id,
@@ -29,6 +31,12 @@ def system_health(services: AppServices = Depends(get_services)) -> dict:
             "events": int(total_events),
             "goals": int(total_goals),
             "tasks": int(total_tasks),
+        },
+        "backpressure": backpressure,
+        "retention": {
+            "events_days": services.settings.events_retention_days,
+            "event_processing_days": services.settings.event_processing_retention_days,
+            "failure_log_days": services.settings.failure_log_retention_days,
         },
         "retry_budget_per_cycle": MAX_TOTAL_RETRIES_PER_CYCLE,
         "consumer_stats": services.event_bus.consumer_stats(),
@@ -59,12 +67,14 @@ def queue_snapshot(services: AppServices = Depends(get_services)) -> list[dict]:
 
 @router.post("/system/scheduler/age")
 def age_scheduler_queue(services: AppServices = Depends(get_services)) -> dict:
+    services.event_bus.ensure_within_backpressure()
     aged = [goal for goal in services.scheduler.age_queue() if goal]
     return {"aged_count": len(aged), "goals": aged}
 
 
 @router.post("/system/scheduler/pick")
 def pick_next_goal(services: AppServices = Depends(get_services)) -> dict:
+    services.event_bus.ensure_within_backpressure()
     picked = services.scheduler.pick_next_goal()
     return {"picked_goal": picked}
 
@@ -75,6 +85,14 @@ def drain_consumer(
     batch_size: int = CONSUMER_BATCH_SIZE,
     services: AppServices = Depends(get_services),
 ) -> dict:
+    if batch_size > services.settings.max_consumer_drain_batch_size:
+        raise BackpressureError(
+            (
+                f"Requested batch_size {batch_size} exceeds safe limit "
+                f"{services.settings.max_consumer_drain_batch_size}."
+            ),
+            retry_after_seconds=services.settings.backpressure_retry_after_seconds,
+        )
     handled: list[str] = []
     processed = services.event_bus.consume_batch(
         consumer_id,
@@ -93,3 +111,21 @@ def drain_consumer(
 def reclaim_consumer(consumer_id: str, services: AppServices = Depends(get_services)) -> dict:
     reclaimed = services.event_bus.reclaim_stuck_processing(consumer_id)
     return {"consumer_id": consumer_id, "reclaimed_count": reclaimed}
+
+
+@router.get("/system/backpressure")
+def backpressure_status(services: AppServices = Depends(get_services)) -> dict:
+    return services.event_bus.backpressure_snapshot()
+
+
+@router.post("/system/maintenance/retention")
+def run_retention_cleanup(services: AppServices = Depends(get_services)) -> dict:
+    deleted = services.event_bus.run_retention_cleanup()
+    return {
+        **deleted,
+        "retention_days": {
+            "events": services.settings.events_retention_days,
+            "event_processing": services.settings.event_processing_retention_days,
+            "failure_log": services.settings.failure_log_retention_days,
+        },
+    }

--- a/goal_ops_console/services.py
+++ b/goal_ops_console/services.py
@@ -30,8 +30,21 @@ def build_services(settings: Settings | None = None) -> AppServices:
     app_settings = settings or Settings()
     db = Database(app_settings.database_url)
     db.initialize()
-    event_bus = EventBus(db)
-    state_manager = StateManager(db, event_bus)
+    event_bus = EventBus(
+        db,
+        default_consumer_id=app_settings.consumer_id,
+        max_pending_events=app_settings.max_pending_events,
+        backpressure_retry_after_seconds=app_settings.backpressure_retry_after_seconds,
+        events_retention_days=app_settings.events_retention_days,
+        event_processing_retention_days=app_settings.event_processing_retention_days,
+        failure_log_retention_days=app_settings.failure_log_retention_days,
+    )
+    state_manager = StateManager(
+        db,
+        event_bus,
+        max_goal_queue_entries=app_settings.max_goal_queue_entries,
+        backpressure_retry_after_seconds=app_settings.backpressure_retry_after_seconds,
+    )
     failure_intelligence = FailureIntelligence(db)
     execution_layer = ExecutionLayer(db, state_manager, event_bus, failure_intelligence)
     scheduler = SchedulerService(db, state_manager)

--- a/goal_ops_console/state_manager.py
+++ b/goal_ops_console/state_manager.py
@@ -1,17 +1,26 @@
 from typing import Any
 
-from goal_ops_console.config import SPEC_VERSION
+from goal_ops_console.config import BACKPRESSURE_RETRY_AFTER_SECONDS, MAX_GOAL_QUEUE_ENTRIES, SPEC_VERSION
 from goal_ops_console.database import Database, Transaction, new_id, now_utc
 from goal_ops_console.event_bus import EventBus
-from goal_ops_console.models import ConflictError, NotFoundError, OptimisticLockError
+from goal_ops_console.models import BackpressureError, ConflictError, NotFoundError, OptimisticLockError
 from goal_ops_console.scheduler import base_priority
 from goal_ops_console.transition_rules import queue_status_for_goal_state, validate_transition
 
 
 class StateManager:
-    def __init__(self, db: Database, event_bus: EventBus):
+    def __init__(
+        self,
+        db: Database,
+        event_bus: EventBus,
+        *,
+        max_goal_queue_entries: int = MAX_GOAL_QUEUE_ENTRIES,
+        backpressure_retry_after_seconds: int = BACKPRESSURE_RETRY_AFTER_SECONDS,
+    ):
         self.db = db
         self.event_bus = event_bus
+        self.max_goal_queue_entries = max_goal_queue_entries
+        self.backpressure_retry_after_seconds = backpressure_retry_after_seconds
 
     def create_goal(
         self,
@@ -22,6 +31,15 @@ class StateManager:
         value: float,
         deadline_score: float,
     ) -> dict[str, Any]:
+        queue_size = int(self.db.fetch_scalar("SELECT COUNT(*) FROM goal_queue") or 0)
+        if queue_size >= self.max_goal_queue_entries:
+            raise BackpressureError(
+                (
+                    f"Goal queue limit reached ({queue_size}/{self.max_goal_queue_entries}). "
+                    "Archive or complete existing goals and retry."
+                ),
+                retry_after_seconds=self.backpressure_retry_after_seconds,
+            )
         goal_id = new_id()
         timestamp = now_utc()
         priority = base_priority(urgency, value, deadline_score)

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -11,14 +11,28 @@ async function api(path, options = {}) {
   const isJson = response.headers.get("content-type")?.includes("application/json");
   const payload = isJson ? await response.json() : await response.text();
   if (!response.ok) {
-    const message = typeof payload === "object" && payload ? payload.detail || JSON.stringify(payload) : payload;
-    throw new Error(message || `Request failed: ${response.status}`);
+    let message = typeof payload === "object" && payload ? payload.detail || JSON.stringify(payload) : payload;
+    if (typeof payload === "object" && payload && typeof payload.retry_after_seconds === "number") {
+      message = `${message} Retry after ${payload.retry_after_seconds}s.`;
+    }
+    const error = new Error(`[${response.status}] ${message || "Request failed"}`);
+    error.status = response.status;
+    error.retryAfterSeconds = payload?.retry_after_seconds;
+    throw error;
   }
   return payload;
 }
 
 function showError(id, error) {
-  document.getElementById(id).textContent = error?.message || "";
+  const target = document.getElementById(id);
+  target.textContent = error?.message || "";
+  if (id === "system-feedback") {
+    if (error) {
+      target.classList.add("error-state");
+    } else {
+      target.classList.remove("error-state");
+    }
+  }
 }
 
 function renderGoalButtons(goal) {
@@ -175,11 +189,25 @@ function renderHealth(health) {
   if (consumerInput && !consumerInput.value.trim()) {
     consumerInput.value = defaultConsumerId;
   }
+  const backpressure = health.backpressure || {};
+  const retention = health.retention || {};
   document.getElementById("health-cards").innerHTML = `
     <div class="card"><span class="meta">Events</span><strong>${health.totals.events}</strong></div>
     <div class="card"><span class="meta">Goals</span><strong>${health.totals.goals}</strong></div>
     <div class="card"><span class="meta">Tasks</span><strong>${health.totals.tasks}</strong></div>
-    <div class="card"><span class="meta">Retry Budget</span><strong>${health.retry_budget_per_cycle}</strong></div>`;
+    <div class="card"><span class="meta">Retry Budget</span><strong>${health.retry_budget_per_cycle}</strong></div>
+    <div class="card"><span class="meta">Pending Events</span><strong>${backpressure.pending_events || 0}</strong></div>
+    <div class="card"><span class="meta">Backpressure</span><strong>${backpressure.is_throttled ? "ON" : "OFF"}</strong></div>`;
+
+  document.getElementById("backpressure-status").innerHTML = `
+    <div class="meta">Consumer: ${backpressure.consumer_id || "-"}</div>
+    <div class="meta">Pending: ${backpressure.pending_events || 0} / ${backpressure.max_pending_events || 0}</div>
+    <div class="meta">Retry-After: ${backpressure.retry_after_seconds || 0}s</div>`;
+
+  document.getElementById("retention-policy").innerHTML = `
+    <div class="meta">Events: ${retention.events_days || 0} days</div>
+    <div class="meta">Event Processing: ${retention.event_processing_days || 0} days</div>
+    <div class="meta">Failure Log: ${retention.failure_log_days || 0} days</div>`;
 
   document.getElementById("consumer-stats").innerHTML = health.consumer_stats.length
     ? `<table><thead><tr><th>Consumer</th><th>Status</th><th>Count</th></tr></thead><tbody>${
@@ -276,6 +304,7 @@ async function runOperatorAction(action) {
   const consumerId = document.getElementById("consumer-id").value.trim() || defaultConsumerId;
   const batchSize = Number(document.getElementById("consumer-batch-size").value || 50);
   let result;
+  showError("system-feedback", null);
   if (action === "age") {
     result = await api("/system/scheduler/age", { method: "POST" });
     document.getElementById("system-feedback").textContent = `Aged ${result.aged_count} queue entries.`;
@@ -293,6 +322,13 @@ async function runOperatorAction(action) {
   } else if (action === "reclaim") {
     result = await api(`/system/consumers/${encodeURIComponent(consumerId)}/reclaim`, { method: "POST" });
     document.getElementById("system-feedback").textContent = `Consumer ${consumerId} reclaimed ${result.reclaimed_count} stuck events.`;
+  } else if (action === "retention") {
+    result = await api("/system/maintenance/retention", { method: "POST" });
+    document.getElementById("system-feedback").textContent = (
+      `Retention cleanup deleted events=${result.events_deleted}, `
+      + `event_processing=${result.event_processing_deleted}, `
+      + `failure_log=${result.failure_log_deleted}.`
+    );
   }
   await refreshAll();
 }
@@ -419,4 +455,5 @@ setInterval(() => {
   refreshTasks().catch(() => {});
   refreshEvents().catch(() => {});
   refreshHealth().catch(() => {});
+  refreshQueue().catch(() => {});
 }, 5000);

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -225,6 +225,15 @@
       min-height: 1.2rem;
       font-size: 0.9rem;
     }
+    #system-feedback {
+      color: var(--muted);
+      min-height: 1.2rem;
+      font-size: 0.9rem;
+      margin-top: 0.5rem;
+    }
+    #system-feedback.error-state {
+      color: var(--bad);
+    }
     .inline-link {
       color: var(--info);
       cursor: pointer;
@@ -293,6 +302,12 @@
             </div>
           </form>
         </div>
+        <div class="card">
+          <span class="meta">Maintenance</span>
+          <div class="actions" style="margin-top:0.75rem;">
+            <button type="button" data-operator-action="retention">Run Retention Cleanup</button>
+          </div>
+        </div>
       </div>
       <div class="error" id="system-feedback"></div>
       <div id="queue-table"></div>
@@ -313,6 +328,10 @@
     <section>
       <h2>System Health</h2>
       <div id="health-cards" class="grid-two"></div>
+      <h3>Backpressure</h3>
+      <div id="backpressure-status"></div>
+      <h3>Retention Policy</h3>
+      <div id="retention-policy"></div>
       <h3>Consumer Stats</h3>
       <div id="consumer-stats"></div>
       <h3>Stuck Events</h3>

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import threading
 
 import pytest
+from fastapi.testclient import TestClient
 
+from goal_ops_console.config import Settings
 from goal_ops_console.database import new_id, now_utc
 from goal_ops_console.failure_intelligence import compute_error_hash
+from goal_ops_console.main import create_app
 from goal_ops_console.models import OptimisticLockError, RetryBudgetExceeded
 from goal_ops_console.scheduler import RetryBudget, write_with_retry
 
@@ -409,3 +412,123 @@ def test_24_consumer_reclaim_endpoint_resets_stuck_processing(client):
     assert response.status_code == 200
     assert response.json()["reclaimed_count"] == 1
     assert row["status"] == "pending"
+
+
+def test_25_backpressure_blocks_new_events_with_retry_hint():
+    app = create_app(
+        Settings(
+            database_url=":memory:",
+            max_pending_events=1,
+            backpressure_retry_after_seconds=7,
+        )
+    )
+    with TestClient(app) as local_client:
+        first = local_client.post(
+            "/goals",
+            json={"title": "A", "description": "check", "urgency": 0.5, "value": 0.5, "deadline_score": 0.0},
+        )
+        blocked = local_client.post(
+            "/goals",
+            json={"title": "B", "description": "check", "urgency": 0.5, "value": 0.5, "deadline_score": 0.0},
+        )
+        assert first.status_code == 201
+        assert blocked.status_code == 429
+        assert blocked.json()["retry_after_seconds"] == 7
+        assert "Event backlog limit reached" in blocked.json()["detail"]
+
+
+def test_26_goal_queue_limit_returns_429():
+    app = create_app(
+        Settings(
+            database_url=":memory:",
+            max_pending_events=10_000,
+            max_goal_queue_entries=1,
+            backpressure_retry_after_seconds=9,
+        )
+    )
+    with TestClient(app) as local_client:
+        first = local_client.post(
+            "/goals",
+            json={"title": "A", "description": "check", "urgency": 0.5, "value": 0.5, "deadline_score": 0.0},
+        )
+        blocked = local_client.post(
+            "/goals",
+            json={"title": "B", "description": "check", "urgency": 0.5, "value": 0.5, "deadline_score": 0.0},
+        )
+        assert first.status_code == 201
+        assert blocked.status_code == 429
+        assert blocked.json()["retry_after_seconds"] == 9
+        assert "Goal queue limit reached" in blocked.json()["detail"]
+
+
+def test_27_scheduler_endpoints_return_429_under_backpressure():
+    app = create_app(
+        Settings(
+            database_url=":memory:",
+            max_pending_events=1,
+            backpressure_retry_after_seconds=6,
+        )
+    )
+    with TestClient(app) as local_client:
+        created = local_client.post(
+            "/goals",
+            json={"title": "A", "description": "check", "urgency": 0.4, "value": 0.4, "deadline_score": 0.0},
+        )
+        response = local_client.post("/system/scheduler/age")
+        assert created.status_code == 201
+        assert response.status_code == 429
+        assert response.json()["retry_after_seconds"] == 6
+
+
+def test_28_consumer_drain_enforces_batch_limit_with_429(client):
+    response = client.post("/system/consumers/manual/drain?batch_size=9999")
+    assert response.status_code == 429
+    assert "exceeds safe limit" in response.json()["detail"]
+
+
+def test_29_retention_cleanup_deletes_old_records(client):
+    services = client.app.state.services
+    old_event_id = new_id()
+    old_failure_id = new_id()
+    services.db.execute(
+        "INSERT INTO events (event_id, event_type, entity_id, correlation_id, payload, emitted_at) "
+        "VALUES (?, 'retention.old', 'entity-1', 'goal-1', '{}', datetime('now', '-120 days'))",
+        old_event_id,
+    )
+    services.db.execute(
+        "INSERT INTO event_processing "
+        "(event_id, consumer_id, status, processing_started_at, processed_at, version) "
+        "VALUES (?, ?, 'processed', datetime('now', '-120 days'), datetime('now', '-120 days'), 1)",
+        old_event_id,
+        services.settings.consumer_id,
+    )
+    services.db.execute(
+        "INSERT INTO failure_log "
+        "(id, task_id, goal_id, correlation_id, failure_type, fingerprint, retry_count, "
+        " last_error, status, version, created_at, updated_at) "
+        "VALUES (?, 'task-old', 'goal-old', 'goal-old:task-old:0', 'ExecutionFailure', "
+        " 'old-fingerprint', 1, 'old', 'recorded', 1, datetime('now', '-120 days'), datetime('now', '-120 days'))",
+        old_failure_id,
+    )
+    response = client.post("/system/maintenance/retention")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["event_processing_deleted"] == 1
+    assert payload["events_deleted"] == 1
+    assert payload["failure_log_deleted"] == 1
+    assert services.db.fetch_scalar("SELECT COUNT(*) FROM events WHERE event_id = ?", old_event_id) == 0
+    assert (
+        services.db.fetch_scalar("SELECT COUNT(*) FROM event_processing WHERE event_id = ?", old_event_id)
+        == 0
+    )
+    assert services.db.fetch_scalar("SELECT COUNT(*) FROM failure_log WHERE id = ?", old_failure_id) == 0
+
+
+def test_30_backpressure_endpoint_and_health_include_limits(client):
+    snapshot = client.get("/system/backpressure")
+    health = client.get("/system/health")
+    assert snapshot.status_code == 200
+    assert health.status_code == 200
+    assert snapshot.json()["max_pending_events"] == client.app.state.services.settings.max_pending_events
+    assert "backpressure" in health.json()
+    assert "retention" in health.json()


### PR DESCRIPTION
## Summary
- add configurable backpressure limits and queue caps
- return clear 429 responses with retry hints (Retry-After + etry_after_seconds)
- block scheduler actions when backlog is throttled
- add retention cleanup endpoint and retention policy visibility in health
- extend Operator Controls UI with retention cleanup action and backpressure status
- add test coverage for backpressure throttling, queue limits, retention cleanup and health snapshot

## API additions
- GET /system/backpressure
- POST /system/maintenance/retention

## Test result
- 30 passed locally
