### PR TITLE
Add audit log and observability metrics hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ The dashboard now includes an `Operator Controls` section for supervised Phase 2
   Resets timed-out `processing` entries back to `pending` for the given consumer id.
 - `Run Retention Cleanup`
   Removes old `events`, `event_processing` and `failure_log` rows based on retention policy.
+- `Audit Log` (new section)
+  Shows recent mutating API operations with status and request details.
+- `Metrics Hooks` (in System Health)
+  Shows live instrumentation counters for HTTP traffic, transitions, events and throttling.
 
 The queue table in this section shows:
 - goal state
@@ -163,6 +167,11 @@ Retention + backpressure endpoints:
 - `GET /system/backpressure`
 - `POST /system/maintenance/retention`
 
+Observability endpoints:
+
+- `GET /system/metrics`
+- `GET /system/audit`
+
 ## Run The Test Suite
 
 ```powershell
@@ -173,7 +182,7 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 Current result during implementation:
 
 ```text
-30 passed
+34 passed
 ```
 
 ## CI And PR Guardrails

--- a/goal_ops_console/database.py
+++ b/goal_ops_console/database.py
@@ -159,6 +159,27 @@ CREATE TABLE IF NOT EXISTS learnings (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_learning_active_version
 ON learnings(parent_learning_id)
 WHERE status = 'promoted';
+
+CREATE TABLE IF NOT EXISTS audit_log (
+  audit_id        TEXT PRIMARY KEY,
+  action          TEXT NOT NULL,
+  actor           TEXT NOT NULL,
+  status          TEXT NOT NULL,
+  entity_type     TEXT,
+  entity_id       TEXT,
+  correlation_id  TEXT,
+  details         TEXT,
+  created_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_audit_log_created_at ON audit_log(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_log_action_created_at ON audit_log(action, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS metrics_counters (
+  metric_name TEXT PRIMARY KEY,
+  value       INTEGER NOT NULL DEFAULT 0,
+  updated_at  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_metrics_updated_at ON metrics_counters(updated_at DESC);
 """
 
 

--- a/goal_ops_console/event_bus.py
+++ b/goal_ops_console/event_bus.py
@@ -1,10 +1,14 @@
 import json
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 from typing import Any
 
 from goal_ops_console.config import CONSUMER_BATCH_SIZE, PROCESSING_TIMEOUT_SECONDS
 from goal_ops_console.database import Database, Transaction, new_id, now_utc
 from goal_ops_console.models import BackpressureError
+
+if TYPE_CHECKING:
+    from goal_ops_console.observability import ObservabilityService
 
 
 def make_payload(data: dict[str, Any] | None = None) -> str:
@@ -23,6 +27,7 @@ class EventBus:
         events_retention_days: int,
         event_processing_retention_days: int,
         failure_log_retention_days: int,
+        observability: "ObservabilityService | None" = None,
     ):
         self.db = db
         self.processing_timeout_seconds = processing_timeout_seconds
@@ -32,6 +37,7 @@ class EventBus:
         self.events_retention_days = events_retention_days
         self.event_processing_retention_days = event_processing_retention_days
         self.failure_log_retention_days = failure_log_retention_days
+        self.observability = observability
 
     def record_event(
         self,
@@ -46,7 +52,7 @@ class EventBus:
         self.ensure_within_backpressure(tx=tx)
         identifier = event_id or new_id()
         runner = tx or self.db
-        runner.execute(
+        inserted = runner.execute(
             "INSERT OR IGNORE INTO events "
             "(event_id, event_type, entity_id, correlation_id, payload, emitted_at) "
             "VALUES (?, ?, ?, ?, ?, ?)",
@@ -57,6 +63,8 @@ class EventBus:
             make_payload(payload),
             now_utc(),
         )
+        if inserted:
+            self._metric("events.emitted", tx=tx)
         return identifier
 
     def pending_backlog_count(
@@ -98,6 +106,7 @@ class EventBus:
         consumer = consumer_id or self.default_consumer_id
         pending = self.pending_backlog_count(consumer, tx=tx)
         if pending >= self.max_pending_events:
+            self._metric("backpressure.throttled", tx=tx)
             raise BackpressureError(
                 (
                     f"Event backlog limit reached for consumer '{consumer}' "
@@ -130,6 +139,16 @@ class EventBus:
                    WHERE created_at < datetime('now', ? || ' days')""",
                 f"-{self.failure_log_retention_days}",
             )
+            if events_deleted:
+                self._metric("maintenance.retention.events_deleted", events_deleted, tx=tx)
+            if event_processing_deleted:
+                self._metric(
+                    "maintenance.retention.event_processing_deleted",
+                    event_processing_deleted,
+                    tx=tx,
+                )
+            if failures_deleted:
+                self._metric("maintenance.retention.failure_log_deleted", failures_deleted, tx=tx)
         return {
             "events_deleted": events_deleted,
             "event_processing_deleted": event_processing_deleted,
@@ -161,7 +180,7 @@ class EventBus:
         return [self._row_to_event(row) for row in rows]
 
     def reclaim_stuck_processing(self, consumer_id: str) -> int:
-        return self.db.execute(
+        reclaimed = self.db.execute(
             """UPDATE event_processing
                SET    status = 'pending',
                       version = version + 1
@@ -171,6 +190,9 @@ class EventBus:
             consumer_id,
             f"-{self.processing_timeout_seconds}",
         )
+        if reclaimed:
+            self._metric("event_processing.reclaimed", reclaimed)
+        return reclaimed
 
     def process_event(
         self,
@@ -241,6 +263,7 @@ class EventBus:
                 event_id,
                 consumer_id,
             )
+            self._metric("events.processed")
             return True
         except Exception:
             self.db.execute(
@@ -249,6 +272,7 @@ class EventBus:
                 event_id,
                 consumer_id,
             )
+            self._metric("events.failed")
             raise
 
     def consume_batch(
@@ -273,6 +297,8 @@ class EventBus:
         for row in rows:
             if self.process_event(row["event_id"], consumer_id, handler):
                 processed += 1
+        if processed:
+            self._metric("event_batches.processed")
         return processed
 
     def consumer_stats(self) -> list[dict[str, Any]]:
@@ -314,3 +340,8 @@ class EventBus:
             "payload": json.loads(payload) if payload else None,
             "emitted_at": row["emitted_at"],
         }
+
+    def _metric(self, name: str, delta: int = 1, *, tx: Transaction | None = None) -> None:
+        if self.observability is None:
+            return
+        self.observability.increment_metric(name, delta=delta, tx=tx)

--- a/goal_ops_console/execution_layer.py
+++ b/goal_ops_console/execution_layer.py
@@ -1,3 +1,4 @@
+from typing import TYPE_CHECKING
 from typing import Any
 
 from goal_ops_console.config import RETRY_STRATEGY
@@ -7,6 +8,9 @@ from goal_ops_console.failure_intelligence import FailureIntelligence, compute_e
 from goal_ops_console.models import ConflictError, NotFoundError
 from goal_ops_console.state_manager import StateManager
 
+if TYPE_CHECKING:
+    from goal_ops_console.observability import ObservabilityService
+
 
 class ExecutionLayer:
     def __init__(
@@ -15,11 +19,14 @@ class ExecutionLayer:
         state_manager: StateManager,
         event_bus: EventBus,
         failure_intelligence: FailureIntelligence,
+        *,
+        observability: "ObservabilityService | None" = None,
     ):
         self.db = db
         self.state_manager = state_manager
         self.event_bus = event_bus
         self.failure_intelligence = failure_intelligence
+        self.observability = observability
 
     def create_task(self, *, goal_id: str, title: str) -> dict[str, Any]:
         goal = self.state_manager.get_goal(goal_id)
@@ -55,6 +62,7 @@ class ExecutionLayer:
                 {"goal_id": goal_id, "title": title},
                 tx=tx,
             )
+            self._metric("tasks.created", tx=tx)
         return self.get_task(task_id)
 
     def list_tasks(self, goal_id: str | None = None) -> list[dict[str, Any]]:
@@ -143,6 +151,7 @@ class ExecutionLayer:
                 payload={"to_state": "succeeded"},
                 tx=tx,
             )
+            self._metric("tasks.succeeded", tx=tx)
         return self.get_task(task_id)
 
     def simulate_failure(
@@ -197,6 +206,7 @@ class ExecutionLayer:
                 retry_count=next_retry_count,
                 error_message=error_message,
             )
+            self._metric(f"tasks.failed.{failure_type}", tx=tx)
 
             max_retries = RETRY_STRATEGY[failure_type]["max"]
             should_escalate = self.failure_intelligence.should_escalate(
@@ -251,6 +261,7 @@ class ExecutionLayer:
                     },
                     tx=tx,
                 )
+                self._metric("tasks.poison", tx=tx)
             elif next_retry_count >= max_retries:
                 final_state = "exhausted"
                 self.state_manager.transition_task(
@@ -267,6 +278,7 @@ class ExecutionLayer:
                     },
                     tx=tx,
                 )
+                self._metric("tasks.exhausted", tx=tx)
 
             if final_state == "poison" and goal["state"] == "active":
                 self.state_manager.transition_goal(
@@ -306,3 +318,8 @@ class ExecutionLayer:
         if row is None:
             raise NotFoundError(f"Task {task_id} not found")
         return dict(row)
+
+    def _metric(self, name: str, delta: int = 1, *, tx: Transaction | None = None) -> None:
+        if self.observability is None:
+            return
+        self.observability.increment_metric(name, delta=delta, tx=tx)

--- a/goal_ops_console/main.py
+++ b/goal_ops_console/main.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from time import perf_counter
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
@@ -25,8 +26,57 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(tasks.router)
     app.include_router(events.router)
 
+    def route_template(request: Request) -> str:
+        route = request.scope.get("route")
+        if route is not None and hasattr(route, "path"):
+            return str(route.path)
+        return request.url.path
+
+    @app.middleware("http")
+    async def observability_middleware(request: Request, call_next):
+        status_code = 500
+        started = perf_counter()
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            return response
+        finally:
+            services = request.app.state.services
+            route = route_template(request)
+            method = request.method.upper()
+            duration_ms = int((perf_counter() - started) * 1000)
+            route_metric = (
+                route.strip("/")
+                .replace("/", ".")
+                .replace("{", "")
+                .replace("}", "")
+                or "root"
+            )
+            services.observability.increment_metric("http.requests.total")
+            services.observability.increment_metric(f"http.requests.method.{method}")
+            services.observability.increment_metric(f"http.requests.status.{status_code}")
+            services.observability.increment_metric(f"http.requests.route.{route_metric}")
+
+            if method in {"POST", "PUT", "PATCH", "DELETE"} and not route.startswith("/static"):
+                services.observability.record_audit(
+                    action="http.mutation",
+                    actor="api",
+                    status="success" if status_code < 400 else "error",
+                    entity_type="route",
+                    entity_id=route,
+                    correlation_id=request.headers.get("x-correlation-id"),
+                    details={
+                        "method": method,
+                        "status_code": status_code,
+                        "duration_ms": duration_ms,
+                    },
+                )
+
     @app.exception_handler(DomainError)
-    async def handle_domain_error(_: Request, exc: DomainError) -> JSONResponse:
+    async def handle_domain_error(request: Request, exc: DomainError) -> JSONResponse:
+        request.app.state.services.observability.increment_metric(
+            f"errors.domain.{exc.__class__.__name__}"
+        )
         content = {"detail": exc.message}
         headers: dict[str, str] = {}
         retry_after = getattr(exc, "retry_after_seconds", None)
@@ -34,6 +84,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             content["retry_after_seconds"] = retry_after
             headers["Retry-After"] = str(retry_after)
         return JSONResponse(status_code=exc.status_code, content=content, headers=headers)
+
+    @app.exception_handler(Exception)
+    async def handle_unexpected_error(request: Request, _: Exception) -> JSONResponse:
+        request.app.state.services.observability.increment_metric("errors.unhandled")
+        return JSONResponse(status_code=500, content={"detail": "Internal server error"})
 
     return app
 

--- a/goal_ops_console/observability.py
+++ b/goal_ops_console/observability.py
@@ -1,0 +1,143 @@
+import json
+from typing import Any
+
+from goal_ops_console.database import Database, Transaction, new_id, now_utc
+
+
+class ObservabilityService:
+    def __init__(self, db: Database):
+        self.db = db
+
+    def increment_metric(
+        self,
+        metric_name: str,
+        delta: int = 1,
+        *,
+        tx: Transaction | None = None,
+    ) -> None:
+        if delta == 0:
+            return
+        timestamp = now_utc()
+        runner = tx or self.db
+        runner.execute(
+            """INSERT INTO metrics_counters (metric_name, value, updated_at)
+               VALUES (?, ?, ?)
+               ON CONFLICT(metric_name) DO UPDATE
+                 SET value = metrics_counters.value + excluded.value,
+                     updated_at = excluded.updated_at""",
+            metric_name,
+            delta,
+            timestamp,
+        )
+
+    def list_metrics(self, *, prefix: str | None = None, limit: int = 200) -> list[dict[str, Any]]:
+        clauses: list[str] = []
+        params: list[Any] = []
+        if prefix:
+            clauses.append("metric_name LIKE ?")
+            params.append(f"{prefix}%")
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        rows = self.db.fetch_all(
+            f"""SELECT metric_name, value, updated_at
+                FROM metrics_counters
+                {where}
+                ORDER BY value DESC, metric_name ASC
+                LIMIT ?""",
+            *params,
+            limit,
+        )
+        return [dict(row) for row in rows]
+
+    def metrics_summary(self) -> dict[str, int]:
+        watched = (
+            "http.requests.total",
+            "http.requests.status.429",
+            "events.emitted",
+            "events.processed",
+            "events.failed",
+            "goals.created",
+            "tasks.created",
+            "transition.rejected",
+            "backpressure.throttled",
+        )
+        summary: dict[str, int] = {}
+        for metric in watched:
+            value = self.db.fetch_scalar(
+                "SELECT value FROM metrics_counters WHERE metric_name = ?",
+                metric,
+            )
+            summary[metric] = int(value or 0)
+        return summary
+
+    def record_audit(
+        self,
+        *,
+        action: str,
+        actor: str,
+        status: str,
+        entity_type: str | None = None,
+        entity_id: str | None = None,
+        correlation_id: str | None = None,
+        details: dict[str, Any] | None = None,
+        tx: Transaction | None = None,
+    ) -> str:
+        audit_id = new_id()
+        runner = tx or self.db
+        runner.execute(
+            """INSERT INTO audit_log
+               (audit_id, action, actor, status, entity_type, entity_id,
+                correlation_id, details, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            audit_id,
+            action,
+            actor,
+            status,
+            entity_type,
+            entity_id,
+            correlation_id,
+            json.dumps(details) if details else None,
+            now_utc(),
+        )
+        return audit_id
+
+    def list_audit(
+        self,
+        *,
+        limit: int = 200,
+        action: str | None = None,
+        status: str | None = None,
+    ) -> list[dict[str, Any]]:
+        clauses: list[str] = []
+        params: list[Any] = []
+        if action:
+            clauses.append("action = ?")
+            params.append(action)
+        if status:
+            clauses.append("status = ?")
+            params.append(status)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        rows = self.db.fetch_all(
+            f"""SELECT audit_id, action, actor, status, entity_type, entity_id,
+                       correlation_id, details, created_at
+                FROM audit_log
+                {where}
+                ORDER BY created_at DESC
+                LIMIT ?""",
+            *params,
+            limit,
+        )
+        result: list[dict[str, Any]] = []
+        for row in rows:
+            item = dict(row)
+            details_raw = item.get("details")
+            item["details"] = json.loads(details_raw) if details_raw else None
+            result.append(item)
+        return result
+
+    def recent_audit_count(self, *, hours: int = 24) -> int:
+        count = self.db.fetch_scalar(
+            """SELECT COUNT(*) FROM audit_log
+               WHERE created_at >= datetime('now', ? || ' hours')""",
+            f"-{hours}",
+        )
+        return int(count or 0)

--- a/goal_ops_console/routers/system.py
+++ b/goal_ops_console/routers/system.py
@@ -38,6 +38,10 @@ def system_health(services: AppServices = Depends(get_services)) -> dict:
             "event_processing_days": services.settings.event_processing_retention_days,
             "failure_log_days": services.settings.failure_log_retention_days,
         },
+        "metrics": services.observability.metrics_summary(),
+        "audit": {
+            "entries_last_24h": services.observability.recent_audit_count(hours=24),
+        },
         "retry_budget_per_cycle": MAX_TOTAL_RETRIES_PER_CYCLE,
         "consumer_stats": services.event_bus.consumer_stats(),
         "stuck_events": services.event_bus.stuck_events(),
@@ -116,6 +120,34 @@ def reclaim_consumer(consumer_id: str, services: AppServices = Depends(get_servi
 @router.get("/system/backpressure")
 def backpressure_status(services: AppServices = Depends(get_services)) -> dict:
     return services.event_bus.backpressure_snapshot()
+
+
+@router.get("/system/metrics")
+def metrics_status(
+    prefix: str | None = None,
+    limit: int = 200,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return {
+        "metrics": services.observability.list_metrics(prefix=prefix, limit=limit),
+        "summary": services.observability.metrics_summary(),
+    }
+
+
+@router.get("/system/audit")
+def audit_log(
+    limit: int = 200,
+    action: str | None = None,
+    status: str | None = None,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return {
+        "entries": services.observability.list_audit(
+            limit=limit,
+            action=action,
+            status=status,
+        )
+    }
 
 
 @router.post("/system/maintenance/retention")

--- a/goal_ops_console/services.py
+++ b/goal_ops_console/services.py
@@ -7,6 +7,7 @@ from goal_ops_console.database import Database
 from goal_ops_console.event_bus import EventBus
 from goal_ops_console.execution_layer import ExecutionLayer
 from goal_ops_console.failure_intelligence import FailureIntelligence
+from goal_ops_console.observability import ObservabilityService
 from goal_ops_console.scheduler import SchedulerService
 from goal_ops_console.state_manager import StateManager
 from goal_ops_console.stubs import PermissionManager, Planner, QdrantClientStub
@@ -16,6 +17,7 @@ from goal_ops_console.stubs import PermissionManager, Planner, QdrantClientStub
 class AppServices:
     settings: Settings
     db: Database
+    observability: ObservabilityService
     event_bus: EventBus
     state_manager: StateManager
     execution_layer: ExecutionLayer
@@ -30,6 +32,7 @@ def build_services(settings: Settings | None = None) -> AppServices:
     app_settings = settings or Settings()
     db = Database(app_settings.database_url)
     db.initialize()
+    observability = ObservabilityService(db)
     event_bus = EventBus(
         db,
         default_consumer_id=app_settings.consumer_id,
@@ -38,19 +41,28 @@ def build_services(settings: Settings | None = None) -> AppServices:
         events_retention_days=app_settings.events_retention_days,
         event_processing_retention_days=app_settings.event_processing_retention_days,
         failure_log_retention_days=app_settings.failure_log_retention_days,
+        observability=observability,
     )
     state_manager = StateManager(
         db,
         event_bus,
+        observability=observability,
         max_goal_queue_entries=app_settings.max_goal_queue_entries,
         backpressure_retry_after_seconds=app_settings.backpressure_retry_after_seconds,
     )
     failure_intelligence = FailureIntelligence(db)
-    execution_layer = ExecutionLayer(db, state_manager, event_bus, failure_intelligence)
+    execution_layer = ExecutionLayer(
+        db,
+        state_manager,
+        event_bus,
+        failure_intelligence,
+        observability=observability,
+    )
     scheduler = SchedulerService(db, state_manager)
     return AppServices(
         settings=app_settings,
         db=db,
+        observability=observability,
         event_bus=event_bus,
         state_manager=state_manager,
         execution_layer=execution_layer,

--- a/goal_ops_console/state_manager.py
+++ b/goal_ops_console/state_manager.py
@@ -1,3 +1,4 @@
+from typing import TYPE_CHECKING
 from typing import Any
 
 from goal_ops_console.config import BACKPRESSURE_RETRY_AFTER_SECONDS, MAX_GOAL_QUEUE_ENTRIES, SPEC_VERSION
@@ -7,6 +8,9 @@ from goal_ops_console.models import BackpressureError, ConflictError, NotFoundEr
 from goal_ops_console.scheduler import base_priority
 from goal_ops_console.transition_rules import queue_status_for_goal_state, validate_transition
 
+if TYPE_CHECKING:
+    from goal_ops_console.observability import ObservabilityService
+
 
 class StateManager:
     def __init__(
@@ -14,11 +18,13 @@ class StateManager:
         db: Database,
         event_bus: EventBus,
         *,
+        observability: "ObservabilityService | None" = None,
         max_goal_queue_entries: int = MAX_GOAL_QUEUE_ENTRIES,
         backpressure_retry_after_seconds: int = BACKPRESSURE_RETRY_AFTER_SECONDS,
     ):
         self.db = db
         self.event_bus = event_bus
+        self.observability = observability
         self.max_goal_queue_entries = max_goal_queue_entries
         self.backpressure_retry_after_seconds = backpressure_retry_after_seconds
 
@@ -83,6 +89,7 @@ class StateManager:
                 },
                 tx=tx,
             )
+            self._metric("goals.created", tx=tx)
         return self.get_goal(goal_id)
 
     def list_goals(self) -> list[dict[str, Any]]:
@@ -164,6 +171,7 @@ class StateManager:
 
         valid, reason_text = validate_transition("goal", goal["state"], to_state, owner)
         if not valid:
+            self._metric("transition.rejected")
             self.event_bus.record_event(
                 "transition.rejected",
                 goal_id,
@@ -214,6 +222,7 @@ class StateManager:
             raise NotFoundError(f"Task {task_id} not found")
         valid, reason_text = validate_transition("task", task["status"], to_state, owner)
         if not valid:
+            self._metric("transition.rejected", tx=tx)
             self.event_bus.record_event(
                 "transition.rejected",
                 task_id,
@@ -246,6 +255,7 @@ class StateManager:
             payload or {"from_state": task["status"], "to_state": to_state},
             tx=tx,
         )
+        self._metric(f"tasks.transition.{to_state}", tx=tx)
         updated = tx.fetch_one(
             """SELECT ts.*, t.title
                FROM task_state ts
@@ -342,6 +352,7 @@ class StateManager:
             payload or {"from_state": goal["state"], "to_state": to_state, "reason": reason},
             tx=tx,
         )
+        self._metric(f"goals.transition.{to_state}", tx=tx)
         updated_goal = tx.fetch_one(
             """SELECT g.goal_id,
                       g.title,
@@ -367,3 +378,8 @@ class StateManager:
             goal["goal_id"],
         )
         return dict(updated_goal) if updated_goal else {}
+
+    def _metric(self, name: str, delta: int = 1, *, tx: Transaction | None = None) -> None:
+        if self.observability is None:
+            return
+        self.observability.increment_metric(name, delta=delta, tx=tx)

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -183,6 +183,38 @@ function renderEvents(events) {
   </table></div>`;
 }
 
+function renderAudit(entries) {
+  const container = document.getElementById("audit-table");
+  if (!entries.length) {
+    container.innerHTML = `<div class="meta">No audit entries yet.</div>`;
+    return;
+  }
+  container.innerHTML = `<div class="table-scroll"><table>
+    <thead>
+      <tr>
+        <th>Time</th>
+        <th>Action</th>
+        <th>Status</th>
+        <th>Entity</th>
+        <th>Details</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${entries.map((entry) => `
+        <tr>
+          <td>${entry.created_at}</td>
+          <td>${entry.action}<div class="meta">${entry.actor}</div></td>
+          <td>${entry.status}</td>
+          <td>
+            <div>${entry.entity_type || "-"}</div>
+            <div class="meta">${entry.entity_id || "-"}</div>
+          </td>
+          <td><pre>${JSON.stringify(entry.details || {}, null, 2)}</pre></td>
+        </tr>`).join("")}
+      </tbody>
+    </table></div>`;
+}
+
 function renderHealth(health) {
   defaultConsumerId = health.default_consumer_id || defaultConsumerId;
   const consumerInput = document.getElementById("consumer-id");
@@ -191,13 +223,17 @@ function renderHealth(health) {
   }
   const backpressure = health.backpressure || {};
   const retention = health.retention || {};
+  const metrics = health.metrics || {};
+  const audit = health.audit || {};
   document.getElementById("health-cards").innerHTML = `
     <div class="card"><span class="meta">Events</span><strong>${health.totals.events}</strong></div>
     <div class="card"><span class="meta">Goals</span><strong>${health.totals.goals}</strong></div>
     <div class="card"><span class="meta">Tasks</span><strong>${health.totals.tasks}</strong></div>
     <div class="card"><span class="meta">Retry Budget</span><strong>${health.retry_budget_per_cycle}</strong></div>
     <div class="card"><span class="meta">Pending Events</span><strong>${backpressure.pending_events || 0}</strong></div>
-    <div class="card"><span class="meta">Backpressure</span><strong>${backpressure.is_throttled ? "ON" : "OFF"}</strong></div>`;
+    <div class="card"><span class="meta">Backpressure</span><strong>${backpressure.is_throttled ? "ON" : "OFF"}</strong></div>
+    <div class="card"><span class="meta">429 Count</span><strong>${metrics["http.requests.status.429"] || 0}</strong></div>
+    <div class="card"><span class="meta">Audit (24h)</span><strong>${audit.entries_last_24h || 0}</strong></div>`;
 
   document.getElementById("backpressure-status").innerHTML = `
     <div class="meta">Consumer: ${backpressure.consumer_id || "-"}</div>
@@ -208,6 +244,13 @@ function renderHealth(health) {
     <div class="meta">Events: ${retention.events_days || 0} days</div>
     <div class="meta">Event Processing: ${retention.event_processing_days || 0} days</div>
     <div class="meta">Failure Log: ${retention.failure_log_days || 0} days</div>`;
+
+  const metricRows = Object.entries(metrics);
+  document.getElementById("metrics-hooks").innerHTML = metricRows.length
+    ? `<table><thead><tr><th>Metric</th><th>Value</th></tr></thead><tbody>${
+        metricRows.map(([name, value]) => `<tr><td>${name}</td><td>${value}</td></tr>`).join("")
+      }</tbody></table>`
+    : `<div class="meta">No metrics captured yet.</div>`;
 
   document.getElementById("consumer-stats").innerHTML = health.consumer_stats.length
     ? `<table><thead><tr><th>Consumer</th><th>Status</th><th>Count</th></tr></thead><tbody>${
@@ -291,13 +334,31 @@ async function refreshEvents() {
   renderEvents(events);
 }
 
+async function refreshAudit() {
+  const action = document.getElementById("audit-action").value.trim();
+  const status = document.getElementById("audit-status").value.trim();
+  const params = new URLSearchParams();
+  if (action) params.set("action", action);
+  if (status) params.set("status", status);
+  const suffix = params.toString() ? `?${params.toString()}` : "";
+  const payload = await api(`/system/audit${suffix}`);
+  renderAudit(payload.entries || []);
+}
+
 async function refreshHealth() {
   const health = await api("/system/health");
   renderHealth(health);
 }
 
 async function refreshAll() {
-  await Promise.all([refreshGoals(), refreshTasks(), refreshEvents(), refreshHealth(), refreshQueue()]);
+  await Promise.all([
+    refreshGoals(),
+    refreshTasks(),
+    refreshEvents(),
+    refreshAudit(),
+    refreshHealth(),
+    refreshQueue(),
+  ]);
 }
 
 async function runOperatorAction(action) {
@@ -386,9 +447,15 @@ document.getElementById("event-filter-form").addEventListener("submit", async (e
   await refreshEvents();
 });
 
+document.getElementById("audit-filter-form").addEventListener("submit", async (event) => {
+  event.preventDefault();
+  await refreshAudit();
+});
+
 document.getElementById("refresh-goals").addEventListener("click", refreshGoals);
 document.getElementById("refresh-tasks").addEventListener("click", refreshTasks);
 document.getElementById("refresh-events").addEventListener("click", refreshEvents);
+document.getElementById("refresh-audit").addEventListener("click", refreshAudit);
 document.getElementById("refresh-queue").addEventListener("click", refreshQueue);
 
 document.addEventListener("click", async (event) => {
@@ -454,6 +521,7 @@ setInterval(() => {
   refreshGoals().catch(() => {});
   refreshTasks().catch(() => {});
   refreshEvents().catch(() => {});
+  refreshAudit().catch(() => {});
   refreshHealth().catch(() => {});
   refreshQueue().catch(() => {});
 }, 5000);

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -325,6 +325,18 @@
       <div id="events-table"></div>
     </section>
 
+    <section class="wide">
+      <h2><span>Audit Log</span><button class="secondary" id="refresh-audit">Refresh</button></h2>
+      <form id="audit-filter-form">
+        <div class="split">
+          <input name="action" id="audit-action" placeholder="Optional action (e.g. http.mutation)">
+          <input name="status" id="audit-status" placeholder="Optional status (success|error)">
+        </div>
+        <button type="submit">Apply Filter</button>
+      </form>
+      <div id="audit-table"></div>
+    </section>
+
     <section>
       <h2>System Health</h2>
       <div id="health-cards" class="grid-two"></div>
@@ -332,6 +344,8 @@
       <div id="backpressure-status"></div>
       <h3>Retention Policy</h3>
       <div id="retention-policy"></div>
+      <h3>Metrics Hooks</h3>
+      <div id="metrics-hooks"></div>
       <h3>Consumer Stats</h3>
       <div id="consumer-stats"></div>
       <h3>Stuck Events</h3>

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -532,3 +532,69 @@ def test_30_backpressure_endpoint_and_health_include_limits(client):
     assert snapshot.json()["max_pending_events"] == client.app.state.services.settings.max_pending_events
     assert "backpressure" in health.json()
     assert "retention" in health.json()
+
+
+def test_31_metrics_endpoint_exposes_hook_counters(client):
+    created = client.post(
+        "/goals",
+        json={"title": "Metrics goal", "description": "check", "urgency": 0.5, "value": 0.5, "deadline_score": 0.0},
+    )
+    metrics = client.get("/system/metrics")
+    assert created.status_code == 201
+    assert metrics.status_code == 200
+    payload = metrics.json()
+    lookup = {item["metric_name"]: item["value"] for item in payload["metrics"]}
+    assert lookup["goals.created"] >= 1
+    assert lookup["events.emitted"] >= 1
+
+
+def test_32_audit_endpoint_lists_mutating_requests(client):
+    response = client.post(
+        "/goals",
+        json={"title": "Audit goal", "description": "check", "urgency": 0.4, "value": 0.4, "deadline_score": 0.0},
+    )
+    audit = client.get("/system/audit")
+    assert response.status_code == 201
+    assert audit.status_code == 200
+    entries = audit.json()["entries"]
+    assert any(
+        item["action"] == "http.mutation"
+        and item["status"] == "success"
+        and item["entity_id"] == "/goals"
+        and item["details"]["method"] == "POST"
+        for item in entries
+    )
+
+
+def test_33_rejected_transition_updates_error_metrics_and_audit(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Reject me", "description": "check", "urgency": 0.5, "value": 0.5, "deadline_score": 0.1},
+    ).json()
+    rejected = client.post(f"/goals/{goal['goal_id']}/archive")
+    metrics = client.get("/system/metrics?prefix=errors.domain")
+    audit_error = client.get("/system/audit?status=error")
+    assert rejected.status_code == 409
+    assert metrics.status_code == 200
+    assert audit_error.status_code == 200
+    metric_names = {item["metric_name"] for item in metrics.json()["metrics"]}
+    assert "errors.domain.ConflictError" in metric_names
+    assert any(
+        item["entity_id"] == "/goals/{goal_id}/archive"
+        and item["details"]["status_code"] == 409
+        for item in audit_error.json()["entries"]
+    )
+
+
+def test_34_health_includes_metrics_and_audit_summaries(client):
+    client.post(
+        "/goals",
+        json={"title": "Health goal", "description": "check", "urgency": 0.6, "value": 0.5, "deadline_score": 0.0},
+    )
+    health = client.get("/system/health")
+    assert health.status_code == 200
+    payload = health.json()
+    assert "metrics" in payload
+    assert "audit" in payload
+    assert payload["metrics"]["goals.created"] >= 1
+    assert payload["audit"]["entries_last_24h"] >= 1


### PR DESCRIPTION
## Summary
- add SQLite-backed audit_log and metrics_counters tables
- add observability service with audit and metrics endpoints
- hook metrics into HTTP middleware, event bus, state transitions, and execution flow
- extend dashboard with Audit Log and Metrics Hooks views
- add tests for metrics and audit behavior (34 passing)

## Validation
- python -m pytest -q