### PR TITLE
Add dedicated goal flow trace endpoint and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ The dashboard now includes an `Operator Controls` section for supervised Phase 2
   Resets timed-out `processing` entries back to `pending` for the given consumer id.
 - `Run Retention Cleanup`
   Removes old `events`, `event_processing` and `failure_log` rows based on retention policy.
+- `Flow Trace` (new section)
+  Loads the full goal event chain and groups retry attempts per task.
 - `Audit Log` (new section)
   Shows recent mutating API operations with status and request details.
 - `Metrics Hooks` (in System Health)
@@ -171,6 +173,7 @@ Observability endpoints:
 
 - `GET /system/metrics`
 - `GET /system/audit`
+- `GET /events/trace/{goal_id}`
 
 ## Run The Test Suite
 
@@ -182,7 +185,7 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 Current result during implementation:
 
 ```text
-34 passed
+36 passed
 ```
 
 ## CI And PR Guardrails

--- a/goal_ops_console/event_bus.py
+++ b/goal_ops_console/event_bus.py
@@ -179,6 +179,57 @@ class EventBus:
         )
         return [self._row_to_event(row) for row in rows]
 
+    def flow_trace(self, goal_id: str, *, limit: int = 500) -> dict[str, Any]:
+        events = self.list_events(correlation_id=goal_id, limit=limit)
+        prefix = f"{goal_id}:"
+        goal_level_events: list[dict[str, Any]] = []
+        attempt_buckets: dict[tuple[str, int], list[dict[str, Any]]] = {}
+
+        for event in events:
+            correlation = event["correlation_id"]
+            if correlation == goal_id:
+                goal_level_events.append(event)
+                continue
+            if not correlation.startswith(prefix):
+                continue
+
+            suffix = correlation[len(prefix):]
+            parts = suffix.split(":")
+            if len(parts) < 2:
+                continue
+            task_id = parts[0]
+            try:
+                attempt = int(parts[1])
+            except ValueError:
+                continue
+
+            attempt_buckets.setdefault((task_id, attempt), []).append(event)
+
+        attempts: list[dict[str, Any]] = []
+        for (task_id, attempt), grouped_events in attempt_buckets.items():
+            seqs = [item["seq"] for item in grouped_events]
+            attempts.append(
+                {
+                    "task_id": task_id,
+                    "attempt": attempt,
+                    "event_count": len(grouped_events),
+                    "first_seq": min(seqs),
+                    "last_seq": max(seqs),
+                    "event_types": [item["event_type"] for item in grouped_events],
+                }
+            )
+
+        attempts.sort(key=lambda item: (item["first_seq"], item["task_id"], item["attempt"]))
+        return {
+            "goal_id": goal_id,
+            "event_count": len(events),
+            "goal_level_count": len(goal_level_events),
+            "attempt_count": len(attempts),
+            "goal_level_events": goal_level_events,
+            "attempts": attempts,
+            "events": events,
+        }
+
     def reclaim_stuck_processing(self, consumer_id: str) -> int:
         reclaimed = self.db.execute(
             """UPDATE event_processing

--- a/goal_ops_console/routers/events.py
+++ b/goal_ops_console/routers/events.py
@@ -17,3 +17,12 @@ def list_events(
         entity_id=entity_id,
         limit=limit,
     )
+
+
+@router.get("/trace/{goal_id}")
+def flow_trace(
+    goal_id: str,
+    limit: int = 500,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return services.event_bus.flow_trace(goal_id, limit=limit)

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -215,6 +215,35 @@ function renderAudit(entries) {
     </table></div>`;
 }
 
+function renderFlowTrace(trace) {
+  const container = document.getElementById("flow-trace");
+  if (!trace || trace.event_count === 0) {
+    container.innerHTML = `<div class="meta">No trace events for this goal id.</div>`;
+    return;
+  }
+  const attempts = trace.attempts || [];
+  container.innerHTML = `
+    <div class="grid-two">
+      <div class="card"><span class="meta">Goal ID</span><div>${trace.goal_id}</div></div>
+      <div class="card"><span class="meta">Total Events</span><strong>${trace.event_count}</strong></div>
+      <div class="card"><span class="meta">Goal-Level Events</span><strong>${trace.goal_level_count}</strong></div>
+      <div class="card"><span class="meta">Attempt Groups</span><strong>${trace.attempt_count}</strong></div>
+    </div>
+    ${attempts.length ? `<div class="table-scroll" style="margin-top:0.75rem;"><table>
+      <thead><tr><th>Task</th><th>Attempt</th><th>Seq Range</th><th>Events</th></tr></thead>
+      <tbody>
+        ${attempts.map((item) => `
+          <tr>
+            <td><div>${item.task_id}</div></td>
+            <td>${item.attempt}</td>
+            <td>${item.first_seq} -> ${item.last_seq}</td>
+            <td>${item.event_types.join(", ")}</td>
+          </tr>`).join("")}
+      </tbody>
+    </table></div>` : `<div class="meta" style="margin-top:0.75rem;">No attempt-level events detected.</div>`}
+  `;
+}
+
 function renderHealth(health) {
   defaultConsumerId = health.default_consumer_id || defaultConsumerId;
   const consumerInput = document.getElementById("consumer-id");
@@ -345,6 +374,17 @@ async function refreshAudit() {
   renderAudit(payload.entries || []);
 }
 
+async function refreshFlowTrace() {
+  const goalId = document.getElementById("trace-goal-id").value.trim();
+  const container = document.getElementById("flow-trace");
+  if (!goalId) {
+    container.innerHTML = `<div class="meta">Enter a goal id to load flow trace.</div>`;
+    return;
+  }
+  const trace = await api(`/events/trace/${encodeURIComponent(goalId)}`);
+  renderFlowTrace(trace);
+}
+
 async function refreshHealth() {
   const health = await api("/system/health");
   renderHealth(health);
@@ -355,6 +395,7 @@ async function refreshAll() {
     refreshGoals(),
     refreshTasks(),
     refreshEvents(),
+    refreshFlowTrace(),
     refreshAudit(),
     refreshHealth(),
     refreshQueue(),
@@ -413,6 +454,7 @@ document.getElementById("goal-form").addEventListener("submit", async (event) =>
     selectedGoalId = goal.goal_id;
     document.getElementById("task-goal-id").value = goal.goal_id;
     document.getElementById("event-correlation-id").value = goal.goal_id;
+    document.getElementById("trace-goal-id").value = goal.goal_id;
     formElement.reset();
     await refreshAll();
   } catch (error) {
@@ -452,9 +494,15 @@ document.getElementById("audit-filter-form").addEventListener("submit", async (e
   await refreshAudit();
 });
 
+document.getElementById("flow-trace-form").addEventListener("submit", async (event) => {
+  event.preventDefault();
+  await refreshFlowTrace();
+});
+
 document.getElementById("refresh-goals").addEventListener("click", refreshGoals);
 document.getElementById("refresh-tasks").addEventListener("click", refreshTasks);
 document.getElementById("refresh-events").addEventListener("click", refreshEvents);
+document.getElementById("refresh-flow-trace").addEventListener("click", refreshFlowTrace);
 document.getElementById("refresh-audit").addEventListener("click", refreshAudit);
 document.getElementById("refresh-queue").addEventListener("click", refreshQueue);
 
@@ -477,6 +525,7 @@ document.addEventListener("click", async (event) => {
       selectedGoalId = goalId;
       document.getElementById("task-goal-id").value = goalId;
       document.getElementById("event-correlation-id").value = goalId;
+      document.getElementById("trace-goal-id").value = goalId;
       await refreshAll();
     }
 
@@ -499,15 +548,19 @@ document.addEventListener("click", async (event) => {
 
     if (correlation) {
       document.getElementById("event-correlation-id").value = correlation;
+      document.getElementById("trace-goal-id").value = correlation.split(":")[0];
       await refreshEvents();
+      await refreshFlowTrace();
     }
 
     if (selectGoal) {
       selectedGoalId = selectGoal;
       document.getElementById("task-goal-id").value = selectGoal;
       document.getElementById("event-correlation-id").value = selectGoal;
+      document.getElementById("trace-goal-id").value = selectGoal;
       await refreshTasks();
       await refreshEvents();
+      await refreshFlowTrace();
       document.getElementById("selected-goal-label").textContent = `Selected goal: ${selectGoal}`;
     }
   } catch (error) {
@@ -521,6 +574,7 @@ setInterval(() => {
   refreshGoals().catch(() => {});
   refreshTasks().catch(() => {});
   refreshEvents().catch(() => {});
+  refreshFlowTrace().catch(() => {});
   refreshAudit().catch(() => {});
   refreshHealth().catch(() => {});
   refreshQueue().catch(() => {});

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -326,6 +326,15 @@
     </section>
 
     <section class="wide">
+      <h2><span>Flow Trace</span><button class="secondary" id="refresh-flow-trace">Refresh</button></h2>
+      <form id="flow-trace-form">
+        <input name="goal_id" id="trace-goal-id" placeholder="Goal ID for full flow trace">
+        <button type="submit">Load Trace</button>
+      </form>
+      <div id="flow-trace"></div>
+    </section>
+
+    <section class="wide">
       <h2><span>Audit Log</span><button class="secondary" id="refresh-audit">Refresh</button></h2>
       <form id="audit-filter-form">
         <div class="split">

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -598,3 +598,39 @@ def test_34_health_includes_metrics_and_audit_summaries(client):
     assert "audit" in payload
     assert payload["metrics"]["goals.created"] >= 1
     assert payload["audit"]["entries_last_24h"] >= 1
+
+
+def test_35_flow_trace_endpoint_groups_attempts(client):
+    goal = create_active_goal(client)
+    task = create_task(client, goal["goal_id"])
+
+    client.post(
+        f"/tasks/{task['task_id']}/fail",
+        json={"failure_type": "SkillFailure", "error_message": "Trace error"},
+    )
+    client.post(
+        f"/tasks/{task['task_id']}/fail",
+        json={"failure_type": "SkillFailure", "error_message": "Trace error"},
+    )
+
+    response = client.get(f"/events/trace/{goal['goal_id']}")
+    assert response.status_code == 200
+    trace = response.json()
+    assert trace["goal_id"] == goal["goal_id"]
+    assert trace["event_count"] >= 9
+
+    attempts = {(item["task_id"], item["attempt"]) for item in trace["attempts"]}
+    assert (task["task_id"], 0) in attempts
+    assert (task["task_id"], 1) in attempts
+
+    seqs = [event["seq"] for event in trace["events"]]
+    assert seqs == sorted(seqs)
+
+
+def test_36_flow_trace_empty_when_goal_has_no_events(client):
+    response = client.get("/events/trace/non-existing-goal-id")
+    assert response.status_code == 200
+    trace = response.json()
+    assert trace["event_count"] == 0
+    assert trace["attempt_count"] == 0
+    assert trace["attempts"] == []


### PR DESCRIPTION
## Summary
- add GET /events/trace/{goal_id} with attempt-level grouping and ordered event chain
- add a dedicated Flow Trace section to the dashboard (filter input + grouped attempts)
- connect existing Trace buttons to auto-load full flow trace
- add tests for trace grouping and empty trace behavior
- update README with new endpoint and latest test count

## Validation
- python -m pytest -q