### PR TITLE
Add dead-letter fault explorer (API + UI + tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ The dashboard now includes an `Operator Controls` section for supervised Phase 2
   Removes old `events`, `event_processing` and `failure_log` rows based on retention policy.
 - `Flow Trace` (new section)
   Loads the full goal event chain and groups retry attempts per task.
+- `Dead-Letter / Fault Explorer` (new section)
+  Lists failure records with filters (`failure_type`, `task_status`, `goal_id`, `error_hash`) and a dead-letter toggle.
 - `Audit Log` (new section)
   Shows recent mutating API operations with status and request details.
 - `Metrics Hooks` (in System Health)
@@ -173,6 +175,8 @@ Observability endpoints:
 
 - `GET /system/metrics`
 - `GET /system/audit`
+- `GET /system/faults`
+- `GET /system/faults/summary`
 - `GET /events/trace/{goal_id}`
 
 ## Run The Test Suite
@@ -185,7 +189,7 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 Current result during implementation:
 
 ```text
-36 passed
+39 passed
 ```
 
 ## CI And PR Guardrails

--- a/goal_ops_console/failure_intelligence.py
+++ b/goal_ops_console/failure_intelligence.py
@@ -93,3 +93,129 @@ class FailureIntelligence:
         if retry_count < max_retries:
             return False
         return self.count_errors_in_window(error_hash, tx=tx) >= 2
+
+    def list_faults(
+        self,
+        *,
+        limit: int = 200,
+        failure_type: str | None = None,
+        task_status: str | None = None,
+        goal_id: str | None = None,
+        error_hash: str | None = None,
+        dead_letter_only: bool = False,
+    ) -> list[dict]:
+        clauses, params = self._fault_filters(
+            failure_type=failure_type,
+            task_status=task_status,
+            goal_id=goal_id,
+            error_hash=error_hash,
+            dead_letter_only=dead_letter_only,
+        )
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        rows = self.db.fetch_all(
+            f"""SELECT fl.id AS failure_id,
+                       fl.created_at,
+                       fl.failure_type,
+                       fl.fingerprint AS error_hash,
+                       fl.retry_count,
+                       fl.last_error,
+                       fl.status AS failure_status,
+                       fl.task_id,
+                       t.title AS task_title,
+                       ts.status AS task_status,
+                       fl.goal_id,
+                       g.title AS goal_title,
+                       g.state AS goal_state,
+                       fl.correlation_id
+                FROM failure_log fl
+                LEFT JOIN task_state ts ON ts.task_id = fl.task_id
+                LEFT JOIN tasks t ON t.task_id = fl.task_id
+                LEFT JOIN goals g ON g.goal_id = fl.goal_id
+                {where}
+                ORDER BY fl.created_at DESC
+                LIMIT ?""",
+            *params,
+            limit,
+        )
+        return [dict(row) for row in rows]
+
+    def fault_summary(
+        self,
+        *,
+        limit: int = 20,
+        failure_type: str | None = None,
+        task_status: str | None = None,
+        goal_id: str | None = None,
+        error_hash: str | None = None,
+        dead_letter_only: bool = False,
+    ) -> dict:
+        clauses, params = self._fault_filters(
+            failure_type=failure_type,
+            task_status=task_status,
+            goal_id=goal_id,
+            error_hash=error_hash,
+            dead_letter_only=dead_letter_only,
+        )
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+
+        top_rows = self.db.fetch_all(
+            f"""SELECT fl.failure_type,
+                       fl.fingerprint AS error_hash,
+                       COUNT(*) AS count,
+                       COUNT(DISTINCT fl.task_id) AS task_count,
+                       MAX(fl.created_at) AS latest_at
+                FROM failure_log fl
+                LEFT JOIN task_state ts ON ts.task_id = fl.task_id
+                {where}
+                GROUP BY fl.failure_type, fl.fingerprint
+                ORDER BY count DESC, latest_at DESC
+                LIMIT ?""",
+            *params,
+            limit,
+        )
+        total_failures = self.db.fetch_scalar(
+            f"""SELECT COUNT(*)
+                FROM failure_log fl
+                LEFT JOIN task_state ts ON ts.task_id = fl.task_id
+                {where}""",
+            *params,
+        ) or 0
+        poison_tasks = self.db.fetch_scalar("SELECT COUNT(*) FROM task_state WHERE status = 'poison'") or 0
+        exhausted_tasks = (
+            self.db.fetch_scalar("SELECT COUNT(*) FROM task_state WHERE status = 'exhausted'") or 0
+        )
+        dead_letter_tasks = int(poison_tasks) + int(exhausted_tasks)
+        return {
+            "total_failures": int(total_failures),
+            "dead_letter_tasks": dead_letter_tasks,
+            "poison_tasks": int(poison_tasks),
+            "exhausted_tasks": int(exhausted_tasks),
+            "top_error_hashes": [dict(row) for row in top_rows],
+        }
+
+    def _fault_filters(
+        self,
+        *,
+        failure_type: str | None,
+        task_status: str | None,
+        goal_id: str | None,
+        error_hash: str | None,
+        dead_letter_only: bool,
+    ) -> tuple[list[str], list[object]]:
+        clauses: list[str] = []
+        params: list[object] = []
+        if failure_type:
+            clauses.append("fl.failure_type = ?")
+            params.append(failure_type)
+        if task_status:
+            clauses.append("ts.status = ?")
+            params.append(task_status)
+        if goal_id:
+            clauses.append("fl.goal_id = ?")
+            params.append(goal_id)
+        if error_hash:
+            clauses.append("fl.fingerprint = ?")
+            params.append(error_hash)
+        if dead_letter_only:
+            clauses.append("ts.status IN ('poison', 'exhausted')")
+        return clauses, params

--- a/goal_ops_console/routers/system.py
+++ b/goal_ops_console/routers/system.py
@@ -24,6 +24,10 @@ def system_health(services: AppServices = Depends(get_services)) -> dict:
     total_goals = services.db.fetch_scalar("SELECT COUNT(*) FROM goals") or 0
     total_tasks = services.db.fetch_scalar("SELECT COUNT(*) FROM task_state") or 0
     backpressure = services.event_bus.backpressure_snapshot()
+    faults = services.failure_intelligence.fault_summary(limit=5, dead_letter_only=True)
+    faults["systemic_external_failures_last_window"] = (
+        services.failure_intelligence.systemic_external_failure_count()
+    )
     return {
         "spec_version": SPEC_VERSION,
         "default_consumer_id": services.settings.consumer_id,
@@ -42,6 +46,7 @@ def system_health(services: AppServices = Depends(get_services)) -> dict:
         "audit": {
             "entries_last_24h": services.observability.recent_audit_count(hours=24),
         },
+        "faults": faults,
         "retry_budget_per_cycle": MAX_TOTAL_RETRIES_PER_CYCLE,
         "consumer_stats": services.event_bus.consumer_stats(),
         "stuck_events": services.event_bus.stuck_events(),
@@ -148,6 +153,52 @@ def audit_log(
             status=status,
         )
     }
+
+
+@router.get("/system/faults")
+def fault_explorer(
+    limit: int = 200,
+    failure_type: str | None = None,
+    task_status: str | None = None,
+    goal_id: str | None = None,
+    error_hash: str | None = None,
+    dead_letter_only: bool = False,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return {
+        "entries": services.failure_intelligence.list_faults(
+            limit=limit,
+            failure_type=failure_type,
+            task_status=task_status,
+            goal_id=goal_id,
+            error_hash=error_hash,
+            dead_letter_only=dead_letter_only,
+        )
+    }
+
+
+@router.get("/system/faults/summary")
+def fault_summary(
+    limit: int = 20,
+    failure_type: str | None = None,
+    task_status: str | None = None,
+    goal_id: str | None = None,
+    error_hash: str | None = None,
+    dead_letter_only: bool = False,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    summary = services.failure_intelligence.fault_summary(
+        limit=limit,
+        failure_type=failure_type,
+        task_status=task_status,
+        goal_id=goal_id,
+        error_hash=error_hash,
+        dead_letter_only=dead_letter_only,
+    )
+    summary["systemic_external_failures_last_window"] = (
+        services.failure_intelligence.systemic_external_failure_count()
+    )
+    return summary
 
 
 @router.post("/system/maintenance/retention")

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -215,6 +215,78 @@ function renderAudit(entries) {
     </table></div>`;
 }
 
+function renderFaults(summary, entries) {
+  const summaryTarget = document.getElementById("fault-summary");
+  const tableTarget = document.getElementById("fault-table");
+  const top = summary?.top_error_hashes || [];
+
+  summaryTarget.innerHTML = `
+    <div class="grid-two" style="margin-bottom:0.75rem;">
+      <div class="card"><span class="meta">Failures (filtered)</span><strong>${summary?.total_failures || 0}</strong></div>
+      <div class="card"><span class="meta">Dead-Letter Tasks</span><strong>${summary?.dead_letter_tasks || 0}</strong></div>
+      <div class="card"><span class="meta">Poison Tasks</span><strong>${summary?.poison_tasks || 0}</strong></div>
+      <div class="card"><span class="meta">Exhausted Tasks</span><strong>${summary?.exhausted_tasks || 0}</strong></div>
+      <div class="card"><span class="meta">External Failures (window)</span><strong>${summary?.systemic_external_failures_last_window || 0}</strong></div>
+      <div class="card"><span class="meta">Top Hash Buckets</span><strong>${top.length}</strong></div>
+    </div>
+    ${top.length ? `<div class="table-scroll"><table>
+      <thead><tr><th>Type</th><th>Error Hash</th><th>Count</th><th>Tasks</th><th>Latest</th></tr></thead>
+      <tbody>
+        ${top.map((item) => `
+          <tr>
+            <td>${item.failure_type}</td>
+            <td>${item.error_hash || "-"}</td>
+            <td>${item.count}</td>
+            <td>${item.task_count}</td>
+            <td>${item.latest_at || "-"}</td>
+          </tr>`).join("")}
+      </tbody>
+    </table></div>` : `<div class="meta">No fault buckets for current filter.</div>`}
+  `;
+
+  if (!entries.length) {
+    tableTarget.innerHTML = `<div class="meta">No fault records for current filter.</div>`;
+    return;
+  }
+  tableTarget.innerHTML = `<div class="table-scroll"><table>
+    <thead>
+      <tr>
+        <th>Time</th>
+        <th>Failure</th>
+        <th>Task</th>
+        <th>Goal</th>
+        <th>Correlation</th>
+        <th>Error</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${entries.map((item) => `
+        <tr>
+          <td>${item.created_at}</td>
+          <td>
+            <div>${item.failure_type}</div>
+            <div class="meta">retry=${item.retry_count} / ${item.failure_status}</div>
+          </td>
+          <td>
+            <div>${item.task_title || "-"}</div>
+            <div class="meta">${item.task_id}</div>
+            <div><span class="pill ${stateClass(item.task_status)}">${item.task_status || "-"}</span></div>
+          </td>
+          <td>
+            <div>${item.goal_title || "-"}</div>
+            <div class="meta">${item.goal_id}</div>
+            <div><span class="pill ${stateClass(item.goal_state)}">${item.goal_state || "-"}</span></div>
+          </td>
+          <td><span class="inline-link" data-correlation="${item.correlation_id}">${item.correlation_id}</span></td>
+          <td>
+            <div>${item.error_hash || "-"}</div>
+            <div class="meta">${item.last_error || ""}</div>
+          </td>
+        </tr>`).join("")}
+    </tbody>
+  </table></div>`;
+}
+
 function renderFlowTrace(trace) {
   const container = document.getElementById("flow-trace");
   if (!trace || trace.event_count === 0) {
@@ -254,6 +326,7 @@ function renderHealth(health) {
   const retention = health.retention || {};
   const metrics = health.metrics || {};
   const audit = health.audit || {};
+  const faults = health.faults || {};
   document.getElementById("health-cards").innerHTML = `
     <div class="card"><span class="meta">Events</span><strong>${health.totals.events}</strong></div>
     <div class="card"><span class="meta">Goals</span><strong>${health.totals.goals}</strong></div>
@@ -262,7 +335,9 @@ function renderHealth(health) {
     <div class="card"><span class="meta">Pending Events</span><strong>${backpressure.pending_events || 0}</strong></div>
     <div class="card"><span class="meta">Backpressure</span><strong>${backpressure.is_throttled ? "ON" : "OFF"}</strong></div>
     <div class="card"><span class="meta">429 Count</span><strong>${metrics["http.requests.status.429"] || 0}</strong></div>
-    <div class="card"><span class="meta">Audit (24h)</span><strong>${audit.entries_last_24h || 0}</strong></div>`;
+    <div class="card"><span class="meta">Audit (24h)</span><strong>${audit.entries_last_24h || 0}</strong></div>
+    <div class="card"><span class="meta">Failures</span><strong>${faults.total_failures || 0}</strong></div>
+    <div class="card"><span class="meta">Dead-Letter Tasks</span><strong>${faults.dead_letter_tasks || 0}</strong></div>`;
 
   document.getElementById("backpressure-status").innerHTML = `
     <div class="meta">Consumer: ${backpressure.consumer_id || "-"}</div>
@@ -296,6 +371,13 @@ function renderHealth(health) {
   document.getElementById("invariant-violations").innerHTML = health.invariant_violations.length
     ? `<ul>${health.invariant_violations.map((item) => `<li>${item}</li>`).join("")}</ul>`
     : `<div class="meta">No invariant violations detected.</div>`;
+
+  const topFaults = faults.top_error_hashes || [];
+  document.getElementById("fault-snapshot").innerHTML = topFaults.length
+    ? `<table><thead><tr><th>Type</th><th>Hash</th><th>Count</th></tr></thead><tbody>${
+        topFaults.map((item) => `<tr><td>${item.failure_type}</td><td>${item.error_hash || "-"}</td><td>${item.count}</td></tr>`).join("")
+      }</tbody></table>`
+    : `<div class="meta">No dead-letter faults in snapshot.</div>`;
 }
 
 function renderQueue(goals) {
@@ -374,6 +456,26 @@ async function refreshAudit() {
   renderAudit(payload.entries || []);
 }
 
+async function refreshFaults() {
+  const failureType = document.getElementById("fault-failure-type").value.trim();
+  const taskStatus = document.getElementById("fault-task-status").value.trim();
+  const goalId = document.getElementById("fault-goal-id").value.trim();
+  const errorHash = document.getElementById("fault-error-hash").value.trim();
+  const deadLetterOnly = document.getElementById("fault-dead-letter-only").checked;
+  const params = new URLSearchParams();
+  if (failureType) params.set("failure_type", failureType);
+  if (taskStatus) params.set("task_status", taskStatus);
+  if (goalId) params.set("goal_id", goalId);
+  if (errorHash) params.set("error_hash", errorHash);
+  params.set("dead_letter_only", deadLetterOnly ? "true" : "false");
+  const suffix = `?${params.toString()}`;
+  const [entryPayload, summaryPayload] = await Promise.all([
+    api(`/system/faults${suffix}`),
+    api(`/system/faults/summary${suffix}`),
+  ]);
+  renderFaults(summaryPayload, entryPayload.entries || []);
+}
+
 async function refreshFlowTrace() {
   const goalId = document.getElementById("trace-goal-id").value.trim();
   const container = document.getElementById("flow-trace");
@@ -397,6 +499,7 @@ async function refreshAll() {
     refreshEvents(),
     refreshFlowTrace(),
     refreshAudit(),
+    refreshFaults(),
     refreshHealth(),
     refreshQueue(),
   ]);
@@ -455,6 +558,7 @@ document.getElementById("goal-form").addEventListener("submit", async (event) =>
     document.getElementById("task-goal-id").value = goal.goal_id;
     document.getElementById("event-correlation-id").value = goal.goal_id;
     document.getElementById("trace-goal-id").value = goal.goal_id;
+    document.getElementById("fault-goal-id").value = goal.goal_id;
     formElement.reset();
     await refreshAll();
   } catch (error) {
@@ -494,6 +598,11 @@ document.getElementById("audit-filter-form").addEventListener("submit", async (e
   await refreshAudit();
 });
 
+document.getElementById("fault-filter-form").addEventListener("submit", async (event) => {
+  event.preventDefault();
+  await refreshFaults();
+});
+
 document.getElementById("flow-trace-form").addEventListener("submit", async (event) => {
   event.preventDefault();
   await refreshFlowTrace();
@@ -504,6 +613,7 @@ document.getElementById("refresh-tasks").addEventListener("click", refreshTasks)
 document.getElementById("refresh-events").addEventListener("click", refreshEvents);
 document.getElementById("refresh-flow-trace").addEventListener("click", refreshFlowTrace);
 document.getElementById("refresh-audit").addEventListener("click", refreshAudit);
+document.getElementById("refresh-faults").addEventListener("click", refreshFaults);
 document.getElementById("refresh-queue").addEventListener("click", refreshQueue);
 
 document.addEventListener("click", async (event) => {
@@ -526,6 +636,7 @@ document.addEventListener("click", async (event) => {
       document.getElementById("task-goal-id").value = goalId;
       document.getElementById("event-correlation-id").value = goalId;
       document.getElementById("trace-goal-id").value = goalId;
+      document.getElementById("fault-goal-id").value = goalId;
       await refreshAll();
     }
 
@@ -549,8 +660,10 @@ document.addEventListener("click", async (event) => {
     if (correlation) {
       document.getElementById("event-correlation-id").value = correlation;
       document.getElementById("trace-goal-id").value = correlation.split(":")[0];
+      document.getElementById("fault-goal-id").value = correlation.split(":")[0];
       await refreshEvents();
       await refreshFlowTrace();
+      await refreshFaults();
     }
 
     if (selectGoal) {
@@ -558,9 +671,11 @@ document.addEventListener("click", async (event) => {
       document.getElementById("task-goal-id").value = selectGoal;
       document.getElementById("event-correlation-id").value = selectGoal;
       document.getElementById("trace-goal-id").value = selectGoal;
+      document.getElementById("fault-goal-id").value = selectGoal;
       await refreshTasks();
       await refreshEvents();
       await refreshFlowTrace();
+      await refreshFaults();
       document.getElementById("selected-goal-label").textContent = `Selected goal: ${selectGoal}`;
     }
   } catch (error) {
@@ -576,6 +691,7 @@ setInterval(() => {
   refreshEvents().catch(() => {});
   refreshFlowTrace().catch(() => {});
   refreshAudit().catch(() => {});
+  refreshFaults().catch(() => {});
   refreshHealth().catch(() => {});
   refreshQueue().catch(() => {});
 }, 5000);

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -346,6 +346,38 @@
       <div id="audit-table"></div>
     </section>
 
+    <section class="wide">
+      <h2><span>Dead-Letter / Fault Explorer</span><button class="secondary" id="refresh-faults">Refresh</button></h2>
+      <form id="fault-filter-form">
+        <div class="split">
+          <select id="fault-failure-type">
+            <option value="">All failure types</option>
+            <option value="SkillFailure">SkillFailure</option>
+            <option value="ExecutionFailure">ExecutionFailure</option>
+            <option value="ExternalFailure">ExternalFailure</option>
+            <option value="PlanFailure">PlanFailure</option>
+          </select>
+          <select id="fault-task-status">
+            <option value="">All task statuses</option>
+            <option value="pending">pending</option>
+            <option value="running">running</option>
+            <option value="failed">failed</option>
+            <option value="succeeded">succeeded</option>
+            <option value="exhausted">exhausted</option>
+            <option value="poison">poison</option>
+          </select>
+        </div>
+        <div class="split">
+          <input id="fault-goal-id" placeholder="Optional goal id">
+          <input id="fault-error-hash" placeholder="Optional error hash">
+        </div>
+        <label class="meta"><input type="checkbox" id="fault-dead-letter-only" checked> Dead-letter only (`poison` + `exhausted`)</label>
+        <button type="submit">Apply Filter</button>
+      </form>
+      <div id="fault-summary"></div>
+      <div id="fault-table"></div>
+    </section>
+
     <section>
       <h2>System Health</h2>
       <div id="health-cards" class="grid-two"></div>
@@ -355,6 +387,8 @@
       <div id="retention-policy"></div>
       <h3>Metrics Hooks</h3>
       <div id="metrics-hooks"></div>
+      <h3>Fault Snapshot</h3>
+      <div id="fault-snapshot"></div>
       <h3>Consumer Stats</h3>
       <div id="consumer-stats"></div>
       <h3>Stuck Events</h3>

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -634,3 +634,74 @@ def test_36_flow_trace_empty_when_goal_has_no_events(client):
     assert trace["event_count"] == 0
     assert trace["attempt_count"] == 0
     assert trace["attempts"] == []
+
+
+def test_37_fault_explorer_dead_letter_filter_returns_poison_task(client):
+    goal = create_active_goal(client, title="Fault Goal")
+    task = create_task(client, goal["goal_id"], title="Fault Task")
+    client.post(
+        f"/tasks/{task['task_id']}/fail",
+        json={"failure_type": "SkillFailure", "error_message": "Persistent issue"},
+    )
+    client.post(
+        f"/tasks/{task['task_id']}/fail",
+        json={"failure_type": "SkillFailure", "error_message": "Persistent issue"},
+    )
+
+    response = client.get("/system/faults?dead_letter_only=true")
+    assert response.status_code == 200
+    entries = response.json()["entries"]
+    assert any(item["task_id"] == task["task_id"] for item in entries)
+    assert any(item["task_status"] == "poison" for item in entries)
+
+
+def test_38_fault_explorer_filters_by_failure_type_and_hash(client):
+    goal = create_active_goal(client, title="Filter Goal")
+    task_a = create_task(client, goal["goal_id"], title="Exec Task")
+    task_b = create_task(client, goal["goal_id"], title="Skill Task")
+
+    exec_message = "Execution exploded"
+    client.post(
+        f"/tasks/{task_a['task_id']}/fail",
+        json={"failure_type": "ExecutionFailure", "error_message": exec_message},
+    )
+    client.post(
+        f"/tasks/{task_b['task_id']}/fail",
+        json={"failure_type": "SkillFailure", "error_message": "Skill exploded"},
+    )
+
+    exec_hash = compute_error_hash("ExecutionFailure", exec_message)
+    response = client.get(
+        f"/system/faults?failure_type=ExecutionFailure&error_hash={exec_hash}&dead_letter_only=false"
+    )
+    assert response.status_code == 200
+    entries = response.json()["entries"]
+    assert entries
+    assert all(item["failure_type"] == "ExecutionFailure" for item in entries)
+    assert all(item["error_hash"] == exec_hash for item in entries)
+
+
+def test_39_health_and_fault_summary_include_fault_snapshot(client):
+    goal = create_active_goal(client, title="Snapshot Goal")
+    task = create_task(client, goal["goal_id"], title="Snapshot Task")
+    client.post(
+        f"/tasks/{task['task_id']}/fail",
+        json={"failure_type": "SkillFailure", "error_message": "Snapshot issue"},
+    )
+    client.post(
+        f"/tasks/{task['task_id']}/fail",
+        json={"failure_type": "SkillFailure", "error_message": "Snapshot issue"},
+    )
+
+    summary = client.get("/system/faults/summary?dead_letter_only=true")
+    health = client.get("/system/health")
+    assert summary.status_code == 200
+    assert health.status_code == 200
+
+    summary_payload = summary.json()
+    health_payload = health.json()
+    assert summary_payload["dead_letter_tasks"] >= 1
+    assert summary_payload["poison_tasks"] >= 1
+    assert "systemic_external_failures_last_window" in summary_payload
+    assert "faults" in health_payload
+    assert health_payload["faults"]["dead_letter_tasks"] >= 1


### PR DESCRIPTION
## Summary
- add read-only fault explorer endpoints (/system/faults, /system/faults/summary)
- add dead-letter filter and fault snapshot to system health
- add dashboard section for Dead-Letter / Fault Explorer with filters and top hash buckets
- include correlation hand-off from other views into fault explorer
- add tests for fault filtering and health snapshot
- update README and test count

## Validation
- python -m pytest -q