### PR TITLE
Add supervised remediation workflow for dead-letter faults

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ The dashboard now includes an `Operator Controls` section for supervised Phase 2
   Loads the full goal event chain and groups retry attempts per task.
 - `Dead-Letter / Fault Explorer` (new section)
   Lists failure records with filters (`failure_type`, `task_status`, `goal_id`, `error_hash`) and a dead-letter toggle.
+  Includes supervised remediation actions:
+  - `Retry Task` creates a new pending retry task for a dead-letter failure.
+  - `Requeue Goal` transitions `blocked` / `escalation_pending` goals back to `active`.
+  - `Dry run` previews remediation without writing state.
 - `Audit Log` (new section)
   Shows recent mutating API operations with status and request details.
 - `Metrics Hooks` (in System Health)
@@ -177,6 +181,8 @@ Observability endpoints:
 - `GET /system/audit`
 - `GET /system/faults`
 - `GET /system/faults/summary`
+- `POST /system/faults/{failure_id}/retry`
+- `POST /system/faults/{failure_id}/requeue_goal`
 - `GET /events/trace/{goal_id}`
 
 ## Run The Test Suite

--- a/goal_ops_console/execution_layer.py
+++ b/goal_ops_console/execution_layer.py
@@ -313,6 +313,251 @@ class ExecutionLayer:
 
         return self.get_task(task_id)
 
+    def retry_fault(
+        self,
+        *,
+        failure_id: str,
+        reason: str,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        context = self.failure_intelligence.get_fault_by_id(failure_id)
+        if context is None:
+            raise NotFoundError(f"Failure {failure_id} not found")
+
+        plan = self._retry_plan(context)
+        if dry_run:
+            return {
+                "dry_run": True,
+                "failure_id": failure_id,
+                **plan,
+            }
+        if not plan["allowed"]:
+            raise ConflictError("; ".join(plan["blockers"]))
+
+        with self.db.transaction() as tx:
+            current = self.failure_intelligence.get_fault_by_id(failure_id, tx=tx)
+            if current is None:
+                raise NotFoundError(f"Failure {failure_id} not found")
+
+            plan = self._retry_plan(current)
+            if not plan["allowed"]:
+                raise ConflictError("; ".join(plan["blockers"]))
+
+            correlation_id = self._remediation_correlation_id(current)
+            if plan["will_requeue_goal"]:
+                self.state_manager.transition_goal(
+                    current["goal_id"],
+                    to_state="active",
+                    owner="state_manager",
+                    event_type="goal.remediation_requeued",
+                    correlation_id=correlation_id,
+                    reason=reason,
+                    payload={
+                        "failure_id": failure_id,
+                        "failure_type": current["failure_type"],
+                        "error_hash": current["error_hash"],
+                        "reason": reason,
+                    },
+                    tx=tx,
+                )
+                self._metric("faults.remediation.goal_requeued", tx=tx)
+
+            retry_task_id = new_id()
+            retry_correlation_id = f"{current['goal_id']}:{retry_task_id}:0"
+            retry_title = current["task_title"] or f"Retry for {current['task_id']}"
+            timestamp = now_utc()
+
+            tx.execute(
+                "INSERT INTO tasks (task_id, goal_id, title, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+                retry_task_id,
+                current["goal_id"],
+                retry_title,
+                timestamp,
+                timestamp,
+            )
+            tx.execute(
+                "INSERT INTO task_state "
+                "(task_id, goal_id, correlation_id, status, retry_count, version, created_at, updated_at) "
+                "VALUES (?, ?, ?, 'pending', 0, 1, ?, ?)",
+                retry_task_id,
+                current["goal_id"],
+                retry_correlation_id,
+                timestamp,
+                timestamp,
+            )
+            self.event_bus.record_event(
+                "task.remediation_retry_queued",
+                retry_task_id,
+                retry_correlation_id,
+                {
+                    "failure_id": failure_id,
+                    "source_task_id": current["task_id"],
+                    "source_error_hash": current["error_hash"],
+                    "reason": reason,
+                },
+                tx=tx,
+            )
+            self.failure_intelligence.update_failure_status(
+                tx,
+                failure_id=failure_id,
+                expected_version=int(current["failure_version"]),
+                status="retry_queued",
+            )
+            self._metric("faults.remediation.retry", tx=tx)
+            self._metric("tasks.created", tx=tx)
+            if self.observability is not None:
+                self.observability.record_audit(
+                    action="fault.remediation.retry",
+                    actor="supervisor",
+                    status="success",
+                    entity_type="failure",
+                    entity_id=failure_id,
+                    correlation_id=retry_correlation_id,
+                    details={
+                        "goal_id": current["goal_id"],
+                        "source_task_id": current["task_id"],
+                        "retry_task_id": retry_task_id,
+                        "goal_requeued": plan["will_requeue_goal"],
+                        "reason": reason,
+                    },
+                    tx=tx,
+                )
+
+        return {
+            "dry_run": False,
+            "failure_id": failure_id,
+            "goal_id": context["goal_id"],
+            "source_task_id": context["task_id"],
+            "retry_task": self.get_task(retry_task_id),
+            "goal_requeued": plan["will_requeue_goal"],
+        }
+
+    def requeue_goal_from_fault(
+        self,
+        *,
+        failure_id: str,
+        reason: str,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        context = self.failure_intelligence.get_fault_by_id(failure_id)
+        if context is None:
+            raise NotFoundError(f"Failure {failure_id} not found")
+
+        plan = self._requeue_goal_plan(context)
+        if dry_run:
+            return {
+                "dry_run": True,
+                "failure_id": failure_id,
+                **plan,
+            }
+        if not plan["allowed"]:
+            raise ConflictError("; ".join(plan["blockers"]))
+
+        with self.db.transaction() as tx:
+            current = self.failure_intelligence.get_fault_by_id(failure_id, tx=tx)
+            if current is None:
+                raise NotFoundError(f"Failure {failure_id} not found")
+            plan = self._requeue_goal_plan(current)
+            if not plan["allowed"]:
+                raise ConflictError("; ".join(plan["blockers"]))
+
+            correlation_id = self._remediation_correlation_id(current)
+            goal = self.state_manager.transition_goal(
+                current["goal_id"],
+                to_state="active",
+                owner="state_manager",
+                event_type="goal.remediation_requeued",
+                correlation_id=correlation_id,
+                reason=reason,
+                payload={
+                    "failure_id": failure_id,
+                    "failure_type": current["failure_type"],
+                    "error_hash": current["error_hash"],
+                    "reason": reason,
+                },
+                tx=tx,
+            )
+            self.failure_intelligence.update_failure_status(
+                tx,
+                failure_id=failure_id,
+                expected_version=int(current["failure_version"]),
+                status="goal_requeued",
+            )
+            self._metric("faults.remediation.goal_requeued", tx=tx)
+            if self.observability is not None:
+                self.observability.record_audit(
+                    action="fault.remediation.requeue_goal",
+                    actor="supervisor",
+                    status="success",
+                    entity_type="failure",
+                    entity_id=failure_id,
+                    correlation_id=correlation_id,
+                    details={
+                        "goal_id": current["goal_id"],
+                        "source_task_id": current["task_id"],
+                        "reason": reason,
+                    },
+                    tx=tx,
+                )
+
+        return {
+            "dry_run": False,
+            "failure_id": failure_id,
+            "goal": goal,
+        }
+
+    def _retry_plan(self, fault: dict[str, Any]) -> dict[str, Any]:
+        blockers: list[str] = []
+        task_status = fault.get("task_status")
+        goal_state = fault.get("goal_state")
+        failure_status = fault.get("failure_status")
+
+        if task_status not in {"failed", "exhausted", "poison"}:
+            blockers.append(
+                f"Task {fault.get('task_id')} has status '{task_status}' and cannot be retried."
+            )
+        if goal_state not in {"active", "blocked", "escalation_pending"}:
+            blockers.append(
+                f"Goal {fault.get('goal_id')} is '{goal_state}' and cannot receive remediated retries."
+            )
+        if failure_status == "retry_queued":
+            blockers.append(f"Failure {fault.get('failure_id')} already has a queued retry task.")
+
+        return {
+            "allowed": len(blockers) == 0,
+            "blockers": blockers,
+            "will_requeue_goal": goal_state in {"blocked", "escalation_pending"},
+            "create_retry_task": True,
+            "task_status": task_status,
+            "goal_state": goal_state,
+            "failure_status": failure_status,
+        }
+
+    def _requeue_goal_plan(self, fault: dict[str, Any]) -> dict[str, Any]:
+        blockers: list[str] = []
+        goal_state = fault.get("goal_state")
+        if goal_state not in {"blocked", "escalation_pending"}:
+            blockers.append(
+                f"Goal {fault.get('goal_id')} is '{goal_state}' and cannot be requeued to active."
+            )
+        return {
+            "allowed": len(blockers) == 0,
+            "blockers": blockers,
+            "goal_state": goal_state,
+            "will_requeue_goal": True,
+        }
+
+    def _remediation_correlation_id(self, fault: dict[str, Any]) -> str:
+        goal_id = fault.get("goal_id")
+        task_id = fault.get("task_id")
+        retry_count = fault.get("retry_count")
+        correlation_id = fault.get("correlation_id") or fault.get("task_correlation_id")
+        if isinstance(correlation_id, str) and correlation_id.startswith(f"{goal_id}:"):
+            return correlation_id
+        if goal_id and task_id is not None and retry_count is not None:
+            return f"{goal_id}:{task_id}:{retry_count}"
+        return str(goal_id or "")
+
     def _get_task_state(self, tx: Transaction, task_id: str) -> dict[str, Any]:
         row = tx.fetch_one("SELECT * FROM task_state WHERE task_id = ?", task_id)
         if row is None:

--- a/goal_ops_console/failure_intelligence.py
+++ b/goal_ops_console/failure_intelligence.py
@@ -6,6 +6,7 @@ from goal_ops_console.config import (
     SYSTEMIC_FAILURE_WINDOW_SECONDS,
 )
 from goal_ops_console.database import Database, Transaction, new_id, now_utc
+from goal_ops_console.models import OptimisticLockError
 
 
 def compute_error_hash(error_type: str, error_message: str) -> str:
@@ -93,6 +94,59 @@ class FailureIntelligence:
         if retry_count < max_retries:
             return False
         return self.count_errors_in_window(error_hash, tx=tx) >= 2
+
+    def get_fault_by_id(
+        self,
+        failure_id: str,
+        *,
+        tx: Transaction | None = None,
+    ) -> dict | None:
+        runner = tx or self.db
+        row = runner.fetch_one(
+            """SELECT fl.id AS failure_id,
+                      fl.version AS failure_version,
+                      fl.created_at,
+                      fl.failure_type,
+                      fl.fingerprint AS error_hash,
+                      fl.retry_count,
+                      fl.last_error,
+                      fl.status AS failure_status,
+                      fl.task_id,
+                      t.title AS task_title,
+                      ts.status AS task_status,
+                      ts.correlation_id AS task_correlation_id,
+                      fl.goal_id,
+                      g.title AS goal_title,
+                      g.state AS goal_state,
+                      fl.correlation_id
+               FROM failure_log fl
+               LEFT JOIN task_state ts ON ts.task_id = fl.task_id
+               LEFT JOIN tasks t ON t.task_id = fl.task_id
+               LEFT JOIN goals g ON g.goal_id = fl.goal_id
+               WHERE fl.id = ?""",
+            failure_id,
+        )
+        return dict(row) if row else None
+
+    def update_failure_status(
+        self,
+        tx: Transaction,
+        *,
+        failure_id: str,
+        expected_version: int,
+        status: str,
+    ) -> None:
+        updated = tx.execute(
+            """UPDATE failure_log
+               SET status = ?, updated_at = ?, version = version + 1
+               WHERE id = ? AND version = ?""",
+            status,
+            now_utc(),
+            failure_id,
+            expected_version,
+        )
+        if updated == 0:
+            raise OptimisticLockError(f"Failure {failure_id} version conflict")
 
     def list_faults(
         self,

--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -80,6 +80,11 @@ class TaskFailureRequest(BaseModel):
     error_message: str = Field(default="Simulated failure", min_length=1, max_length=500)
 
 
+class FaultRemediationRequest(BaseModel):
+    reason: str = Field(min_length=3, max_length=500)
+    dry_run: bool = False
+
+
 class EventResponse(BaseModel):
     seq: int
     event_id: str

--- a/goal_ops_console/routers/system.py
+++ b/goal_ops_console/routers/system.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
 
 from goal_ops_console.config import CONSUMER_BATCH_SIZE, MAX_TOTAL_RETRIES_PER_CYCLE, SPEC_VERSION
-from goal_ops_console.models import BackpressureError
+from goal_ops_console.models import BackpressureError, FaultRemediationRequest
 from goal_ops_console.services import AppServices, get_services
 
 router = APIRouter(tags=["system"])
@@ -199,6 +199,32 @@ def fault_summary(
         services.failure_intelligence.systemic_external_failure_count()
     )
     return summary
+
+
+@router.post("/system/faults/{failure_id}/retry")
+def retry_fault(
+    failure_id: str,
+    request: FaultRemediationRequest,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return services.execution_layer.retry_fault(
+        failure_id=failure_id,
+        reason=request.reason,
+        dry_run=request.dry_run,
+    )
+
+
+@router.post("/system/faults/{failure_id}/requeue_goal")
+def requeue_fault_goal(
+    failure_id: str,
+    request: FaultRemediationRequest,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return services.execution_layer.requeue_goal_from_fault(
+        failure_id=failure_id,
+        reason=request.reason,
+        dry_run=request.dry_run,
+    )
 
 
 @router.post("/system/maintenance/retention")

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -257,6 +257,7 @@ function renderFaults(summary, entries) {
         <th>Goal</th>
         <th>Correlation</th>
         <th>Error</th>
+        <th>Remediation</th>
       </tr>
     </thead>
     <tbody>
@@ -282,9 +283,28 @@ function renderFaults(summary, entries) {
             <div>${item.error_hash || "-"}</div>
             <div class="meta">${item.last_error || ""}</div>
           </td>
+          <td>${renderFaultRemediationButtons(item)}</td>
         </tr>`).join("")}
     </tbody>
   </table></div>`;
+}
+
+function renderFaultRemediationButtons(item) {
+  const buttons = [];
+  if (["failed", "exhausted", "poison"].includes(item.task_status)) {
+    buttons.push(
+      `<button class="secondary" data-fault-action="retry" data-failure-id="${item.failure_id}">Retry Task</button>`,
+    );
+  }
+  if (["blocked", "escalation_pending"].includes(item.goal_state)) {
+    buttons.push(
+      `<button class="secondary" data-fault-action="requeue_goal" data-failure-id="${item.failure_id}">Requeue Goal</button>`,
+    );
+  }
+  if (!buttons.length) {
+    return `<div class="meta">No remediation needed</div>`;
+  }
+  return `<div class="actions">${buttons.join("")}</div>`;
 }
 
 function renderFlowTrace(trace) {
@@ -538,6 +558,41 @@ async function runOperatorAction(action) {
   await refreshAll();
 }
 
+async function runFaultAction(action, failureId) {
+  const reasonInput = document.getElementById("fault-remediation-reason");
+  const dryRunInput = document.getElementById("fault-remediation-dry-run");
+  const reason = (reasonInput?.value || "").trim();
+  const dryRun = Boolean(dryRunInput?.checked);
+  if (!reason) {
+    throw new Error("Remediation reason is required.");
+  }
+
+  const actionPath = action === "retry" ? "retry" : "requeue_goal";
+  const payload = await api(`/system/faults/${encodeURIComponent(failureId)}/${actionPath}`, {
+    method: "POST",
+    body: JSON.stringify({ reason, dry_run: dryRun }),
+  });
+
+  const feedback = document.getElementById("system-feedback");
+  if (dryRun) {
+    const blockers = payload.blockers?.length ? ` Blockers: ${payload.blockers.join(" | ")}` : "";
+    feedback.textContent = payload.allowed
+      ? `Dry run passed for ${actionPath} on failure ${failureId}.`
+      : `Dry run blocked for ${actionPath} on failure ${failureId}.${blockers}`;
+    await Promise.all([refreshFaults(), refreshHealth()]);
+    return;
+  }
+
+  if (action === "retry") {
+    feedback.textContent = (
+      `Retry task ${payload.retry_task.task_id} queued for source task ${payload.source_task_id}.`
+    );
+  } else {
+    feedback.textContent = `Goal ${payload.goal.goal_id} requeued to state ${payload.goal.state}.`;
+  }
+  await refreshAll();
+}
+
 document.getElementById("goal-form").addEventListener("submit", async (event) => {
   event.preventDefault();
   showError("goal-error", null);
@@ -621,6 +676,8 @@ document.addEventListener("click", async (event) => {
   const goalId = event.target.dataset.goalId;
   const taskAction = event.target.dataset.taskAction;
   const taskId = event.target.dataset.taskId;
+  const faultAction = event.target.dataset.faultAction;
+  const failureId = event.target.dataset.failureId;
   const correlation = event.target.dataset.correlation;
   const selectGoal = event.target.dataset.selectGoal;
   const operatorAction = event.target.dataset.operatorAction;
@@ -628,6 +685,10 @@ document.addEventListener("click", async (event) => {
   try {
     if (operatorAction) {
       await runOperatorAction(operatorAction);
+    }
+
+    if (faultAction && failureId) {
+      await runFaultAction(faultAction, failureId);
     }
 
     if (goalAction && goalId) {
@@ -679,7 +740,7 @@ document.addEventListener("click", async (event) => {
       document.getElementById("selected-goal-label").textContent = `Selected goal: ${selectGoal}`;
     }
   } catch (error) {
-    const target = operatorAction ? "system-feedback" : goalAction ? "goal-error" : "task-error";
+    const target = operatorAction || faultAction ? "system-feedback" : goalAction ? "goal-error" : "task-error";
     showError(target, error);
   }
 });

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -371,6 +371,10 @@
           <input id="fault-goal-id" placeholder="Optional goal id">
           <input id="fault-error-hash" placeholder="Optional error hash">
         </div>
+        <div class="split">
+          <input id="fault-remediation-reason" value="Supervisor remediation from dashboard" placeholder="Remediation reason (required)">
+          <label class="meta"><input type="checkbox" id="fault-remediation-dry-run"> Dry run only (no writes)</label>
+        </div>
         <label class="meta"><input type="checkbox" id="fault-dead-letter-only" checked> Dead-letter only (`poison` + `exhausted`)</label>
         <button type="submit">Apply Filter</button>
       </form>

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -705,3 +705,122 @@ def test_39_health_and_fault_summary_include_fault_snapshot(client):
     assert "systemic_external_failures_last_window" in summary_payload
     assert "faults" in health_payload
     assert health_payload["faults"]["dead_letter_tasks"] >= 1
+
+
+def test_40_fault_retry_endpoint_creates_pending_retry_task_and_requeues_goal(client):
+    goal = create_active_goal(client, title="Retry Goal")
+    task = create_task(client, goal["goal_id"], title="Retry Source Task")
+
+    for idx in range(3):
+        client.post(
+            f"/tasks/{task['task_id']}/fail",
+            json={"failure_type": "ExecutionFailure", "error_message": f"Execution issue {idx}"},
+        )
+
+    source_task = client.get(f"/tasks/{task['task_id']}").json()
+    goal_before = client.get(f"/goals/{goal['goal_id']}").json()
+    faults = client.get("/system/faults?dead_letter_only=true").json()["entries"]
+    failure_id = next(item["failure_id"] for item in faults if item["task_id"] == task["task_id"])
+
+    response = client.post(
+        f"/system/faults/{failure_id}/retry",
+        json={"reason": "Manual remediation after dependency fix", "dry_run": False},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert source_task["status"] == "exhausted"
+    assert goal_before["state"] == "blocked"
+    assert payload["goal_requeued"] is True
+    assert payload["source_task_id"] == task["task_id"]
+    assert payload["retry_task"]["status"] == "pending"
+    assert payload["retry_task"]["task_id"] != task["task_id"]
+
+    goal_after = client.get(f"/goals/{goal['goal_id']}").json()
+    assert goal_after["state"] == "active"
+
+    failure_row = client.app.state.services.db.fetch_one(
+        "SELECT status FROM failure_log WHERE id = ?",
+        failure_id,
+    )
+    assert failure_row["status"] == "retry_queued"
+
+
+def test_41_fault_retry_dry_run_keeps_state_unchanged(client):
+    goal = create_active_goal(client, title="Dry run goal")
+    task = create_task(client, goal["goal_id"], title="Dry run task")
+    client.post(
+        f"/tasks/{task['task_id']}/fail",
+        json={"failure_type": "SkillFailure", "error_message": "persistent skill issue"},
+    )
+    client.post(
+        f"/tasks/{task['task_id']}/fail",
+        json={"failure_type": "SkillFailure", "error_message": "persistent skill issue"},
+    )
+
+    services = client.app.state.services
+    task_count_before = services.db.fetch_scalar("SELECT COUNT(*) FROM task_state")
+    fault = client.get("/system/faults?dead_letter_only=true").json()["entries"][0]
+    failure_id = fault["failure_id"]
+
+    response = client.post(
+        f"/system/faults/{failure_id}/retry",
+        json={"reason": "Preview remediation only", "dry_run": True},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["dry_run"] is True
+    assert payload["allowed"] is True
+    assert payload["will_requeue_goal"] is True
+
+    task_count_after = services.db.fetch_scalar("SELECT COUNT(*) FROM task_state")
+    failure_status = services.db.fetch_scalar("SELECT status FROM failure_log WHERE id = ?", failure_id)
+    assert task_count_after == task_count_before
+    assert failure_status == "recorded"
+
+
+def test_42_fault_requeue_goal_endpoint_reactivates_escalation_pending_goal(client):
+    goal = create_active_goal(client, title="Requeue Goal")
+    task = create_task(client, goal["goal_id"], title="Requeue Task")
+    client.post(
+        f"/tasks/{task['task_id']}/fail",
+        json={"failure_type": "SkillFailure", "error_message": "requeue me"},
+    )
+    client.post(
+        f"/tasks/{task['task_id']}/fail",
+        json={"failure_type": "SkillFailure", "error_message": "requeue me"},
+    )
+
+    fault = client.get("/system/faults?dead_letter_only=true").json()["entries"][0]
+    failure_id = fault["failure_id"]
+
+    response = client.post(
+        f"/system/faults/{failure_id}/requeue_goal",
+        json={"reason": "Supervisor approved unblock", "dry_run": False},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["goal"]["state"] == "active"
+
+    failure_status = client.app.state.services.db.fetch_scalar(
+        "SELECT status FROM failure_log WHERE id = ?",
+        failure_id,
+    )
+    assert failure_status == "goal_requeued"
+
+
+def test_43_fault_requeue_goal_rejects_when_goal_is_not_blocked_or_escalated(client):
+    goal = create_active_goal(client, title="Active Goal")
+    task = create_task(client, goal["goal_id"], title="Active Task")
+    client.post(
+        f"/tasks/{task['task_id']}/fail",
+        json={"failure_type": "SkillFailure", "error_message": "single failure"},
+    )
+    fault = client.get("/system/faults?dead_letter_only=false").json()["entries"][0]
+
+    response = client.post(
+        f"/system/faults/{fault['failure_id']}/requeue_goal",
+        json={"reason": "Should not be needed", "dry_run": False},
+    )
+    assert response.status_code == 409
+    assert "cannot be requeued" in response.json()["detail"]


### PR DESCRIPTION
## Summary
- add supervised fault remediation request model with reason + optional dry_run
- add retry and goal requeue remediation endpoints for Fault Explorer
- keep transition integrity by creating a new pending retry task instead of mutating terminal task state
- wire remediation controls into the dashboard (reason, dry run, row actions)
- extend test coverage for remediation flow and guardrails

## Validation
- python -m pytest -q
- 43 passed