### PR TITLE
[codex] Add fault resolution lifecycle and status filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ The dashboard now includes an `Operator Controls` section for supervised Phase 2
   Includes supervised remediation actions:
   - `Retry Task` creates a new pending retry task for a dead-letter failure.
   - `Requeue Goal` transitions `blocked` / `escalation_pending` goals back to `active`.
+  - `Resolve` marks a failure as operator-resolved without changing task/goal state.
   - `Dry run` previews remediation without writing state.
+  Supports filtering by `failure_status` (`recorded`, `retry_queued`, `goal_requeued`, `resolved`) in addition to existing filters.
 - `Audit Log` (new section)
   Shows recent mutating API operations with status and request details.
 - `Metrics Hooks` (in System Health)
@@ -183,6 +185,7 @@ Observability endpoints:
 - `GET /system/faults/summary`
 - `POST /system/faults/{failure_id}/retry`
 - `POST /system/faults/{failure_id}/requeue_goal`
+- `POST /system/faults/{failure_id}/resolve`
 - `GET /events/trace/{goal_id}`
 
 ## Run The Test Suite

--- a/goal_ops_console/execution_layer.py
+++ b/goal_ops_console/execution_layer.py
@@ -506,6 +506,84 @@ class ExecutionLayer:
             "goal": goal,
         }
 
+    def resolve_fault(
+        self,
+        *,
+        failure_id: str,
+        reason: str,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        context = self.failure_intelligence.get_fault_by_id(failure_id)
+        if context is None:
+            raise NotFoundError(f"Failure {failure_id} not found")
+
+        plan = self._resolve_plan(context)
+        if dry_run:
+            return {
+                "dry_run": True,
+                "failure_id": failure_id,
+                **plan,
+            }
+        if not plan["allowed"]:
+            raise ConflictError("; ".join(plan["blockers"]))
+
+        with self.db.transaction() as tx:
+            current = self.failure_intelligence.get_fault_by_id(failure_id, tx=tx)
+            if current is None:
+                raise NotFoundError(f"Failure {failure_id} not found")
+
+            plan = self._resolve_plan(current)
+            if not plan["allowed"]:
+                raise ConflictError("; ".join(plan["blockers"]))
+
+            previous_status = str(current.get("failure_status") or "")
+            correlation_id = self._remediation_correlation_id(current)
+            self.failure_intelligence.update_failure_status(
+                tx,
+                failure_id=failure_id,
+                expected_version=int(current["failure_version"]),
+                status="resolved",
+            )
+            self.event_bus.record_event(
+                "fault.resolved",
+                failure_id,
+                correlation_id,
+                {
+                    "failure_id": failure_id,
+                    "goal_id": current.get("goal_id"),
+                    "task_id": current.get("task_id"),
+                    "previous_status": previous_status,
+                    "reason": reason,
+                },
+                tx=tx,
+            )
+            self._metric("faults.remediation.resolved", tx=tx)
+            if self.observability is not None:
+                self.observability.record_audit(
+                    action="fault.remediation.resolve",
+                    actor="supervisor",
+                    status="success",
+                    entity_type="failure",
+                    entity_id=failure_id,
+                    correlation_id=correlation_id,
+                    details={
+                        "goal_id": current.get("goal_id"),
+                        "source_task_id": current.get("task_id"),
+                        "previous_status": previous_status,
+                        "reason": reason,
+                    },
+                    tx=tx,
+                )
+
+        return {
+            "dry_run": False,
+            "failure_id": failure_id,
+            "status": "resolved",
+            "previous_status": context.get("failure_status"),
+            "goal_id": context.get("goal_id"),
+            "task_id": context.get("task_id"),
+        }
+
     def _retry_plan(self, fault: dict[str, Any]) -> dict[str, Any]:
         blockers: list[str] = []
         task_status = fault.get("task_status")
@@ -545,6 +623,20 @@ class ExecutionLayer:
             "blockers": blockers,
             "goal_state": goal_state,
             "will_requeue_goal": True,
+        }
+
+    def _resolve_plan(self, fault: dict[str, Any]) -> dict[str, Any]:
+        blockers: list[str] = []
+        failure_status = fault.get("failure_status")
+        if failure_status == "resolved":
+            blockers.append(
+                f"Failure {fault.get('failure_id')} is already resolved."
+            )
+        return {
+            "allowed": len(blockers) == 0,
+            "blockers": blockers,
+            "failure_status": failure_status,
+            "target_status": "resolved",
         }
 
     def _remediation_correlation_id(self, fault: dict[str, Any]) -> str:

--- a/goal_ops_console/failure_intelligence.py
+++ b/goal_ops_console/failure_intelligence.py
@@ -153,6 +153,7 @@ class FailureIntelligence:
         *,
         limit: int = 200,
         failure_type: str | None = None,
+        failure_status: str | None = None,
         task_status: str | None = None,
         goal_id: str | None = None,
         error_hash: str | None = None,
@@ -160,6 +161,7 @@ class FailureIntelligence:
     ) -> list[dict]:
         clauses, params = self._fault_filters(
             failure_type=failure_type,
+            failure_status=failure_status,
             task_status=task_status,
             goal_id=goal_id,
             error_hash=error_hash,
@@ -198,6 +200,7 @@ class FailureIntelligence:
         *,
         limit: int = 20,
         failure_type: str | None = None,
+        failure_status: str | None = None,
         task_status: str | None = None,
         goal_id: str | None = None,
         error_hash: str | None = None,
@@ -205,6 +208,7 @@ class FailureIntelligence:
     ) -> dict:
         clauses, params = self._fault_filters(
             failure_type=failure_type,
+            failure_status=failure_status,
             task_status=task_status,
             goal_id=goal_id,
             error_hash=error_hash,
@@ -251,6 +255,7 @@ class FailureIntelligence:
         self,
         *,
         failure_type: str | None,
+        failure_status: str | None,
         task_status: str | None,
         goal_id: str | None,
         error_hash: str | None,
@@ -261,6 +266,9 @@ class FailureIntelligence:
         if failure_type:
             clauses.append("fl.failure_type = ?")
             params.append(failure_type)
+        if failure_status:
+            clauses.append("fl.status = ?")
+            params.append(failure_status)
         if task_status:
             clauses.append("ts.status = ?")
             params.append(task_status)

--- a/goal_ops_console/routers/system.py
+++ b/goal_ops_console/routers/system.py
@@ -159,6 +159,7 @@ def audit_log(
 def fault_explorer(
     limit: int = 200,
     failure_type: str | None = None,
+    failure_status: str | None = None,
     task_status: str | None = None,
     goal_id: str | None = None,
     error_hash: str | None = None,
@@ -169,6 +170,7 @@ def fault_explorer(
         "entries": services.failure_intelligence.list_faults(
             limit=limit,
             failure_type=failure_type,
+            failure_status=failure_status,
             task_status=task_status,
             goal_id=goal_id,
             error_hash=error_hash,
@@ -181,6 +183,7 @@ def fault_explorer(
 def fault_summary(
     limit: int = 20,
     failure_type: str | None = None,
+    failure_status: str | None = None,
     task_status: str | None = None,
     goal_id: str | None = None,
     error_hash: str | None = None,
@@ -190,6 +193,7 @@ def fault_summary(
     summary = services.failure_intelligence.fault_summary(
         limit=limit,
         failure_type=failure_type,
+        failure_status=failure_status,
         task_status=task_status,
         goal_id=goal_id,
         error_hash=error_hash,
@@ -221,6 +225,19 @@ def requeue_fault_goal(
     services: AppServices = Depends(get_services),
 ) -> dict:
     return services.execution_layer.requeue_goal_from_fault(
+        failure_id=failure_id,
+        reason=request.reason,
+        dry_run=request.dry_run,
+    )
+
+
+@router.post("/system/faults/{failure_id}/resolve")
+def resolve_fault(
+    failure_id: str,
+    request: FaultRemediationRequest,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return services.execution_layer.resolve_fault(
         failure_id=failure_id,
         reason=request.reason,
         dry_run=request.dry_run,

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -301,6 +301,11 @@ function renderFaultRemediationButtons(item) {
       `<button class="secondary" data-fault-action="requeue_goal" data-failure-id="${item.failure_id}">Requeue Goal</button>`,
     );
   }
+  if (item.failure_status !== "resolved") {
+    buttons.push(
+      `<button class="secondary" data-fault-action="resolve" data-failure-id="${item.failure_id}">Resolve</button>`,
+    );
+  }
   if (!buttons.length) {
     return `<div class="meta">No remediation needed</div>`;
   }
@@ -478,12 +483,14 @@ async function refreshAudit() {
 
 async function refreshFaults() {
   const failureType = document.getElementById("fault-failure-type").value.trim();
+  const failureStatus = document.getElementById("fault-failure-status").value.trim();
   const taskStatus = document.getElementById("fault-task-status").value.trim();
   const goalId = document.getElementById("fault-goal-id").value.trim();
   const errorHash = document.getElementById("fault-error-hash").value.trim();
   const deadLetterOnly = document.getElementById("fault-dead-letter-only").checked;
   const params = new URLSearchParams();
   if (failureType) params.set("failure_type", failureType);
+  if (failureStatus) params.set("failure_status", failureStatus);
   if (taskStatus) params.set("task_status", taskStatus);
   if (goalId) params.set("goal_id", goalId);
   if (errorHash) params.set("error_hash", errorHash);
@@ -567,7 +574,15 @@ async function runFaultAction(action, failureId) {
     throw new Error("Remediation reason is required.");
   }
 
-  const actionPath = action === "retry" ? "retry" : "requeue_goal";
+  const actionMap = {
+    retry: "retry",
+    requeue_goal: "requeue_goal",
+    resolve: "resolve",
+  };
+  const actionPath = actionMap[action];
+  if (!actionPath) {
+    throw new Error(`Unsupported fault action: ${action}`);
+  }
   const payload = await api(`/system/faults/${encodeURIComponent(failureId)}/${actionPath}`, {
     method: "POST",
     body: JSON.stringify({ reason, dry_run: dryRun }),
@@ -587,6 +602,8 @@ async function runFaultAction(action, failureId) {
     feedback.textContent = (
       `Retry task ${payload.retry_task.task_id} queued for source task ${payload.source_task_id}.`
     );
+  } else if (action === "resolve") {
+    feedback.textContent = `Failure ${payload.failure_id} marked as resolved.`;
   } else {
     feedback.textContent = `Goal ${payload.goal.goal_id} requeued to state ${payload.goal.state}.`;
   }

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -357,6 +357,15 @@
             <option value="ExternalFailure">ExternalFailure</option>
             <option value="PlanFailure">PlanFailure</option>
           </select>
+          <select id="fault-failure-status">
+            <option value="">All failure statuses</option>
+            <option value="recorded">recorded</option>
+            <option value="retry_queued">retry_queued</option>
+            <option value="goal_requeued">goal_requeued</option>
+            <option value="resolved">resolved</option>
+          </select>
+        </div>
+        <div class="split">
           <select id="fault-task-status">
             <option value="">All task statuses</option>
             <option value="pending">pending</option>
@@ -366,13 +375,13 @@
             <option value="exhausted">exhausted</option>
             <option value="poison">poison</option>
           </select>
-        </div>
-        <div class="split">
           <input id="fault-goal-id" placeholder="Optional goal id">
-          <input id="fault-error-hash" placeholder="Optional error hash">
         </div>
         <div class="split">
+          <input id="fault-error-hash" placeholder="Optional error hash">
           <input id="fault-remediation-reason" value="Supervisor remediation from dashboard" placeholder="Remediation reason (required)">
+        </div>
+        <div class="split">
           <label class="meta"><input type="checkbox" id="fault-remediation-dry-run"> Dry run only (no writes)</label>
         </div>
         <label class="meta"><input type="checkbox" id="fault-dead-letter-only" checked> Dead-letter only (`poison` + `exhausted`)</label>

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -824,3 +824,87 @@ def test_43_fault_requeue_goal_rejects_when_goal_is_not_blocked_or_escalated(cli
     )
     assert response.status_code == 409
     assert "cannot be requeued" in response.json()["detail"]
+
+
+def test_44_fault_resolve_endpoint_marks_failure_resolved_and_records_audit(client):
+    goal = create_active_goal(client, title="Resolve Goal")
+    task = create_task(client, goal["goal_id"], title="Resolve Task")
+    client.post(
+        f"/tasks/{task['task_id']}/fail",
+        json={"failure_type": "SkillFailure", "error_message": "resolve me"},
+    )
+    client.post(
+        f"/tasks/{task['task_id']}/fail",
+        json={"failure_type": "SkillFailure", "error_message": "resolve me"},
+    )
+
+    fault = client.get("/system/faults?dead_letter_only=true").json()["entries"][0]
+    failure_id = fault["failure_id"]
+
+    response = client.post(
+        f"/system/faults/{failure_id}/resolve",
+        json={"reason": "Supervisor accepted residual risk", "dry_run": False},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "resolved"
+    assert payload["failure_id"] == failure_id
+
+    status = client.app.state.services.db.fetch_scalar(
+        "SELECT status FROM failure_log WHERE id = ?",
+        failure_id,
+    )
+    assert status == "resolved"
+
+    metrics = client.get("/system/metrics?prefix=faults.remediation").json()["metrics"]
+    metric_map = {item["metric_name"]: item["value"] for item in metrics}
+    assert metric_map["faults.remediation.resolved"] >= 1
+
+    audit_entries = client.get("/system/audit?action=fault.remediation.resolve").json()["entries"]
+    assert any(item["entity_id"] == failure_id and item["status"] == "success" for item in audit_entries)
+
+    resolved_faults = client.get("/system/faults?failure_status=resolved&dead_letter_only=false").json()["entries"]
+    assert any(item["failure_id"] == failure_id for item in resolved_faults)
+
+
+def test_45_fault_resolve_dry_run_and_conflict_when_already_resolved(client):
+    goal = create_active_goal(client, title="Resolve Dry Run Goal")
+    task = create_task(client, goal["goal_id"], title="Resolve Dry Run Task")
+    client.post(
+        f"/tasks/{task['task_id']}/fail",
+        json={"failure_type": "ExecutionFailure", "error_message": "resolve dry run"},
+    )
+    client.post(
+        f"/tasks/{task['task_id']}/fail",
+        json={"failure_type": "ExecutionFailure", "error_message": "resolve dry run 2"},
+    )
+    client.post(
+        f"/tasks/{task['task_id']}/fail",
+        json={"failure_type": "ExecutionFailure", "error_message": "resolve dry run 3"},
+    )
+
+    fault = client.get("/system/faults?dead_letter_only=true").json()["entries"][0]
+    failure_id = fault["failure_id"]
+
+    dry_run = client.post(
+        f"/system/faults/{failure_id}/resolve",
+        json={"reason": "Preview close action", "dry_run": True},
+    )
+    assert dry_run.status_code == 200
+    dry_payload = dry_run.json()
+    assert dry_payload["dry_run"] is True
+    assert dry_payload["allowed"] is True
+    assert dry_payload["target_status"] == "resolved"
+
+    apply_response = client.post(
+        f"/system/faults/{failure_id}/resolve",
+        json={"reason": "Apply close action", "dry_run": False},
+    )
+    assert apply_response.status_code == 200
+
+    conflict = client.post(
+        f"/system/faults/{failure_id}/resolve",
+        json={"reason": "Second close attempt", "dry_run": False},
+    )
+    assert conflict.status_code == 409
+    assert "already resolved" in conflict.json()["detail"]


### PR DESCRIPTION
## Summary
- add supervised `resolve` remediation endpoint for failures: `POST /system/faults/{failure_id}/resolve`
- implement dry-run planning and conflict guard for already resolved failures
- emit `fault.resolved` event plus observability hooks (`faults.remediation.resolved`) and audit entries
- extend fault explorer filters to include `failure_status`
- add dashboard support for `Resolve` action and status filter options
- document the new workflow and endpoint in README

## Why
The dead-letter workflow supported retry/requeue, but operators still needed a way to intentionally close a failure case without changing task or goal state. This adds an explicit lifecycle step for supervised closure and better tracking of open vs resolved failure records.

## Impact
- operators can close a failure as resolved from API or dashboard
- fault explorer can separate unresolved and resolved failures by status
- remediation actions are now more complete and auditable end-to-end

## Validation
- `./scripts/run-tests.ps1`
- `45 passed in 1.57s`
