### PR TITLE
[codex] Add bulk fault resolution workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ The dashboard now includes an `Operator Controls` section for supervised Phase 2
   - `Retry Task` creates a new pending retry task for a dead-letter failure.
   - `Requeue Goal` transitions `blocked` / `escalation_pending` goals back to `active`.
   - `Resolve` marks a failure as operator-resolved without changing task/goal state.
+  - `Resolve Filtered` applies `Resolve` to all currently filtered fault rows (bounded by a limit).
   - `Dry run` previews remediation without writing state.
   Supports filtering by `failure_status` (`recorded`, `retry_queued`, `goal_requeued`, `resolved`) in addition to existing filters.
 - `Audit Log` (new section)
@@ -183,6 +184,7 @@ Observability endpoints:
 - `GET /system/audit`
 - `GET /system/faults`
 - `GET /system/faults/summary`
+- `POST /system/faults/resolve_bulk`
 - `POST /system/faults/{failure_id}/retry`
 - `POST /system/faults/{failure_id}/requeue_goal`
 - `POST /system/faults/{failure_id}/resolve`

--- a/goal_ops_console/execution_layer.py
+++ b/goal_ops_console/execution_layer.py
@@ -584,6 +584,93 @@ class ExecutionLayer:
             "task_id": context.get("task_id"),
         }
 
+    def resolve_faults_bulk(
+        self,
+        *,
+        reason: str,
+        dry_run: bool = False,
+        failure_type: str | None = None,
+        failure_status: str | None = None,
+        task_status: str | None = None,
+        goal_id: str | None = None,
+        error_hash: str | None = None,
+        dead_letter_only: bool = True,
+        limit: int = 50,
+    ) -> dict[str, Any]:
+        matched_faults = self.failure_intelligence.list_faults(
+            limit=limit,
+            failure_type=failure_type,
+            failure_status=failure_status,
+            task_status=task_status,
+            goal_id=goal_id,
+            error_hash=error_hash,
+            dead_letter_only=dead_letter_only,
+        )
+        unresolved = [item for item in matched_faults if item.get("failure_status") != "resolved"]
+        skipped_resolved = [item for item in matched_faults if item.get("failure_status") == "resolved"]
+        unresolved_ids = [str(item["failure_id"]) for item in unresolved]
+        skipped_ids = [str(item["failure_id"]) for item in skipped_resolved]
+        filters = {
+            "failure_type": failure_type,
+            "failure_status": failure_status,
+            "task_status": task_status,
+            "goal_id": goal_id,
+            "error_hash": error_hash,
+            "dead_letter_only": dead_letter_only,
+            "limit": limit,
+        }
+
+        if dry_run:
+            return {
+                "dry_run": True,
+                "allowed": len(unresolved_ids) > 0,
+                "reason": reason,
+                "matched_count": len(matched_faults),
+                "will_resolve_count": len(unresolved_ids),
+                "candidate_failure_ids": unresolved_ids,
+                "skipped_already_resolved_count": len(skipped_ids),
+                "skipped_failure_ids": skipped_ids,
+                "filters": filters,
+            }
+
+        resolved_ids: list[str] = []
+        for failure_id in unresolved_ids:
+            self.resolve_fault(
+                failure_id=failure_id,
+                reason=reason,
+                dry_run=False,
+            )
+            resolved_ids.append(failure_id)
+
+        self._metric("faults.remediation.bulk_resolved", delta=len(resolved_ids))
+        if self.observability is not None:
+            self.observability.record_audit(
+                action="fault.remediation.resolve_bulk",
+                actor="supervisor",
+                status="success",
+                entity_type="failure_batch",
+                entity_id=None,
+                correlation_id=None,
+                details={
+                    "resolved_count": len(resolved_ids),
+                    "matched_count": len(matched_faults),
+                    "skipped_already_resolved_count": len(skipped_ids),
+                    "reason": reason,
+                    "filters": filters,
+                },
+            )
+
+        return {
+            "dry_run": False,
+            "reason": reason,
+            "matched_count": len(matched_faults),
+            "resolved_count": len(resolved_ids),
+            "resolved_failure_ids": resolved_ids,
+            "skipped_already_resolved_count": len(skipped_ids),
+            "skipped_failure_ids": skipped_ids,
+            "filters": filters,
+        }
+
     def _retry_plan(self, fault: dict[str, Any]) -> dict[str, Any]:
         blockers: list[str] = []
         task_status = fault.get("task_status")

--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -85,6 +85,18 @@ class FaultRemediationRequest(BaseModel):
     dry_run: bool = False
 
 
+class FaultBulkResolveRequest(BaseModel):
+    reason: str = Field(min_length=3, max_length=500)
+    dry_run: bool = False
+    failure_type: FailureType | None = None
+    failure_status: str | None = Field(default=None, max_length=64)
+    task_status: TaskState | None = None
+    goal_id: str | None = Field(default=None, max_length=200)
+    error_hash: str | None = Field(default=None, max_length=128)
+    dead_letter_only: bool = True
+    limit: int = Field(default=50, ge=1, le=500)
+
+
 class EventResponse(BaseModel):
     seq: int
     event_id: str

--- a/goal_ops_console/routers/system.py
+++ b/goal_ops_console/routers/system.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
 
 from goal_ops_console.config import CONSUMER_BATCH_SIZE, MAX_TOTAL_RETRIES_PER_CYCLE, SPEC_VERSION
-from goal_ops_console.models import BackpressureError, FaultRemediationRequest
+from goal_ops_console.models import BackpressureError, FaultBulkResolveRequest, FaultRemediationRequest
 from goal_ops_console.services import AppServices, get_services
 
 router = APIRouter(tags=["system"])
@@ -203,6 +203,24 @@ def fault_summary(
         services.failure_intelligence.systemic_external_failure_count()
     )
     return summary
+
+
+@router.post("/system/faults/resolve_bulk")
+def resolve_faults_bulk(
+    request: FaultBulkResolveRequest,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return services.execution_layer.resolve_faults_bulk(
+        reason=request.reason,
+        dry_run=request.dry_run,
+        failure_type=request.failure_type,
+        failure_status=request.failure_status,
+        task_status=request.task_status,
+        goal_id=request.goal_id,
+        error_hash=request.error_hash,
+        dead_letter_only=request.dead_letter_only,
+        limit=request.limit,
+    )
 
 
 @router.post("/system/faults/{failure_id}/retry")

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -481,20 +481,33 @@ async function refreshAudit() {
   renderAudit(payload.entries || []);
 }
 
-async function refreshFaults() {
+function collectFaultFilters() {
   const failureType = document.getElementById("fault-failure-type").value.trim();
   const failureStatus = document.getElementById("fault-failure-status").value.trim();
   const taskStatus = document.getElementById("fault-task-status").value.trim();
   const goalId = document.getElementById("fault-goal-id").value.trim();
   const errorHash = document.getElementById("fault-error-hash").value.trim();
   const deadLetterOnly = document.getElementById("fault-dead-letter-only").checked;
+  const filters = {
+    dead_letter_only: deadLetterOnly,
+  };
+  if (failureType) filters.failure_type = failureType;
+  if (failureStatus) filters.failure_status = failureStatus;
+  if (taskStatus) filters.task_status = taskStatus;
+  if (goalId) filters.goal_id = goalId;
+  if (errorHash) filters.error_hash = errorHash;
+  return filters;
+}
+
+async function refreshFaults() {
+  const filters = collectFaultFilters();
   const params = new URLSearchParams();
-  if (failureType) params.set("failure_type", failureType);
-  if (failureStatus) params.set("failure_status", failureStatus);
-  if (taskStatus) params.set("task_status", taskStatus);
-  if (goalId) params.set("goal_id", goalId);
-  if (errorHash) params.set("error_hash", errorHash);
-  params.set("dead_letter_only", deadLetterOnly ? "true" : "false");
+  if (filters.failure_type) params.set("failure_type", filters.failure_type);
+  if (filters.failure_status) params.set("failure_status", filters.failure_status);
+  if (filters.task_status) params.set("task_status", filters.task_status);
+  if (filters.goal_id) params.set("goal_id", filters.goal_id);
+  if (filters.error_hash) params.set("error_hash", filters.error_hash);
+  params.set("dead_letter_only", filters.dead_letter_only ? "true" : "false");
   const suffix = `?${params.toString()}`;
   const [entryPayload, summaryPayload] = await Promise.all([
     api(`/system/faults${suffix}`),
@@ -610,6 +623,46 @@ async function runFaultAction(action, failureId) {
   await refreshAll();
 }
 
+async function runFaultBulkResolve() {
+  const reasonInput = document.getElementById("fault-remediation-reason");
+  const dryRunInput = document.getElementById("fault-remediation-dry-run");
+  const limitInput = document.getElementById("fault-bulk-limit");
+  const reason = (reasonInput?.value || "").trim();
+  const dryRun = Boolean(dryRunInput?.checked);
+  const parsedLimit = Number(limitInput?.value || 50);
+  const limit = Number.isFinite(parsedLimit)
+    ? Math.max(1, Math.min(500, Math.trunc(parsedLimit)))
+    : 50;
+  if (!reason) {
+    throw new Error("Remediation reason is required.");
+  }
+
+  const payload = {
+    reason,
+    dry_run: dryRun,
+    ...collectFaultFilters(),
+    limit,
+  };
+  const result = await api("/system/faults/resolve_bulk", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  const feedback = document.getElementById("system-feedback");
+  if (dryRun) {
+    feedback.textContent = (
+      `Dry run: ${result.will_resolve_count} filtered faults would be resolved `
+      + `(${result.skipped_already_resolved_count} already resolved skipped).`
+    );
+    await Promise.all([refreshFaults(), refreshHealth()]);
+    return;
+  }
+  feedback.textContent = (
+    `Bulk resolve completed: ${result.resolved_count} failures resolved `
+    + `(${result.skipped_already_resolved_count} already resolved skipped).`
+  );
+  await refreshAll();
+}
+
 document.getElementById("goal-form").addEventListener("submit", async (event) => {
   event.preventDefault();
   showError("goal-error", null);
@@ -673,6 +726,15 @@ document.getElementById("audit-filter-form").addEventListener("submit", async (e
 document.getElementById("fault-filter-form").addEventListener("submit", async (event) => {
   event.preventDefault();
   await refreshFaults();
+});
+
+document.getElementById("bulk-resolve-faults").addEventListener("click", async () => {
+  try {
+    showError("system-feedback", null);
+    await runFaultBulkResolve();
+  } catch (error) {
+    showError("system-feedback", error);
+  }
 });
 
 document.getElementById("flow-trace-form").addEventListener("submit", async (event) => {

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -382,10 +382,14 @@
           <input id="fault-remediation-reason" value="Supervisor remediation from dashboard" placeholder="Remediation reason (required)">
         </div>
         <div class="split">
+          <input id="fault-bulk-limit" type="number" min="1" max="500" value="50" placeholder="Bulk resolve limit">
           <label class="meta"><input type="checkbox" id="fault-remediation-dry-run"> Dry run only (no writes)</label>
         </div>
         <label class="meta"><input type="checkbox" id="fault-dead-letter-only" checked> Dead-letter only (`poison` + `exhausted`)</label>
-        <button type="submit">Apply Filter</button>
+        <div class="actions">
+          <button type="submit">Apply Filter</button>
+          <button type="button" class="secondary" id="bulk-resolve-faults">Resolve Filtered</button>
+        </div>
       </form>
       <div id="fault-summary"></div>
       <div id="fault-table"></div>

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -908,3 +908,105 @@ def test_45_fault_resolve_dry_run_and_conflict_when_already_resolved(client):
     )
     assert conflict.status_code == 409
     assert "already resolved" in conflict.json()["detail"]
+
+
+def test_46_fault_resolve_bulk_dry_run_reports_candidates_without_writes(client):
+    goal_a = create_active_goal(client, title="Bulk Dry Goal A")
+    goal_b = create_active_goal(client, title="Bulk Dry Goal B")
+    task_a = create_task(client, goal_a["goal_id"], title="Bulk Dry Task A")
+    task_b = create_task(client, goal_b["goal_id"], title="Bulk Dry Task B")
+
+    client.post(
+        f"/tasks/{task_a['task_id']}/fail",
+        json={"failure_type": "SkillFailure", "error_message": "bulk dry issue a"},
+    )
+    client.post(
+        f"/tasks/{task_b['task_id']}/fail",
+        json={"failure_type": "SkillFailure", "error_message": "bulk dry issue b"},
+    )
+
+    response = client.post(
+        "/system/faults/resolve_bulk",
+        json={
+            "reason": "Preview bulk resolution",
+            "dry_run": True,
+            "failure_type": "SkillFailure",
+            "task_status": "failed",
+            "dead_letter_only": False,
+            "limit": 10,
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["dry_run"] is True
+    assert payload["allowed"] is True
+    assert payload["matched_count"] == 2
+    assert payload["will_resolve_count"] == 2
+    assert len(payload["candidate_failure_ids"]) == 2
+    assert payload["skipped_already_resolved_count"] == 0
+
+    recorded_count = client.app.state.services.db.fetch_scalar(
+        "SELECT COUNT(*) FROM failure_log WHERE status = 'recorded'"
+    )
+    assert recorded_count == 2
+
+
+def test_47_fault_resolve_bulk_applies_filtered_resolution_and_tracks_skip(client):
+    goal_a = create_active_goal(client, title="Bulk Apply Goal A")
+    goal_b = create_active_goal(client, title="Bulk Apply Goal B")
+    task_a = create_task(client, goal_a["goal_id"], title="Bulk Apply Task A")
+    task_b = create_task(client, goal_b["goal_id"], title="Bulk Apply Task B")
+
+    client.post(
+        f"/tasks/{task_a['task_id']}/fail",
+        json={"failure_type": "ExecutionFailure", "error_message": "bulk apply issue a"},
+    )
+    client.post(
+        f"/tasks/{task_b['task_id']}/fail",
+        json={"failure_type": "ExecutionFailure", "error_message": "bulk apply issue b"},
+    )
+
+    faults = client.get(
+        "/system/faults?failure_type=ExecutionFailure&task_status=failed&dead_letter_only=false"
+    ).json()["entries"]
+    assert len(faults) == 2
+    first_failure_id = faults[0]["failure_id"]
+    second_failure_id = faults[1]["failure_id"]
+
+    single_resolve = client.post(
+        f"/system/faults/{first_failure_id}/resolve",
+        json={"reason": "Resolve one before bulk", "dry_run": False},
+    )
+    assert single_resolve.status_code == 200
+
+    bulk_response = client.post(
+        "/system/faults/resolve_bulk",
+        json={
+            "reason": "Resolve filtered execution failures",
+            "dry_run": False,
+            "failure_type": "ExecutionFailure",
+            "task_status": "failed",
+            "dead_letter_only": False,
+            "limit": 10,
+        },
+    )
+    assert bulk_response.status_code == 200
+    payload = bulk_response.json()
+    assert payload["dry_run"] is False
+    assert payload["matched_count"] == 2
+    assert payload["resolved_count"] == 1
+    assert payload["skipped_already_resolved_count"] == 1
+    assert set(payload["resolved_failure_ids"]) == {second_failure_id}
+    assert set(payload["skipped_failure_ids"]) == {first_failure_id}
+
+    unresolved_after = client.app.state.services.db.fetch_scalar(
+        "SELECT COUNT(*) FROM failure_log WHERE status <> 'resolved'"
+    )
+    assert unresolved_after == 0
+
+    metrics = client.get("/system/metrics?prefix=faults.remediation.bulk_resolved").json()["metrics"]
+    assert metrics
+    assert metrics[0]["value"] >= 1
+
+    audit_entries = client.get("/system/audit?action=fault.remediation.resolve_bulk").json()["entries"]
+    assert any(item["status"] == "success" for item in audit_entries)


### PR DESCRIPTION
## Summary
- add bulk remediation API endpoint `POST /system/faults/resolve_bulk`
- add `FaultBulkResolveRequest` model with validated filter + limit inputs
- implement bulk resolve flow in execution layer (dry run preview, skip already resolved, audit + metrics)
- extend dashboard fault explorer with `Resolve Filtered` action and configurable bulk limit
- update README with new operator action and endpoint
- add tests for bulk dry-run preview and applied bulk resolution behavior

## Why
Single-fault remediation was in place, but operators still had to close repeated fault rows one by one. This adds a supervised, bounded batch workflow that uses the same filters as the fault explorer.

## Impact
- faster operator remediation for repeated failures
- safer bulk action via dry-run mode and explicit limit
- full observability for batch closures through audit and metric hooks

## Validation
- `./scripts/run-tests.ps1`
- `47 passed in 1.85s`
