### PR TITLE
Add desktop shell scaffold with launcher and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Stack:
 - Jinja2
 - SQLite
 - Pytest
+- pywebview (optional, desktop shell)
 
 ## Project Path
 
@@ -29,6 +30,12 @@ Install dependencies if needed:
 python -m pip install fastapi jinja2 uvicorn pytest
 ```
 
+Or install from project metadata (recommended):
+
+```powershell
+python -m pip install -e ".[test]"
+```
+
 Start the server:
 
 ```powershell
@@ -38,6 +45,35 @@ Start the server:
 Open the dashboard:
 
 [http://127.0.0.1:8000](http://127.0.0.1:8000)
+
+## Desktop Shell (Preview)
+
+Use this if you prefer a desktop window over a browser tab.
+
+Install the optional desktop dependency:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+python -m pip install -e ".[desktop]"
+```
+
+Start the desktop shell:
+
+```powershell
+.\scripts\start-desktop.ps1
+```
+
+Optional startup parameters:
+
+```powershell
+.\scripts\start-desktop.ps1 -DatabaseUrl "goal_ops.db" -Width 1600 -Height 1000
+.\scripts\start-desktop.ps1 -Port 8010
+```
+
+Behavior:
+- starts an embedded local FastAPI server (`127.0.0.1`)
+- opens the same dashboard UI in a native window via `pywebview`
+- shuts down the embedded server when the desktop window closes
 
 ## Stop And Restart
 
@@ -200,7 +236,7 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 Current result during implementation:
 
 ```text
-39 passed
+run `.\scripts\run-tests.ps1` (latest local count may change as features are added)
 ```
 
 ## CI And PR Guardrails
@@ -252,6 +288,15 @@ If the smoke test says the server is not reachable:
 - make sure `uvicorn` is already running
 - keep the server terminal open
 - check that the URL is `http://127.0.0.1:8000`
+
+### `pywebview is required for desktop mode`
+
+If desktop mode fails with this message, install the optional extra:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+python -m pip install -e ".[desktop]"
+```
 
 ### `ModuleNotFoundError: No module named 'goal_ops_console'`
 
@@ -320,9 +365,12 @@ If a value is rejected:
 ## Key Files
 
 - [main.py](/C:/Users/raffa/OneDrive/Documents/New%20project/goal_ops_console/main.py)
+- [desktop.py](/C:/Users/raffa/OneDrive/Documents/New%20project/goal_ops_console/desktop.py)
 - [app.js](/C:/Users/raffa/OneDrive/Documents/New%20project/goal_ops_console/static/app.js)
 - [index.html](/C:/Users/raffa/OneDrive/Documents/New%20project/goal_ops_console/templates/index.html)
 - [start-server.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/start-server.ps1)
+- [start-desktop.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/start-desktop.ps1)
 - [reset-db.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/reset-db.ps1)
 - [run-tests.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-tests.ps1)
 - [test_goal_ops.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_goal_ops.py)
+- [test_desktop_launcher.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_desktop_launcher.py)

--- a/goal_ops_console/desktop.py
+++ b/goal_ops_console/desktop.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import argparse
+import socket
+import threading
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+from uvicorn import Config, Server
+
+from goal_ops_console.config import Settings
+from goal_ops_console.main import create_app
+
+
+def _pick_port(host: str, explicit_port: int | None) -> int:
+    if explicit_port is not None and explicit_port > 0:
+        return explicit_port
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_until_ready(url: str, timeout_seconds: float = 15.0) -> None:
+    deadline = time.time() + timeout_seconds
+    last_error: Exception | None = None
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=1.5):
+                return
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            last_error = exc
+            time.sleep(0.2)
+    if last_error is not None:
+        raise RuntimeError(f"Desktop server did not become ready at {url}") from last_error
+    raise RuntimeError(f"Desktop server did not become ready at {url}")
+
+
+def run_desktop(
+    *,
+    database_url: str,
+    host: str = "127.0.0.1",
+    port: int | None = None,
+    width: int = 1440,
+    height: int = 900,
+    window_title: str = "Goal Ops Console",
+    debug: bool = False,
+) -> None:
+    selected_port = _pick_port(host, port)
+    app = create_app(Settings(database_url=database_url))
+    server = Server(
+        Config(
+            app=app,
+            host=host,
+            port=selected_port,
+            log_level="warning",
+        )
+    )
+    server_thread = threading.Thread(target=server.run, daemon=True, name="goal-ops-desktop-server")
+    server_thread.start()
+
+    url = f"http://{host}:{selected_port}/"
+    try:
+        _wait_until_ready(url)
+
+        try:
+            import webview  # pyright: ignore[reportMissingImports]
+        except ImportError as exc:  # pragma: no cover - dependency is optional
+            raise RuntimeError(
+                "pywebview is required for desktop mode. Install with: "
+                "python -m pip install \"goal-ops-console[desktop]\""
+            ) from exc
+
+        webview.create_window(
+            title=window_title,
+            url=url,
+            width=width,
+            height=height,
+            min_size=(1024, 720),
+            text_select=True,
+        )
+        webview.start(debug=debug)
+    finally:
+        server.should_exit = True
+        server_thread.join(timeout=5.0)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run Goal Ops Console in a desktop window.")
+    parser.add_argument(
+        "--database-url",
+        default="goal_ops.db",
+        help="SQLite database path or URI (default: goal_ops.db).",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host for the embedded local server (default: 127.0.0.1).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=0,
+        help="Server port (0 = auto-pick a free port).",
+    )
+    parser.add_argument(
+        "--width",
+        type=int,
+        default=1440,
+        help="Desktop window width.",
+    )
+    parser.add_argument(
+        "--height",
+        type=int,
+        default=900,
+        help="Desktop window height.",
+    )
+    parser.add_argument(
+        "--title",
+        default="Goal Ops Console",
+        help="Desktop window title.",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable pywebview debug mode.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        run_desktop(
+            database_url=args.database_url,
+            host=args.host,
+            port=(args.port if args.port > 0 else None),
+            width=args.width,
+            height=args.height,
+            window_title=args.title,
+            debug=args.debug,
+        )
+    except Exception as exc:  # pragma: no cover - this is top-level UX handling
+        print(f"[desktop] Failed to launch: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,13 @@ dependencies = [
   "uvicorn>=0.29",
 ]
 
+[project.scripts]
+goal-ops-desktop = "goal_ops_console.desktop:main"
+
 [project.optional-dependencies]
+desktop = [
+  "pywebview>=5.1",
+]
 test = [
   "httpx>=0.27",
   "pytest>=8.0",

--- a/scripts/start-desktop.ps1
+++ b/scripts/start-desktop.ps1
@@ -1,0 +1,33 @@
+param(
+    [string]$DatabaseUrl = "goal_ops.db",
+    [int]$Port = 0,
+    [int]$Width = 1440,
+    [int]$Height = 900
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$env:GOAL_OPS_DATABASE_URL = $DatabaseUrl
+
+Write-Host "Starting Goal Ops Console desktop shell from $ProjectRoot" -ForegroundColor Cyan
+Write-Host "Database: $DatabaseUrl" -ForegroundColor Cyan
+if ($Port -gt 0) {
+    Write-Host "Desktop server URL: http://127.0.0.1:$Port" -ForegroundColor Cyan
+} else {
+    Write-Host "Desktop server URL: auto-selected free local port" -ForegroundColor Cyan
+}
+
+$args = @(
+    "-m", "goal_ops_console.desktop",
+    "--database-url", $DatabaseUrl,
+    "--width", $Width,
+    "--height", $Height
+)
+if ($Port -gt 0) {
+    $args += @("--port", $Port)
+}
+
+python @args

--- a/tests/test_desktop_launcher.py
+++ b/tests/test_desktop_launcher.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import goal_ops_console.desktop as desktop
+
+
+def test_pick_port_prefers_explicit_port():
+    assert desktop._pick_port("127.0.0.1", 8123) == 8123
+
+
+def test_pick_port_chooses_ephemeral_port_when_none():
+    port = desktop._pick_port("127.0.0.1", None)
+    assert isinstance(port, int)
+    assert port > 0
+
+
+def test_parse_args_defaults():
+    args = desktop._parse_args([])
+    assert args.database_url == "goal_ops.db"
+    assert args.host == "127.0.0.1"
+    assert args.port == 0
+    assert args.width == 1440
+    assert args.height == 900
+    assert args.title == "Goal Ops Console"
+    assert args.debug is False
+
+
+def test_main_returns_nonzero_when_launch_fails(monkeypatch, capsys):
+    def _raise(**_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(desktop, "run_desktop", _raise)
+    exit_code = desktop.main(["--database-url", "demo.db"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "[desktop] Failed to launch:" in captured.out
+
+
+def test_main_maps_port_zero_to_none(monkeypatch):
+    captured_kwargs = {}
+
+    def _fake_run_desktop(**kwargs):
+        captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr(desktop, "run_desktop", _fake_run_desktop)
+    exit_code = desktop.main(
+        [
+            "--database-url",
+            "demo.db",
+            "--port",
+            "0",
+            "--width",
+            "1200",
+            "--height",
+            "800",
+            "--title",
+            "Demo",
+            "--debug",
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured_kwargs["database_url"] == "demo.db"
+    assert captured_kwargs["port"] is None
+    assert captured_kwargs["width"] == 1200
+    assert captured_kwargs["height"] == 800
+    assert captured_kwargs["window_title"] == "Demo"
+    assert captured_kwargs["debug"] is True
+
+
+def test_main_passes_explicit_port(monkeypatch):
+    captured_kwargs = {}
+
+    def _fake_run_desktop(**kwargs):
+        captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr(desktop, "run_desktop", _fake_run_desktop)
+    exit_code = desktop.main(["--database-url", "demo.db", "--port", "8124"])
+
+    assert exit_code == 0
+    assert captured_kwargs["port"] == 8124


### PR DESCRIPTION
## Summary
- add a desktop launcher module (`goal_ops_console.desktop`) that starts an embedded local FastAPI server and opens the UI in a native `pywebview` window
- add `scripts/start-desktop.ps1` for one-command desktop startup with optional database/port/window parameters
- add desktop packaging metadata (`[project.optional-dependencies].desktop` and `goal-ops-desktop` entrypoint)
- add README usage/troubleshooting updates for desktop mode
- add focused unit tests for desktop argument mapping and launcher error handling

## Validation
- `./scripts/run-tests.ps1` -> `53 passed`
- `python -m goal_ops_console.desktop --help`