### PR TITLE
Polish dashboard visuals and add live header KPIs

### DIFF
--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -343,7 +343,40 @@ function renderFlowTrace(trace) {
   `;
 }
 
+function renderTopKpis(health) {
+  const target = document.getElementById("top-kpis");
+  if (!target) {
+    return;
+  }
+  const totals = health.totals || {};
+  const backpressure = health.backpressure || {};
+  const faults = health.faults || {};
+  const audit = health.audit || {};
+  const throttled = Boolean(backpressure.is_throttled);
+  const deadLetterTasks = faults.dead_letter_tasks || 0;
+
+  target.innerHTML = `
+    <div class="kpi-chip">
+      <span class="meta">Goals</span>
+      <strong>${totals.goals || 0}</strong>
+    </div>
+    <div class="kpi-chip ${throttled ? "alert" : "good"}">
+      <span class="meta">Backpressure</span>
+      <strong>${throttled ? "ON" : "OFF"}</strong>
+    </div>
+    <div class="kpi-chip ${deadLetterTasks > 0 ? "alert" : ""}">
+      <span class="meta">Dead-Letter</span>
+      <strong>${deadLetterTasks}</strong>
+    </div>
+    <div class="kpi-chip">
+      <span class="meta">Audit 24h</span>
+      <strong>${audit.entries_last_24h || 0}</strong>
+    </div>
+  `;
+}
+
 function renderHealth(health) {
+  renderTopKpis(health);
   defaultConsumerId = health.default_consumer_id || defaultConsumerId;
   const consumerInput = document.getElementById("consumer-id");
   if (consumerInput && !consumerInput.value.trim()) {

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -6,19 +6,20 @@
   <title>Goal Ops Console</title>
   <style>
     :root {
-      --font-display: "Trebuchet MS", "Gill Sans MT", "Segoe UI", sans-serif;
-      --font-body: "Candara", "Segoe UI", sans-serif;
-      --bg: #f4efe7;
-      --panel: #fffaf2;
-      --ink: #1f1b17;
-      --muted: #6f655b;
-      --line: #ddcdbd;
-      --accent: #c46a2d;
-      --accent-soft: #f4d7c3;
-      --good: #2f855a;
-      --warn: #b7791f;
-      --bad: #c53030;
-      --info: #2b6cb0;
+      --font-display: "Bahnschrift", "Trebuchet MS", "Gill Sans MT", sans-serif;
+      --font-body: "Corbel", "Candara", "Segoe UI", sans-serif;
+      --bg: #f7f1e8;
+      --panel: #fff8ef;
+      --ink: #1d1a16;
+      --muted: #6d6358;
+      --line: #d8c9b7;
+      --accent: #cb6b2e;
+      --accent-soft: #f7decb;
+      --good: #20755a;
+      --warn: #b56e11;
+      --bad: #bf2f2f;
+      --info: #2366ad;
+      --focus: rgba(203, 107, 46, 0.32);
     }
 
     * { box-sizing: border-box; }
@@ -56,60 +57,164 @@
       font-family: var(--font-body);
       color: var(--ink);
       background:
-        radial-gradient(circle at top left, #f8dcc4 0, transparent 32%),
-        radial-gradient(circle at 90% 12%, #f2e4ce 0, transparent 28%),
-        linear-gradient(160deg, #f4efe7 0%, #eee1d0 100%);
+        radial-gradient(circle at 8% 12%, rgba(255, 175, 120, 0.42) 0, transparent 28%),
+        radial-gradient(circle at 88% 8%, rgba(147, 199, 245, 0.32) 0, transparent 24%),
+        radial-gradient(circle at 92% 78%, rgba(255, 212, 166, 0.38) 0, transparent 26%),
+        linear-gradient(165deg, #f7f1e8 0%, #efe3d4 48%, #e9dccd 100%);
       min-height: 100vh;
       line-height: 1.35;
+      position: relative;
+    }
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      background-image: repeating-linear-gradient(
+        120deg,
+        rgba(255, 255, 255, 0.06) 0,
+        rgba(255, 255, 255, 0.06) 1px,
+        transparent 1px,
+        transparent 26px
+      );
+      opacity: 0.75;
+      mix-blend-mode: soft-light;
+      z-index: -1;
     }
     header {
-      padding: 1.5rem 2rem 1rem;
-      border-bottom: 1px solid rgba(31, 27, 23, 0.08);
-      background: rgba(255, 250, 242, 0.8);
-      backdrop-filter: blur(12px);
+      padding: 1.2rem 1.5rem 1rem;
+      border-bottom: 1px solid rgba(29, 26, 22, 0.1);
+      background:
+        linear-gradient(120deg, rgba(255, 249, 241, 0.9) 0%, rgba(255, 242, 228, 0.86) 55%, rgba(242, 249, 255, 0.82) 100%);
+      backdrop-filter: blur(14px);
       position: sticky;
       top: 0;
-      z-index: 10;
+      z-index: 30;
     }
     header h1 {
       margin: 0;
-      font-size: 2rem;
+      font-size: clamp(1.8rem, 2vw + 1rem, 2.5rem);
       font-family: var(--font-display);
-      letter-spacing: 0.01em;
-      text-shadow: 0 1px 0 rgba(255, 255, 255, 0.8);
+      letter-spacing: 0.02em;
+      text-shadow: 0 1px 0 rgba(255, 255, 255, 0.8), 0 8px 20px rgba(60, 44, 32, 0.12);
+      line-height: 1.05;
     }
-    header p { margin: 0.35rem 0 0; color: var(--muted); }
-    main {
-      padding: 1.5rem;
+    .header-shell {
+      max-width: 1680px;
+      margin: 0 auto;
       display: grid;
       gap: 1rem;
+      grid-template-columns: minmax(320px, 1fr) minmax(280px, 560px);
+      align-items: end;
+    }
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.74rem;
+      font-weight: 700;
+      color: #7a5031;
+      background: rgba(255, 255, 255, 0.55);
+      border: 1px solid rgba(122, 80, 49, 0.22);
+      border-radius: 999px;
+      padding: 0.28rem 0.65rem;
+      width: fit-content;
+      margin-bottom: 0.45rem;
+    }
+    header p {
+      margin: 0.45rem 0 0;
+      color: #5f564c;
+      max-width: 62ch;
+    }
+    .kpi-strip {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(120px, 1fr));
+      gap: 0.5rem;
+      align-self: stretch;
+    }
+    .kpi-chip {
+      display: grid;
+      gap: 0.12rem;
+      align-content: center;
+      border-radius: 14px;
+      border: 1px solid rgba(29, 26, 22, 0.12);
+      background: rgba(255, 255, 255, 0.72);
+      padding: 0.5rem 0.65rem;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
+      min-height: 62px;
+    }
+    .kpi-chip .meta {
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: #776b5f;
+    }
+    .kpi-chip strong {
+      font-size: 1.1rem;
+      font-family: var(--font-display);
+      line-height: 1.05;
+    }
+    .kpi-chip.alert {
+      border-color: rgba(191, 47, 47, 0.35);
+      background: rgba(255, 235, 235, 0.84);
+    }
+    .kpi-chip.good {
+      border-color: rgba(32, 117, 90, 0.28);
+      background: rgba(232, 248, 242, 0.82);
+    }
+    main {
+      padding: 1.3rem;
+      display: grid;
+      gap: 1.05rem;
       grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
       max-width: 1680px;
       margin: 0 auto;
     }
     section {
-      background: rgba(255, 250, 242, 0.88);
-      border: 1px solid rgba(31, 27, 23, 0.08);
-      border-radius: 18px;
-      padding: 1rem;
-      box-shadow: 0 20px 40px rgba(68, 50, 33, 0.08);
+      background:
+        linear-gradient(165deg, rgba(255, 252, 248, 0.9) 0%, rgba(255, 247, 237, 0.82) 100%);
+      border: 1px solid rgba(29, 26, 22, 0.1);
+      border-top: 4px solid rgba(203, 107, 46, 0.45);
+      border-radius: 20px;
+      padding: 1.05rem;
+      box-shadow: 0 24px 44px rgba(68, 50, 33, 0.11), inset 0 1px 0 rgba(255, 255, 255, 0.84);
       min-width: 0;
-      animation: fade-rise 320ms ease both;
-      transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+      animation: fade-rise 460ms ease both;
+      transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+      position: relative;
+      overflow: clip;
+    }
+    section::after {
+      content: "";
+      position: absolute;
+      inset: auto -10% 0 auto;
+      width: 180px;
+      height: 180px;
+      background: radial-gradient(circle, rgba(203, 107, 46, 0.12) 0, transparent 70%);
+      pointer-events: none;
     }
     section:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 22px 42px rgba(68, 50, 33, 0.11);
-      border-color: rgba(196, 106, 45, 0.25);
+      transform: translateY(-2px);
+      box-shadow: 0 26px 48px rgba(68, 50, 33, 0.16);
+      border-color: rgba(203, 107, 46, 0.35);
     }
     section h2 {
       margin: 0 0 0.75rem;
-      font-size: 1.05rem;
+      font-size: 1.03rem;
+      font-family: var(--font-display);
+      letter-spacing: 0.015em;
       display: flex;
       justify-content: space-between;
       gap: 0.75rem;
       align-items: center;
     }
+    section:nth-of-type(2) { animation-delay: 40ms; }
+    section:nth-of-type(3) { animation-delay: 80ms; }
+    section:nth-of-type(4) { animation-delay: 120ms; }
+    section:nth-of-type(5) { animation-delay: 160ms; }
+    section:nth-of-type(6) { animation-delay: 200ms; }
     .wide { grid-column: 1 / -1; }
     form {
       display: grid;
@@ -118,10 +223,10 @@
     }
     input, textarea, select, button {
       font: inherit;
-      border-radius: 10px;
+      border-radius: 11px;
       border: 1px solid var(--line);
       padding: 0.65rem 0.8rem;
-      background: white;
+      background: rgba(255, 255, 255, 0.92);
       color: var(--ink);
       transition: border-color 120ms ease, box-shadow 120ms ease, transform 120ms ease;
     }
@@ -129,26 +234,27 @@
     input:focus, textarea:focus, select:focus {
       outline: none;
       border-color: rgba(196, 106, 45, 0.65);
-      box-shadow: 0 0 0 3px rgba(196, 106, 45, 0.18);
+      box-shadow: 0 0 0 3px var(--focus);
     }
     button {
       cursor: pointer;
-      background: linear-gradient(180deg, #cd783d 0%, var(--accent) 100%);
+      background: linear-gradient(180deg, #da8850 0%, var(--accent) 100%);
       color: white;
       border: none;
-      box-shadow: 0 6px 14px rgba(196, 106, 45, 0.25);
-      transition: transform 120ms ease, opacity 120ms ease;
+      box-shadow: 0 7px 14px rgba(203, 107, 46, 0.3);
+      font-weight: 600;
+      transition: transform 120ms ease, opacity 120ms ease, filter 120ms ease;
     }
-    button:hover { transform: translateY(-1px); }
+    button:hover { transform: translateY(-1px); filter: saturate(1.05); }
     button:active { transform: translateY(0); }
     button.secondary {
-      background: #fff;
+      background: rgba(255, 255, 255, 0.92);
       color: var(--ink);
       border: 1px solid var(--line);
-      box-shadow: none;
+      box-shadow: 0 2px 8px rgba(59, 42, 28, 0.06);
     }
     button.secondary:hover {
-      background: #fff6eb;
+      background: #fff4e7;
     }
     button.ghost {
       background: transparent;
@@ -229,7 +335,8 @@
       border: 1px solid rgba(31, 27, 23, 0.08);
       border-radius: 14px;
       padding: 0.8rem;
-      background: rgba(255,255,255,0.6);
+      background: rgba(255, 255, 255, 0.72);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.84);
     }
     .card strong { display: block; font-size: 1.4rem; }
     .stack-list {
@@ -239,7 +346,7 @@
     .entity-card {
       border: 1px solid rgba(31, 27, 23, 0.08);
       border-radius: 14px;
-      background: rgba(255, 255, 255, 0.62);
+      background: rgba(255, 255, 255, 0.74);
       padding: 0.85rem;
       display: grid;
       gap: 0.7rem;
@@ -365,7 +472,7 @@
       color: #6f655b;
     }
     @keyframes fade-rise {
-      from { opacity: 0; transform: translateY(6px); }
+      from { opacity: 0; transform: translateY(10px); }
       to { opacity: 1; transform: translateY(0); }
     }
     @media (prefers-reduced-motion: reduce) {
@@ -378,6 +485,12 @@
       }
     }
     @media (max-width: 900px) {
+      .header-shell {
+        grid-template-columns: 1fr;
+      }
+      .kpi-strip {
+        grid-template-columns: 1fr 1fr;
+      }
       .split { grid-template-columns: 1fr; }
       .entity-header { flex-direction: column; }
       main { padding: 1rem; }
@@ -387,8 +500,19 @@
 <body>
   <a class="skip-link" href="#main-content">Skip to main content</a>
   <header>
-    <h1>Goal Ops Console</h1>
-    <p>Spec {{ spec_version }}. SQLite-authoritative supervised MVP with atomic state writes and append-only events.</p>
+    <div class="header-shell">
+      <div>
+        <div class="eyebrow">Supervised Operations</div>
+        <h1>Goal Ops Console</h1>
+        <p>Spec {{ spec_version }}. SQLite-authoritative supervised MVP with atomic state writes and append-only events.</p>
+      </div>
+      <div class="kpi-strip" id="top-kpis" role="status" aria-live="polite">
+        <div class="kpi-chip"><span class="meta">Goals</span><strong>...</strong></div>
+        <div class="kpi-chip"><span class="meta">Backpressure</span><strong>...</strong></div>
+        <div class="kpi-chip"><span class="meta">Dead-Letter</span><strong>...</strong></div>
+        <div class="kpi-chip"><span class="meta">Audit 24h</span><strong>...</strong></div>
+      </div>
+    </div>
   </header>
   <main id="main-content" tabindex="-1">
     <section>


### PR DESCRIPTION
## Summary
- redesign the dashboard shell into a stronger operator-cockpit style with richer gradients, section accents, elevated cards, and clearer typography hierarchy
- add a sticky header layout with a live KPI strip so critical health information is visible immediately
- wire header KPI cards to `/system/health` data (goals, backpressure state, dead-letter count, audit entries)
- keep all existing flows and controls intact while improving scannability on desktop and mobile

## Validation
- `./scripts/run-tests.ps1` -> `53 passed`
- root page render check via `TestClient(create_app(...)).get("/")` -> `200`
