### PR TITLE
Add desktop EXE packaging workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ __pycache__/
 *.py[cod]
 .pytest_cache/
 pytest-cache-files-*/
+build/
+dist/
 goal_ops.db
 goal_ops.db-journal
 probe.db

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Stack:
 - SQLite
 - Pytest
 - pywebview (optional, desktop shell)
+- PyInstaller (optional, desktop packaging)
 
 ## Project Path
 
@@ -74,6 +75,43 @@ Behavior:
 - starts an embedded local FastAPI server (`127.0.0.1`)
 - opens the same dashboard UI in a native window via `pywebview`
 - shuts down the embedded server when the desktop window closes
+
+## Build Windows Desktop EXE (Preview)
+
+Install desktop runtime + build tooling:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+python -m pip install -e ".[desktop,desktop-build]"
+```
+
+Build `onedir` (recommended for first packaging pass):
+
+```powershell
+.\scripts\build-desktop.ps1 -Mode onedir
+```
+
+Build `onefile`:
+
+```powershell
+.\scripts\build-desktop.ps1 -Mode onefile
+```
+
+Optional:
+
+```powershell
+.\scripts\build-desktop.ps1 -Mode onedir -Name "GoalOpsConsole"
+.\scripts\build-desktop.ps1 -Mode onefile -IconPath ".\assets\goal-ops.ico"
+.\scripts\build-desktop.ps1 -DryRun
+```
+
+Output paths:
+- `onedir`: `dist\GoalOpsConsole\GoalOpsConsole.exe`
+- `onefile`: `dist\GoalOpsConsole.exe`
+
+Note:
+- `pywebview` on Windows requires WebView2 runtime.
+- In `onefile` mode startup can be slower because the executable self-extracts before launch.
 
 ## Stop And Restart
 
@@ -298,6 +336,15 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 python -m pip install -e ".[desktop]"
 ```
 
+### `No module named PyInstaller`
+
+If desktop packaging fails with this error, install the optional build extra:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+python -m pip install -e ".[desktop,desktop-build]"
+```
+
 ### `ModuleNotFoundError: No module named 'goal_ops_console'`
 
 This means `uvicorn` was started from the wrong directory or without the app dir.
@@ -370,6 +417,7 @@ If a value is rejected:
 - [index.html](/C:/Users/raffa/OneDrive/Documents/New%20project/goal_ops_console/templates/index.html)
 - [start-server.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/start-server.ps1)
 - [start-desktop.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/start-desktop.ps1)
+- [build-desktop.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/build-desktop.ps1)
 - [reset-db.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/reset-db.ps1)
 - [run-tests.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-tests.ps1)
 - [test_goal_ops.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_goal_ops.py)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ goal-ops-desktop = "goal_ops_console.desktop:main"
 desktop = [
   "pywebview>=5.1",
 ]
+desktop-build = [
+  "pyinstaller>=6.6",
+]
 test = [
   "httpx>=0.27",
   "pytest>=8.0",

--- a/scripts/build-desktop.ps1
+++ b/scripts/build-desktop.ps1
@@ -1,0 +1,72 @@
+param(
+    [ValidateSet("onedir", "onefile")]
+    [string]$Mode = "onedir",
+    [string]$Name = "GoalOpsConsole",
+    [switch]$InstallDependencies,
+    [switch]$Clean = $true,
+    [switch]$DryRun,
+    [string]$IconPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+if ($InstallDependencies) {
+    Write-Host "Installing desktop build dependencies..." -ForegroundColor Cyan
+    python -m pip install -e ".[desktop,desktop-build]"
+}
+
+$pyInstallerArgs = @(
+    "-m", "PyInstaller",
+    "--noconfirm",
+    "--name", $Name,
+    "--collect-data", "goal_ops_console",
+    "--collect-submodules", "webview",
+    "--hidden-import", "uvicorn.logging",
+    "--hidden-import", "uvicorn.loops.auto",
+    "--hidden-import", "uvicorn.protocols.http.auto",
+    "--hidden-import", "uvicorn.protocols.websockets.auto",
+    "--hidden-import", "uvicorn.lifespan.on",
+    "--windowed",
+    "--distpath", "dist",
+    "--workpath", "build/pyinstaller/work",
+    "--specpath", "build/pyinstaller/spec",
+    "goal_ops_console/desktop.py"
+)
+
+if ($Clean) {
+    $pyInstallerArgs += "--clean"
+}
+
+if ($Mode -eq "onefile") {
+    $pyInstallerArgs += "--onefile"
+} else {
+    $pyInstallerArgs += "--onedir"
+}
+
+if ($IconPath) {
+    $resolvedIconPath = Resolve-Path -LiteralPath $IconPath
+    $pyInstallerArgs += @("--icon", $resolvedIconPath.Path)
+}
+
+Write-Host "Building desktop app ($Mode)..." -ForegroundColor Cyan
+Write-Host "Project root: $ProjectRoot" -ForegroundColor Cyan
+Write-Host "Command: python $($pyInstallerArgs -join ' ')" -ForegroundColor DarkGray
+
+if ($DryRun) {
+    Write-Host "Dry run only. No build executed." -ForegroundColor Yellow
+    exit 0
+}
+
+python @pyInstallerArgs
+
+$outputPath = if ($Mode -eq "onefile") {
+    Join-Path $ProjectRoot "dist/$Name.exe"
+} else {
+    Join-Path $ProjectRoot "dist/$Name/$Name.exe"
+}
+
+Write-Host "Build complete." -ForegroundColor Green
+Write-Host "Desktop executable: $outputPath" -ForegroundColor Green


### PR DESCRIPTION
## Summary
- add `scripts/build-desktop.ps1` to package the desktop shell as a Windows executable using PyInstaller (`onedir` and `onefile` modes)
- add optional project dependency group `desktop-build` with `pyinstaller`
- ignore packaging artifact directories (`build/`, `dist/`) in `.gitignore`
- document end-to-end desktop packaging flow in README, including troubleshooting and output paths

## Validation
- `./scripts/build-desktop.ps1 -DryRun`
- `./scripts/build-desktop.ps1 -Mode onefile -DryRun`
- `./scripts/run-tests.ps1` -> `53 passed`
