### PR TITLE
Harden desktop build script validation and error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 __pycache__/
 *.py[cod]
+*.egg-info/
 .pytest_cache/
 pytest-cache-files-*/
 build/
 dist/
+.tmp/
 goal_ops.db
 goal_ops.db-journal
 probe.db

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Build `onefile`:
 Optional:
 
 ```powershell
+.\scripts\build-desktop.ps1 -Mode onedir -InstallDependencies
 .\scripts\build-desktop.ps1 -Mode onedir -Name "GoalOpsConsole"
 .\scripts\build-desktop.ps1 -Mode onefile -IconPath ".\assets\goal-ops.ico"
 .\scripts\build-desktop.ps1 -DryRun

--- a/scripts/build-desktop.ps1
+++ b/scripts/build-desktop.ps1
@@ -13,9 +13,18 @@ $ErrorActionPreference = "Stop"
 $ProjectRoot = Split-Path -Parent $PSScriptRoot
 Set-Location $ProjectRoot
 
-if ($InstallDependencies) {
-    Write-Host "Installing desktop build dependencies..." -ForegroundColor Cyan
-    python -m pip install -e ".[desktop,desktop-build]"
+function Invoke-PythonCommand {
+    param(
+        [string[]]$PythonArgs,
+        [string]$Description
+    )
+
+    Write-Host "Running: python $($PythonArgs -join ' ')" -ForegroundColor DarkGray
+    & python @PythonArgs
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw "$Description failed (exit code $exitCode)."
+    }
 }
 
 $pyInstallerArgs = @(
@@ -60,12 +69,28 @@ if ($DryRun) {
     exit 0
 }
 
-python @pyInstallerArgs
+if ($InstallDependencies) {
+    $LocalPipTemp = Join-Path $ProjectRoot ".tmp/pip"
+    New-Item -ItemType Directory -Force -Path $LocalPipTemp | Out-Null
+    $env:TMP = $LocalPipTemp
+    $env:TEMP = $LocalPipTemp
+
+    Write-Host "Installing desktop build dependencies..." -ForegroundColor Cyan
+    Write-Host "Using temp dir: $LocalPipTemp" -ForegroundColor DarkGray
+    Invoke-PythonCommand -PythonArgs @("-m", "pip", "install", "-e", ".[desktop,desktop-build]") -Description "Dependency installation"
+}
+
+Invoke-PythonCommand -PythonArgs @("-m", "PyInstaller", "--version") -Description "PyInstaller availability check"
+Invoke-PythonCommand -PythonArgs $pyInstallerArgs -Description "Desktop packaging"
 
 $outputPath = if ($Mode -eq "onefile") {
     Join-Path $ProjectRoot "dist/$Name.exe"
 } else {
     Join-Path $ProjectRoot "dist/$Name/$Name.exe"
+}
+
+if (-not (Test-Path -LiteralPath $outputPath)) {
+    throw "Desktop packaging completed but executable was not found at: $outputPath"
 }
 
 Write-Host "Build complete." -ForegroundColor Green


### PR DESCRIPTION
## Summary
- harden `scripts/build-desktop.ps1` to fail fast when external Python commands return non-zero exit codes
- add explicit PyInstaller availability check before running the packaging command
- avoid temp-directory permission issues during `-InstallDependencies` by redirecting `TEMP/TMP` to project-local `.tmp/pip`
- verify expected output executable exists before reporting success
- ignore generated `.tmp/` and `*.egg-info/` artifacts in `.gitignore`

## Validation
- `./scripts/build-desktop.ps1 -DryRun`
- `./scripts/build-desktop.ps1 -Mode onedir` (expected failure with clear message when PyInstaller missing)
- `./scripts/build-desktop.ps1 -Mode onedir -InstallDependencies` (successful build)
- `./scripts/run-tests.ps1` -> `53 passed`
