### PR TITLE
Add command bar and advanced dashboard filtering UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ Behavior:
 - opens the same dashboard UI in a native window via `pywebview`
 - shuts down the embedded server when the desktop window closes
 
+## Operator Command Bar (UI)
+
+The dashboard header now includes a command bar for faster operator workflows:
+
+- `Global filter` searches across goals, tasks, events, audit, faults and queue rows.
+- Keyboard shortcut `/` focuses the global filter input.
+- `Auto-refresh` toggle pauses or resumes the 5-second refresh loop.
+- `Density` toggle switches between `Comfy` and `Compact` layout.
+- `Quick jump` buttons scroll directly to major panels (`Goals`, `Tasks`, `Operator`, `Events`, `Faults`, `Health`).
+
 ## Build Windows Desktop EXE (Preview)
 
 Install desktop runtime + build tooling:

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -1,7 +1,33 @@
 const stateClass = (value) => `state-${String(value || "").replaceAll(" ", "_")}`;
 
+const AUTO_REFRESH_MS = 5000;
+const SECTION_IDS = [
+  "goals-section",
+  "tasks-section",
+  "operator-section",
+  "events-section",
+  "faults-section",
+  "health-section",
+];
+
 let selectedGoalId = "";
 let defaultConsumerId = "goal_ops_console";
+let autoRefreshEnabled = true;
+let autoRefreshHandle = null;
+let densityMode = "comfy";
+let globalFilterTerm = "";
+let jumpScrollScheduled = false;
+
+const viewCache = {
+  goals: [],
+  tasks: [],
+  events: [],
+  auditEntries: [],
+  faultSummary: {},
+  faultEntries: [],
+  queue: [],
+  health: null,
+};
 
 async function api(path, options = {}) {
   const response = await fetch(path, {
@@ -35,6 +61,130 @@ function showError(id, error) {
       target.classList.remove("error-state");
     }
   }
+}
+
+function escapeHtml(value) {
+  return String(value || "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function normalizeFilterToken(value) {
+  return String(value ?? "").toLowerCase();
+}
+
+function matchesGlobalFilter(values) {
+  if (!globalFilterTerm) {
+    return true;
+  }
+  return values.some((value) => normalizeFilterToken(value).includes(globalFilterTerm));
+}
+
+function filterRows(rows, valueMapper) {
+  if (!globalFilterTerm) {
+    return rows;
+  }
+  return rows.filter((row) => matchesGlobalFilter(valueMapper(row)));
+}
+
+function filteredEmptyMessage(defaultMessage) {
+  if (!globalFilterTerm) {
+    return defaultMessage;
+  }
+  return `No entries match "${escapeHtml(globalFilterTerm)}".`;
+}
+
+function updateSelectedGoalLabel() {
+  const selectedLabel = selectedGoalId ? `Selected goal: ${selectedGoalId}` : "No goal selected.";
+  document.getElementById("selected-goal-label").textContent = selectedLabel;
+}
+
+function setActiveJump(sectionId) {
+  document.querySelectorAll(".jump-btn").forEach((button) => {
+    button.classList.toggle("active", button.dataset.jumpTarget === sectionId);
+  });
+}
+
+function jumpToSection(sectionId) {
+  const target = document.getElementById(sectionId);
+  if (!target) {
+    return;
+  }
+  target.scrollIntoView({ behavior: "smooth", block: "start" });
+  setActiveJump(sectionId);
+}
+
+function updateActiveJumpByScroll() {
+  let nearestId = SECTION_IDS[0];
+  let nearestDistance = Number.POSITIVE_INFINITY;
+  for (const sectionId of SECTION_IDS) {
+    const target = document.getElementById(sectionId);
+    if (!target) {
+      continue;
+    }
+    const distance = Math.abs(target.getBoundingClientRect().top - 220);
+    if (distance < nearestDistance) {
+      nearestDistance = distance;
+      nearestId = sectionId;
+    }
+  }
+  setActiveJump(nearestId);
+}
+
+function updateToolbarStatus() {
+  const status = document.getElementById("toolbar-status");
+  if (!status) {
+    return;
+  }
+  const filterPart = globalFilterTerm
+    ? `Filter active: "${globalFilterTerm}".`
+    : "Global filter inactive.";
+  const refreshPart = autoRefreshEnabled
+    ? `Auto-refresh every ${AUTO_REFRESH_MS / 1000}s.`
+    : "Auto-refresh paused.";
+  const densityPart = `Density: ${densityMode}.`;
+  status.textContent = `${filterPart} ${refreshPart} ${densityPart}`;
+}
+
+function setDensityMode(mode) {
+  densityMode = mode === "compact" ? "compact" : "comfy";
+  document.body.classList.toggle("density-compact", densityMode === "compact");
+  const toggleButton = document.getElementById("toggle-density");
+  if (toggleButton) {
+    toggleButton.textContent = `Density: ${densityMode === "compact" ? "Compact" : "Comfy"}`;
+  }
+  try {
+    localStorage.setItem("goal_ops_density", densityMode);
+  } catch {
+    // Ignore localStorage write failures in restricted contexts.
+  }
+  updateToolbarStatus();
+}
+
+function toggleDensityMode() {
+  setDensityMode(densityMode === "compact" ? "comfy" : "compact");
+}
+
+function setAutoRefresh(enabled) {
+  autoRefreshEnabled = Boolean(enabled);
+  const toggleButton = document.getElementById("toggle-refresh");
+  if (toggleButton) {
+    toggleButton.textContent = `Auto-refresh: ${autoRefreshEnabled ? "On" : "Off"}`;
+  }
+  updateToolbarStatus();
+}
+
+function rerenderFilteredViews() {
+  renderGoals(viewCache.goals);
+  renderTasks(viewCache.tasks);
+  renderEvents(viewCache.events);
+  renderAudit(viewCache.auditEntries);
+  renderFaults(viewCache.faultSummary, viewCache.faultEntries);
+  renderQueue(viewCache.queue);
+  updateSelectedGoalLabel();
 }
 
 function renderGoalButtons(goal) {
@@ -90,9 +240,16 @@ function renderTaskButtons(task) {
 }
 
 function renderGoals(goals) {
-  const content = goals.length
+  const filteredGoals = filterRows(goals, (goal) => [
+    goal.goal_id,
+    goal.title,
+    goal.state,
+    goal.blocked_reason,
+    goal.escalation_reason,
+  ]);
+  const content = filteredGoals.length
     ? `<div class="stack-list">
-        ${goals.map((goal) => `
+        ${filteredGoals.map((goal) => `
           <article class="entity-card ${selectedGoalId === goal.goal_id ? "selected" : ""}">
             <div class="entity-header">
               <div>
@@ -118,18 +275,27 @@ function renderGoals(goals) {
             <div class="actions">${renderGoalButtons(goal)}</div>
           </article>`).join("")}
       </div>`
-    : `<div class="meta">No goals yet.</div>`;
+    : `<div class="meta">${filteredEmptyMessage("No goals yet.")}</div>`;
   document.getElementById("goals-table").innerHTML = content;
 }
 
 function renderTasks(tasks) {
   const container = document.getElementById("tasks-table");
-  if (!tasks.length) {
-    container.innerHTML = `<div class="meta">No tasks for the current selection.</div>`;
+  const filteredTasks = filterRows(tasks, (task) => [
+    task.task_id,
+    task.goal_id,
+    task.title,
+    task.status,
+    task.failure_type,
+    task.error_hash,
+    task.correlation_id,
+  ]);
+  if (!filteredTasks.length) {
+    container.innerHTML = `<div class="meta">${filteredEmptyMessage("No tasks for the current selection.")}</div>`;
     return;
   }
   container.innerHTML = `<div class="stack-list">
-    ${tasks.map((task) => `
+    ${filteredTasks.map((task) => `
       <article class="entity-card">
         <div class="entity-header">
           <div>
@@ -158,8 +324,16 @@ function renderTasks(tasks) {
 
 function renderEvents(events) {
   const container = document.getElementById("events-table");
-  if (!events.length) {
-    container.innerHTML = `<div class="meta">No events match the current filter.</div>`;
+  const filteredEvents = filterRows(events, (event) => [
+    event.seq,
+    event.event_type,
+    event.entity_id,
+    event.correlation_id,
+    event.emitted_at,
+    JSON.stringify(event.payload || {}),
+  ]);
+  if (!filteredEvents.length) {
+    container.innerHTML = `<div class="meta">${filteredEmptyMessage("No events match the current filter.")}</div>`;
     return;
   }
   container.innerHTML = `<div class="table-scroll"><table>
@@ -173,7 +347,7 @@ function renderEvents(events) {
       </tr>
     </thead>
     <tbody>
-      ${events.map((event) => `
+      ${filteredEvents.map((event) => `
         <tr>
           <td>${event.seq}</td>
           <td>${event.event_type}<div class="meta">${event.emitted_at}</div></td>
@@ -187,8 +361,17 @@ function renderEvents(events) {
 
 function renderAudit(entries) {
   const container = document.getElementById("audit-table");
-  if (!entries.length) {
-    container.innerHTML = `<div class="meta">No audit entries yet.</div>`;
+  const filteredEntries = filterRows(entries, (entry) => [
+    entry.created_at,
+    entry.action,
+    entry.actor,
+    entry.status,
+    entry.entity_type,
+    entry.entity_id,
+    JSON.stringify(entry.details || {}),
+  ]);
+  if (!filteredEntries.length) {
+    container.innerHTML = `<div class="meta">${filteredEmptyMessage("No audit entries yet.")}</div>`;
     return;
   }
   container.innerHTML = `<div class="table-scroll"><table>
@@ -202,7 +385,7 @@ function renderAudit(entries) {
       </tr>
     </thead>
     <tbody>
-      ${entries.map((entry) => `
+      ${filteredEntries.map((entry) => `
         <tr>
           <td>${entry.created_at}</td>
           <td>${entry.action}<div class="meta">${entry.actor}</div></td>
@@ -246,8 +429,23 @@ function renderFaults(summary, entries) {
     </table></div>` : `<div class="meta">No fault buckets for current filter.</div>`}
   `;
 
-  if (!entries.length) {
-    tableTarget.innerHTML = `<div class="meta">No fault records for current filter.</div>`;
+  const filteredEntries = filterRows(entries, (item) => [
+    item.failure_id,
+    item.created_at,
+    item.failure_type,
+    item.failure_status,
+    item.task_id,
+    item.task_title,
+    item.task_status,
+    item.goal_id,
+    item.goal_title,
+    item.goal_state,
+    item.correlation_id,
+    item.error_hash,
+    item.last_error,
+  ]);
+  if (!filteredEntries.length) {
+    tableTarget.innerHTML = `<div class="meta">${filteredEmptyMessage("No fault records for current filter.")}</div>`;
     return;
   }
   tableTarget.innerHTML = `<div class="table-scroll"><table>
@@ -263,7 +461,7 @@ function renderFaults(summary, entries) {
       </tr>
     </thead>
     <tbody>
-      ${entries.map((item) => `
+      ${filteredEntries.map((item) => `
         <tr>
           <td>${item.created_at}</td>
           <td>
@@ -442,8 +640,14 @@ function renderHealth(health) {
 
 function renderQueue(goals) {
   const container = document.getElementById("queue-table");
-  if (!goals.length) {
-    container.innerHTML = `<div class="meta">No queue entries yet.</div>`;
+  const filteredGoals = filterRows(goals, (goal) => [
+    goal.goal_id,
+    goal.title,
+    goal.state,
+    goal.queue_status,
+  ]);
+  if (!filteredGoals.length) {
+    container.innerHTML = `<div class="meta">${filteredEmptyMessage("No queue entries yet.")}</div>`;
     return;
   }
   container.innerHTML = `<div class="table-scroll"><table>
@@ -457,7 +661,7 @@ function renderQueue(goals) {
       </tr>
     </thead>
     <tbody>
-      ${goals.map((goal) => `
+      ${filteredGoals.map((goal) => `
         <tr>
           <td>
             <div><button type="button" class="inline-link-button" data-select-goal="${goal.goal_id}" aria-label="Select goal ${goal.title}">${goal.title}</button></div>
@@ -477,21 +681,23 @@ function renderQueue(goals) {
 
 async function refreshGoals() {
   const goals = await api("/goals");
-  renderGoals(goals);
-  const selectedLabel = selectedGoalId ? `Selected goal: ${selectedGoalId}` : "No goal selected.";
-  document.getElementById("selected-goal-label").textContent = selectedLabel;
+  viewCache.goals = goals;
+  renderGoals(viewCache.goals);
+  updateSelectedGoalLabel();
 }
 
 async function refreshQueue() {
   const queue = await api("/system/queue");
-  renderQueue(queue);
+  viewCache.queue = queue;
+  renderQueue(viewCache.queue);
 }
 
 async function refreshTasks() {
   const goalId = document.getElementById("task-goal-id").value.trim();
   const path = goalId ? `/tasks?goal_id=${encodeURIComponent(goalId)}` : "/tasks";
   const tasks = await api(path);
-  renderTasks(tasks);
+  viewCache.tasks = tasks;
+  renderTasks(viewCache.tasks);
 }
 
 async function refreshEvents() {
@@ -502,7 +708,8 @@ async function refreshEvents() {
   if (entityId) params.set("entity_id", entityId);
   const suffix = params.toString() ? `?${params.toString()}` : "";
   const events = await api(`/events${suffix}`);
-  renderEvents(events);
+  viewCache.events = events;
+  renderEvents(viewCache.events);
 }
 
 async function refreshAudit() {
@@ -513,7 +720,8 @@ async function refreshAudit() {
   if (status) params.set("status", status);
   const suffix = params.toString() ? `?${params.toString()}` : "";
   const payload = await api(`/system/audit${suffix}`);
-  renderAudit(payload.entries || []);
+  viewCache.auditEntries = payload.entries || [];
+  renderAudit(viewCache.auditEntries);
 }
 
 function collectFaultFilters() {
@@ -562,7 +770,9 @@ async function refreshFaults() {
     api(`/system/faults${suffix}`),
     api(`/system/faults/summary${suffix}`),
   ]);
-  renderFaults(summaryPayload, entryPayload.entries || []);
+  viewCache.faultSummary = summaryPayload || {};
+  viewCache.faultEntries = entryPayload.entries || [];
+  renderFaults(viewCache.faultSummary, viewCache.faultEntries);
 }
 
 async function refreshFlowTrace() {
@@ -578,7 +788,8 @@ async function refreshFlowTrace() {
 
 async function refreshHealth() {
   const health = await api("/system/health");
-  renderHealth(health);
+  viewCache.health = health;
+  renderHealth(viewCache.health);
 }
 
 async function refreshAll() {
@@ -592,6 +803,25 @@ async function refreshAll() {
     refreshHealth(),
     refreshQueue(),
   ]);
+}
+
+function startAutoRefreshLoop() {
+  if (autoRefreshHandle) {
+    clearInterval(autoRefreshHandle);
+  }
+  autoRefreshHandle = setInterval(() => {
+    if (!autoRefreshEnabled) {
+      return;
+    }
+    refreshGoals().catch(() => {});
+    refreshTasks().catch(() => {});
+    refreshEvents().catch(() => {});
+    refreshFlowTrace().catch(() => {});
+    refreshAudit().catch(() => {});
+    refreshFaults().catch(() => {});
+    refreshHealth().catch(() => {});
+    refreshQueue().catch(() => {});
+  }, AUTO_REFRESH_MS);
 }
 
 async function runOperatorAction(action) {
@@ -798,6 +1028,49 @@ document.getElementById("refresh-flow-trace").addEventListener("click", refreshF
 document.getElementById("refresh-audit").addEventListener("click", refreshAudit);
 document.getElementById("refresh-faults").addEventListener("click", refreshFaults);
 document.getElementById("refresh-queue").addEventListener("click", refreshQueue);
+document.getElementById("global-filter").addEventListener("input", (event) => {
+  globalFilterTerm = String(event.target.value || "").trim().toLowerCase();
+  rerenderFilteredViews();
+  updateToolbarStatus();
+});
+document.getElementById("toggle-refresh").addEventListener("click", async () => {
+  setAutoRefresh(!autoRefreshEnabled);
+  if (autoRefreshEnabled) {
+    await refreshAll();
+  }
+});
+document.getElementById("toggle-density").addEventListener("click", () => {
+  toggleDensityMode();
+});
+
+window.addEventListener("scroll", () => {
+  if (jumpScrollScheduled) {
+    return;
+  }
+  jumpScrollScheduled = true;
+  window.requestAnimationFrame(() => {
+    updateActiveJumpByScroll();
+    jumpScrollScheduled = false;
+  });
+}, { passive: true });
+
+document.addEventListener("keydown", (event) => {
+  if (event.key !== "/") {
+    return;
+  }
+  const target = event.target;
+  const isTextInput = target instanceof HTMLInputElement
+    || target instanceof HTMLTextAreaElement
+    || target instanceof HTMLSelectElement
+    || target?.isContentEditable;
+  if (isTextInput) {
+    return;
+  }
+  event.preventDefault();
+  const filterInput = document.getElementById("global-filter");
+  filterInput?.focus();
+  filterInput?.select();
+});
 
 document.addEventListener("click", async (event) => {
   const goalAction = event.target.dataset.goalAction;
@@ -809,8 +1082,14 @@ document.addEventListener("click", async (event) => {
   const correlation = event.target.dataset.correlation;
   const selectGoal = event.target.dataset.selectGoal;
   const operatorAction = event.target.dataset.operatorAction;
+  const jumpTarget = event.target.dataset.jumpTarget;
 
   try {
+    if (jumpTarget) {
+      jumpToSection(jumpTarget);
+      return;
+    }
+
     if (operatorAction) {
       await runOperatorAction(operatorAction);
     }
@@ -850,6 +1129,7 @@ document.addEventListener("click", async (event) => {
       document.getElementById("event-correlation-id").value = correlation;
       document.getElementById("trace-goal-id").value = correlation.split(":")[0];
       document.getElementById("fault-goal-id").value = correlation.split(":")[0];
+      setActiveJump("events-section");
       await refreshEvents();
       await refreshFlowTrace();
       await refreshFaults();
@@ -861,11 +1141,12 @@ document.addEventListener("click", async (event) => {
       document.getElementById("event-correlation-id").value = selectGoal;
       document.getElementById("trace-goal-id").value = selectGoal;
       document.getElementById("fault-goal-id").value = selectGoal;
+      setActiveJump("goals-section");
       await refreshTasks();
       await refreshEvents();
       await refreshFlowTrace();
       await refreshFaults();
-      document.getElementById("selected-goal-label").textContent = `Selected goal: ${selectGoal}`;
+      updateSelectedGoalLabel();
     }
   } catch (error) {
     const target = operatorAction || faultAction ? "system-feedback" : goalAction ? "goal-error" : "task-error";
@@ -873,14 +1154,14 @@ document.addEventListener("click", async (event) => {
   }
 });
 
+try {
+  const storedDensity = localStorage.getItem("goal_ops_density");
+  setDensityMode(storedDensity === "compact" ? "compact" : "comfy");
+} catch {
+  setDensityMode("comfy");
+}
+setAutoRefresh(true);
+setActiveJump("goals-section");
+updateActiveJumpByScroll();
 refreshAll();
-setInterval(() => {
-  refreshGoals().catch(() => {});
-  refreshTasks().catch(() => {});
-  refreshEvents().catch(() => {});
-  refreshFlowTrace().catch(() => {});
-  refreshAudit().catch(() => {});
-  refreshFaults().catch(() => {});
-  refreshHealth().catch(() => {});
-  refreshQueue().catch(() => {});
-}, 5000);
+startAutoRefreshLoop();

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -164,6 +164,53 @@
       border-color: rgba(32, 117, 90, 0.28);
       background: rgba(232, 248, 242, 0.82);
     }
+    .command-bar {
+      max-width: 1680px;
+      margin: 0.95rem auto 0;
+      display: grid;
+      gap: 0.55rem;
+      padding: 0.68rem 0.75rem;
+      border-radius: 14px;
+      border: 1px solid rgba(29, 26, 22, 0.1);
+      background: rgba(255, 255, 255, 0.7);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.88);
+    }
+    .command-row {
+      display: grid;
+      grid-template-columns: minmax(260px, 1fr) auto auto;
+      gap: 0.5rem;
+      align-items: center;
+    }
+    #global-filter {
+      min-width: 0;
+    }
+    .section-jump {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.45rem;
+    }
+    .jump-btn {
+      border: 1px solid rgba(29, 26, 22, 0.12);
+      background: rgba(255, 255, 255, 0.9);
+      color: #4c4034;
+      box-shadow: none;
+      padding: 0.35rem 0.62rem;
+      font-size: 0.82rem;
+    }
+    .jump-btn:hover {
+      background: #fff4e7;
+      transform: translateY(0);
+    }
+    .jump-btn.active {
+      color: #fff;
+      border-color: rgba(203, 107, 46, 0.8);
+      background: linear-gradient(180deg, #d98951 0%, #c96d33 100%);
+      box-shadow: 0 5px 12px rgba(203, 107, 46, 0.24);
+    }
+    .toolbar-status {
+      margin: 0;
+      font-size: 0.84rem;
+    }
     main {
       padding: 1.3rem;
       display: grid;
@@ -216,6 +263,9 @@
     section:nth-of-type(5) { animation-delay: 160ms; }
     section:nth-of-type(6) { animation-delay: 200ms; }
     .wide { grid-column: 1 / -1; }
+    section[data-section-anchor] {
+      scroll-margin-top: 230px;
+    }
     form {
       display: grid;
       gap: 0.6rem;
@@ -471,6 +521,40 @@
       font-size: 0.85rem;
       color: #6f655b;
     }
+    body.density-compact main {
+      gap: 0.75rem;
+    }
+    body.density-compact section {
+      padding: 0.78rem;
+      border-radius: 16px;
+    }
+    body.density-compact section h2 {
+      margin-bottom: 0.5rem;
+      font-size: 0.98rem;
+    }
+    body.density-compact .entity-card {
+      padding: 0.62rem;
+      gap: 0.45rem;
+      border-radius: 12px;
+    }
+    body.density-compact .grid-two {
+      gap: 0.55rem;
+    }
+    body.density-compact th,
+    body.density-compact td {
+      padding: 0.42rem 0.38rem;
+      font-size: 0.88rem;
+    }
+    body.density-compact input,
+    body.density-compact textarea,
+    body.density-compact select,
+    body.density-compact button {
+      padding: 0.5rem 0.64rem;
+    }
+    body.density-compact .kpi-chip {
+      min-height: 54px;
+      padding: 0.42rem 0.56rem;
+    }
     @keyframes fade-rise {
       from { opacity: 0; transform: translateY(10px); }
       to { opacity: 1; transform: translateY(0); }
@@ -490,6 +574,9 @@
       }
       .kpi-strip {
         grid-template-columns: 1fr 1fr;
+      }
+      .command-row {
+        grid-template-columns: 1fr;
       }
       .split { grid-template-columns: 1fr; }
       .entity-header { flex-direction: column; }
@@ -513,9 +600,26 @@
         <div class="kpi-chip"><span class="meta">Audit 24h</span><strong>...</strong></div>
       </div>
     </div>
+    <div class="command-bar" aria-label="Operator command bar">
+      <div class="command-row">
+        <label class="sr-only" for="global-filter">Global filter</label>
+        <input id="global-filter" placeholder="Global filter across goals, tasks, events, faults and queue (press /)">
+        <button type="button" class="secondary" id="toggle-refresh">Auto-refresh: On</button>
+        <button type="button" class="secondary" id="toggle-density">Density: Comfy</button>
+      </div>
+      <nav class="section-jump" aria-label="Quick jump">
+        <button type="button" class="jump-btn active" data-jump-target="goals-section">Goals</button>
+        <button type="button" class="jump-btn" data-jump-target="tasks-section">Tasks</button>
+        <button type="button" class="jump-btn" data-jump-target="operator-section">Operator</button>
+        <button type="button" class="jump-btn" data-jump-target="events-section">Events</button>
+        <button type="button" class="jump-btn" data-jump-target="faults-section">Faults</button>
+        <button type="button" class="jump-btn" data-jump-target="health-section">Health</button>
+      </nav>
+      <p class="meta toolbar-status" id="toolbar-status" role="status" aria-live="polite">Global filter inactive. Auto-refresh every 5s.</p>
+    </div>
   </header>
   <main id="main-content" tabindex="-1">
-    <section>
+    <section id="goals-section" data-section-anchor="goals">
       <h2><span>Goals Dashboard</span><button class="secondary" id="refresh-goals">Refresh</button></h2>
       <form id="goal-form">
         <label class="sr-only" for="goal-title">Goal title</label>
@@ -537,7 +641,7 @@
       <div id="goals-table"></div>
     </section>
 
-    <section>
+    <section id="tasks-section" data-section-anchor="tasks">
       <h2><span>Task View</span><button class="secondary" id="refresh-tasks">Refresh</button></h2>
       <form id="task-form">
         <label class="sr-only" for="task-goal-id">Goal ID</label>
@@ -550,7 +654,7 @@
       <div id="tasks-table"></div>
     </section>
 
-    <section class="wide">
+    <section class="wide" id="operator-section" data-section-anchor="operator">
       <h2><span>Operator Controls</span><button class="secondary" id="refresh-queue">Refresh Queue</button></h2>
       <div class="grid-two">
         <div class="card">
@@ -584,7 +688,7 @@
       <div id="queue-table"></div>
     </section>
 
-    <section class="wide">
+    <section class="wide" id="events-section" data-section-anchor="events">
       <h2><span>Event Log</span><button class="secondary" id="refresh-events">Refresh</button></h2>
       <form id="event-filter-form">
         <div class="split">
@@ -598,7 +702,7 @@
       <div id="events-table"></div>
     </section>
 
-    <section class="wide">
+    <section class="wide" id="trace-section" data-section-anchor="trace">
       <h2><span>Flow Trace</span><button class="secondary" id="refresh-flow-trace">Refresh</button></h2>
       <form id="flow-trace-form">
         <label class="sr-only" for="trace-goal-id">Goal ID for flow trace</label>
@@ -608,7 +712,7 @@
       <div id="flow-trace"></div>
     </section>
 
-    <section class="wide">
+    <section class="wide" id="audit-section" data-section-anchor="audit">
       <h2><span>Audit Log</span><button class="secondary" id="refresh-audit">Refresh</button></h2>
       <form id="audit-filter-form">
         <div class="split">
@@ -622,7 +726,7 @@
       <div id="audit-table"></div>
     </section>
 
-    <section class="wide">
+    <section class="wide" id="faults-section" data-section-anchor="faults">
       <h2><span>Dead-Letter / Fault Explorer</span><button class="secondary" id="refresh-faults">Refresh</button></h2>
       <div class="toolbar-note">Use filters first, then run single-item remediation or the supervised batch action.</div>
       <form id="fault-filter-form">
@@ -680,7 +784,7 @@
       <div id="fault-table"></div>
     </section>
 
-    <section>
+    <section id="health-section" data-section-anchor="health">
       <h2>System Health</h2>
       <div id="health-cards" class="grid-two"></div>
       <h3>Backpressure</h3>
@@ -699,7 +803,7 @@
       <div id="invariant-violations"></div>
     </section>
 
-    <section>
+    <section id="states-section" data-section-anchor="states">
       <h2>State Machines</h2>
       <div class="status-legend">
         <span class="legend-item"><span class="legend-dot dot-info"></span>queued / pending</span>


### PR DESCRIPTION
## Summary
- add an Operator Command Bar below the header with:
  - global text filter across goals/tasks/events/audit/faults/queue
  - auto-refresh on/off toggle
  - density toggle (comfy/compact)
  - quick jump buttons to major dashboard sections
- add keyboard shortcut `/` to focus the global filter input
- add panel anchor ids + active quick-jump highlighting while scrolling
- make list rendering filter-aware with local cache-based rerendering (without extra API calls per keypress)
- preserve all existing supervised operations workflows and APIs
- document the new command bar capabilities in README

## Validation
- `./scripts/run-tests.ps1` -> `53 passed` (with existing known thread warning)
- FastAPI render smoke check:
  - `TestClient(create_app(...)).get("/")` -> `200`
  - confirms `global-filter`, `toggle-refresh`, `toggle-density` present
