### PR TITLE
[codex] Add desktop artifact build workflow

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -1,0 +1,104 @@
+name: Desktop Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Build mode to run
+        required: true
+        type: choice
+        default: both
+        options:
+          - onedir
+          - onefile
+          - both
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: desktop-build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  package:
+    name: Windows Desktop Artifact
+    runs-on: windows-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install desktop build dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[desktop,desktop-build]"
+
+      - name: Resolve build modes
+        id: modes
+        shell: pwsh
+        run: |
+          $modeInput = "${{ github.event.inputs.mode }}"
+          if ([string]::IsNullOrWhiteSpace($modeInput)) {
+            $modeInput = "both"
+          }
+          if ($modeInput -eq "both") {
+            "modes=onedir,onefile" >> $env:GITHUB_OUTPUT
+          } else {
+            "modes=$modeInput" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Build desktop onedir
+        if: contains(steps.modes.outputs.modes, 'onedir')
+        shell: pwsh
+        run: |
+          .\scripts\build-desktop.ps1 -Mode onedir -Name GoalOpsConsole -Clean
+
+      - name: Build desktop onefile
+        if: contains(steps.modes.outputs.modes, 'onefile')
+        shell: pwsh
+        run: |
+          .\scripts\build-desktop.ps1 -Mode onefile -Name GoalOpsConsole -Clean
+
+      - name: Stage desktop artifacts
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path artifacts -Force | Out-Null
+
+          if (Test-Path -LiteralPath "dist/GoalOpsConsole/GoalOpsConsole.exe") {
+            Compress-Archive -Path "dist/GoalOpsConsole/*" -DestinationPath "artifacts/GoalOpsConsole-onedir.zip" -Force
+          }
+
+          if (Test-Path -LiteralPath "dist/GoalOpsConsole.exe") {
+            Copy-Item -LiteralPath "dist/GoalOpsConsole.exe" -Destination "artifacts/GoalOpsConsole-onefile.exe" -Force
+          }
+
+      - name: Generate checksums
+        shell: pwsh
+        run: |
+          $files = Get-ChildItem -LiteralPath artifacts -File
+          if (-not $files) {
+            throw "No desktop artifacts were produced."
+          }
+          $lines = @()
+          foreach ($file in $files) {
+            $hash = Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256
+            $lines += "$($hash.Hash)  $($file.Name)"
+          }
+          $lines | Set-Content -LiteralPath "artifacts/SHA256SUMS.txt"
+
+      - name: Upload desktop artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-${{ github.run_number }}
+          path: artifacts/*
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -124,6 +124,21 @@ Note:
 - `pywebview` on Windows requires WebView2 runtime.
 - In `onefile` mode startup can be slower because the executable self-extracts before launch.
 
+## Desktop Build In GitHub Actions
+
+Desktop artifacts can now be built in CI via workflow:
+
+- [desktop-build.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/desktop-build.yml)
+
+Triggers:
+- manual run (`workflow_dispatch`) with mode: `onedir`, `onefile`, or `both`
+- push of tags matching `v*` (for release-style builds)
+
+Published artifacts:
+- `GoalOpsConsole-onedir.zip` (if `onedir` was built)
+- `GoalOpsConsole-onefile.exe` (if `onefile` was built)
+- `SHA256SUMS.txt` (checksums for uploaded files)
+
 ## Stop And Restart
 
 Stop the server in the terminal where `uvicorn` is running:
@@ -298,6 +313,9 @@ GitHub Actions now runs `pytest` automatically for:
 
 Workflow file:
 [ci.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/ci.yml)
+
+Desktop workflow file:
+[desktop-build.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/desktop-build.yml)
 
 Recommended branch protection on `master`:
 


### PR DESCRIPTION
## Summary
- add a new GitHub Actions workflow `.github/workflows/desktop-build.yml` to build Windows desktop artifacts
- support manual runs with `mode` (`onedir`, `onefile`, `both`) and tag-triggered runs for `v*`
- package outputs (`GoalOpsConsole-onedir.zip`, `GoalOpsConsole-onefile.exe`) and publish `SHA256SUMS.txt`
- document the new desktop CI workflow in `README.md`

## Validation
- local tests: `./scripts/run-tests.ps1` (53 passed)