### PR TITLE
[codex] Add multi-preset UI polish modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ The dashboard header now includes a command bar for faster operator workflows:
 - Keyboard shortcut `/` focuses the global filter input.
 - `Auto-refresh` toggle pauses or resumes the 5-second refresh loop.
 - `Density` toggle switches between `Comfy` and `Compact` layout.
-- `Quick jump` buttons scroll directly to major panels (`Goals`, `Tasks`, `Operator`, `Events`, `Faults`, `Health`).
+- `Visual` toggle cycles through `Warm`, `Graphite`, and `Signal` presets.
+- `Quick jump` buttons scroll directly to major panels (`Goals`, `Tasks`, `Operator`, `Events`, `Trace`, `Audit`, `Faults`, `Health`, `States`).
 
 ## Build Windows Desktop EXE (Preview)
 
@@ -260,7 +261,7 @@ The dashboard now includes an `Operator Controls` section for supervised Phase 2
 - `Metrics Hooks` (in System Health)
   Shows live instrumentation counters for HTTP traffic, transitions, events and throttling.
 - `Visual Mode` (new toggle in command bar)
-  Switches UI styling between `Warm` and `Graphite` while keeping all workflows identical.
+  Cycles UI styling across `Warm`, `Graphite`, and `Signal` while keeping all workflows identical.
 - `Quick Jump` (extended)
   Includes direct jumps for `Trace`, `Audit`, and `States` sections.
 

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -12,6 +12,23 @@ const SECTION_IDS = [
   "health-section",
   "states-section",
 ];
+const VISUAL_PRESETS = [
+  {
+    id: "warm",
+    label: "Warm",
+    className: "",
+  },
+  {
+    id: "graphite",
+    label: "Graphite",
+    className: "visual-graphite",
+  },
+  {
+    id: "signal",
+    label: "Signal",
+    className: "visual-signal",
+  },
+];
 
 let selectedGoalId = "";
 let defaultConsumerId = "goal_ops_console";
@@ -150,7 +167,8 @@ function updateToolbarStatus() {
     ? `Auto-refresh every ${AUTO_REFRESH_MS / 1000}s.`
     : "Auto-refresh paused.";
   const densityPart = `Density: ${densityMode}.`;
-  const visualPart = `Visual: ${visualMode}.`;
+  const activeVisualPreset = VISUAL_PRESETS.find((preset) => preset.id === visualMode) || VISUAL_PRESETS[0];
+  const visualPart = `Visual: ${activeVisualPreset.label}.`;
   status.textContent = `${filterPart} ${refreshPart} ${densityPart} ${visualPart}`;
 }
 
@@ -174,11 +192,19 @@ function toggleDensityMode() {
 }
 
 function setVisualMode(mode) {
-  visualMode = mode === "graphite" ? "graphite" : "warm";
-  document.body.classList.toggle("visual-graphite", visualMode === "graphite");
+  const preset = VISUAL_PRESETS.find((item) => item.id === mode) || VISUAL_PRESETS[0];
+  visualMode = preset.id;
+  VISUAL_PRESETS.forEach((item) => {
+    if (item.className) {
+      document.body.classList.remove(item.className);
+    }
+  });
+  if (preset.className) {
+    document.body.classList.add(preset.className);
+  }
   const toggleButton = document.getElementById("toggle-visual-mode");
   if (toggleButton) {
-    toggleButton.textContent = `Visual: ${visualMode === "graphite" ? "Graphite" : "Warm"}`;
+    toggleButton.textContent = `Visual: ${preset.label}`;
   }
   try {
     localStorage.setItem("goal_ops_visual_mode", visualMode);
@@ -189,7 +215,11 @@ function setVisualMode(mode) {
 }
 
 function toggleVisualMode() {
-  setVisualMode(visualMode === "graphite" ? "warm" : "graphite");
+  const currentIndex = VISUAL_PRESETS.findIndex((preset) => preset.id === visualMode);
+  const nextIndex = currentIndex >= 0
+    ? (currentIndex + 1) % VISUAL_PRESETS.length
+    : 0;
+  setVisualMode(VISUAL_PRESETS[nextIndex].id);
 }
 
 function setAutoRefresh(enabled) {
@@ -1189,7 +1219,7 @@ try {
 }
 try {
   const storedVisualMode = localStorage.getItem("goal_ops_visual_mode");
-  setVisualMode(storedVisualMode === "graphite" ? "graphite" : "warm");
+  setVisualMode(storedVisualMode);
 } catch {
   setVisualMode("warm");
 }

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -77,6 +77,8 @@
       transition: background 280ms ease, color 220ms ease;
     }
     body.visual-graphite {
+      --font-display: "Segoe UI Variable Display", "Segoe UI Semibold", "Trebuchet MS", sans-serif;
+      --font-body: "Segoe UI Variable", "Segoe UI", "Candara", sans-serif;
       --bg: #edf4fb;
       --panel: #f7fbff;
       --ink: #162538;
@@ -99,6 +101,32 @@
       --header-glow-2: rgba(228, 241, 251, 0.88);
       --header-glow-3: rgba(236, 249, 241, 0.84);
       --grid-overlay: rgba(255, 255, 255, 0.16);
+    }
+    body.visual-signal {
+      --font-display: "Rockwell", "Cambria", "Bahnschrift", sans-serif;
+      --font-body: "Franklin Gothic Book", "Gill Sans MT", "Segoe UI", sans-serif;
+      --bg: #f6f4f1;
+      --panel: #faf8f6;
+      --ink: #1f2329;
+      --muted: #5b626d;
+      --line: #c9ced6;
+      --accent: #b64f2e;
+      --accent-soft: #f3ddd4;
+      --good: #1f6f54;
+      --warn: #b56d17;
+      --bad: #bb3838;
+      --info: #2f6389;
+      --focus: rgba(182, 79, 46, 0.24);
+      --bg-glow-1: rgba(170, 115, 84, 0.24);
+      --bg-glow-2: rgba(95, 145, 188, 0.2);
+      --bg-glow-3: rgba(250, 205, 146, 0.22);
+      --bg-tone-1: #f4f2ef;
+      --bg-tone-2: #e5e8ed;
+      --bg-tone-3: #d9dee5;
+      --header-glow-1: rgba(251, 249, 247, 0.96);
+      --header-glow-2: rgba(240, 244, 249, 0.9);
+      --header-glow-3: rgba(234, 240, 248, 0.86);
+      --grid-overlay: rgba(255, 255, 255, 0.14);
     }
     body::before {
       content: "";
@@ -267,6 +295,44 @@
     body.visual-graphite pre {
       background: #edf5fb;
       color: #2a3f51;
+    }
+    body.visual-signal .eyebrow {
+      color: #783f2d;
+      border-color: rgba(120, 63, 45, 0.28);
+      background: rgba(255, 248, 243, 0.88);
+      letter-spacing: 0.1em;
+    }
+    body.visual-signal .jump-btn:hover {
+      background: #f7e8e1;
+    }
+    body.visual-signal .jump-btn.active {
+      border-color: rgba(182, 79, 46, 0.85);
+      background: linear-gradient(180deg, #c97652 0%, #b64f2e 100%);
+      box-shadow: 0 6px 14px rgba(182, 79, 46, 0.24);
+    }
+    body.visual-signal main {
+      gap: 1.2rem;
+      padding-top: 1.5rem;
+    }
+    body.visual-signal section {
+      border-radius: 14px;
+      border-top-width: 3px;
+      box-shadow: 0 22px 34px rgba(53, 59, 69, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.88);
+    }
+    body.visual-signal section h2 {
+      letter-spacing: 0.03em;
+      font-size: 1rem;
+    }
+    body.visual-signal button {
+      border-radius: 9px;
+    }
+    body.visual-signal .entity-card,
+    body.visual-signal .card,
+    body.visual-signal .kpi-chip {
+      border-radius: 11px;
+    }
+    body.visual-signal .priority-fill {
+      background: linear-gradient(90deg, #d59d79 0%, #b64f2e 100%);
     }
     .toolbar-status {
       margin: 0;


### PR DESCRIPTION
## Summary
- extend the command-bar visual mode from 2 to 3 presets: `Warm`, `Graphite`, `Signal`
- cycle presets with one button while persisting selection in local storage
- apply distinct typography and spacing polish for each preset through CSS variables and targeted layout refinements
- update README command-bar documentation and operator-controls feature notes

## Validation
- local tests: `./scripts/run-tests.ps1` (53 passed)