### PR TITLE
[codex] Add desktop-first window and shortcut UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,16 @@ Optional startup parameters:
 ```powershell
 .\scripts\start-desktop.ps1 -DatabaseUrl "goal_ops.db" -Width 1600 -Height 1000
 .\scripts\start-desktop.ps1 -Port 8010
+.\scripts\start-desktop.ps1 -Maximized
+.\scripts\start-desktop.ps1 -MinWidth 1200 -MinHeight 800
+.\scripts\start-desktop.ps1 -NoWindowState
+.\scripts\start-desktop.ps1 -WindowStatePath ".\custom-window-state.json"
 ```
 
 Behavior:
 - starts an embedded local FastAPI server (`127.0.0.1`)
 - opens the same dashboard UI in a native window via `pywebview`
+- remembers window size/position across launches (disable with `-NoWindowState`)
 - shuts down the embedded server when the desktop window closes
 
 ## Operator Command Bar (UI)
@@ -86,6 +91,7 @@ The dashboard header now includes a command bar for faster operator workflows:
 - `Density` toggle switches between `Comfy` and `Compact` layout.
 - `Visual` toggle cycles through `Warm`, `Graphite`, and `Signal` presets.
 - `Quick jump` buttons scroll directly to major panels (`Goals`, `Tasks`, `Operator`, `Events`, `Trace`, `Audit`, `Faults`, `Health`, `States`).
+- Desktop mode shortcuts: `Ctrl+1/2/3` (preset), `Ctrl+Shift+F` (focus global filter), `Ctrl+Shift+R` (manual refresh).
 
 ## Build Windows Desktop EXE (Preview)
 

--- a/goal_ops_console/desktop.py
+++ b/goal_ops_console/desktop.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import argparse
+import json
 import socket
 import threading
 import time
 import urllib.error
 import urllib.request
+from pathlib import Path
 from typing import Any
 
 from uvicorn import Config, Server
@@ -37,6 +39,92 @@ def _wait_until_ready(url: str, timeout_seconds: float = 15.0) -> None:
     raise RuntimeError(f"Desktop server did not become ready at {url}")
 
 
+def _default_window_state_path() -> Path:
+    return Path.home() / ".goal_ops_console" / "window_state.json"
+
+
+def _coerce_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _load_window_state(
+    *,
+    path: Path,
+    width: int,
+    height: int,
+    min_width: int,
+    min_height: int,
+    start_maximized: bool,
+) -> dict[str, Any]:
+    defaults = {
+        "width": max(min_width, int(width)),
+        "height": max(min_height, int(height)),
+        "x": None,
+        "y": None,
+        "maximized": bool(start_maximized),
+    }
+    if not path.exists():
+        return defaults
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError):
+        return defaults
+
+    if not isinstance(payload, dict):
+        return defaults
+
+    loaded_width = _coerce_int(payload.get("width"))
+    loaded_height = _coerce_int(payload.get("height"))
+    loaded_x = _coerce_int(payload.get("x"))
+    loaded_y = _coerce_int(payload.get("y"))
+
+    return {
+        "width": max(min_width, loaded_width) if loaded_width is not None else defaults["width"],
+        "height": max(min_height, loaded_height) if loaded_height is not None else defaults["height"],
+        "x": loaded_x,
+        "y": loaded_y,
+        "maximized": bool(payload.get("maximized", defaults["maximized"])),
+    }
+
+
+def _capture_window_state(
+    *,
+    window: Any,
+    min_width: int,
+    min_height: int,
+    maximized: bool,
+) -> dict[str, Any]:
+    raw_width = _coerce_int(getattr(window, "width", None))
+    raw_height = _coerce_int(getattr(window, "height", None))
+
+    return {
+        "width": max(min_width, raw_width if raw_width is not None else min_width),
+        "height": max(min_height, raw_height if raw_height is not None else min_height),
+        "x": _coerce_int(getattr(window, "x", None)),
+        "y": _coerce_int(getattr(window, "y", None)),
+        "maximized": bool(maximized),
+    }
+
+
+def _save_window_state(*, path: Path, state: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, ensure_ascii=True, indent=2), encoding="utf-8")
+
+
+def _register_window_event(events: Any, event_name: str, callback: Any) -> None:
+    event = getattr(events, event_name, None)
+    if event is None:
+        return
+    try:
+        event += callback
+    except Exception:
+        return
+
+
 def run_desktop(
     *,
     database_url: str,
@@ -44,9 +132,36 @@ def run_desktop(
     port: int | None = None,
     width: int = 1440,
     height: int = 900,
+    min_width: int = 1024,
+    min_height: int = 720,
+    start_maximized: bool = False,
+    remember_window: bool = True,
+    window_state_path: str | None = None,
     window_title: str = "Goal Ops Console",
     debug: bool = False,
 ) -> None:
+    safe_min_width = max(640, int(min_width))
+    safe_min_height = max(480, int(min_height))
+    state_path = Path(window_state_path).expanduser() if window_state_path else _default_window_state_path()
+    initial_state = (
+        _load_window_state(
+            path=state_path,
+            width=width,
+            height=height,
+            min_width=safe_min_width,
+            min_height=safe_min_height,
+            start_maximized=start_maximized,
+        )
+        if remember_window
+        else {
+            "width": max(safe_min_width, int(width)),
+            "height": max(safe_min_height, int(height)),
+            "x": None,
+            "y": None,
+            "maximized": bool(start_maximized),
+        }
+    )
+
     selected_port = _pick_port(host, port)
     app = create_app(Settings(database_url=database_url))
     server = Server(
@@ -60,7 +175,7 @@ def run_desktop(
     server_thread = threading.Thread(target=server.run, daemon=True, name="goal-ops-desktop-server")
     server_thread.start()
 
-    url = f"http://{host}:{selected_port}/"
+    url = f"http://{host}:{selected_port}/?desktop=1"
     try:
         _wait_until_ready(url)
 
@@ -72,15 +187,51 @@ def run_desktop(
                 "python -m pip install \"goal-ops-console[desktop]\""
             ) from exc
 
-        webview.create_window(
-            title=window_title,
-            url=url,
-            width=width,
-            height=height,
-            min_size=(1024, 720),
-            text_select=True,
-        )
-        webview.start(debug=debug)
+        create_kwargs: dict[str, Any] = {
+            "title": window_title,
+            "url": url,
+            "width": initial_state["width"],
+            "height": initial_state["height"],
+            "min_size": (safe_min_width, safe_min_height),
+            "text_select": True,
+        }
+        if initial_state["x"] is not None and initial_state["y"] is not None:
+            create_kwargs["x"] = initial_state["x"]
+            create_kwargs["y"] = initial_state["y"]
+
+        window = webview.create_window(**create_kwargs)
+
+        maximize_state = {"maximized": bool(initial_state["maximized"])}
+        events = getattr(window, "events", None)
+        if events is not None:
+            _register_window_event(events, "maximized", lambda *_args, **_kwargs: maximize_state.update(maximized=True))
+            _register_window_event(events, "restored", lambda *_args, **_kwargs: maximize_state.update(maximized=False))
+
+            if remember_window:
+                def _persist_window_state(*_args: Any, **_kwargs: Any) -> None:
+                    try:
+                        state = _capture_window_state(
+                            window=window,
+                            min_width=safe_min_width,
+                            min_height=safe_min_height,
+                            maximized=maximize_state["maximized"],
+                        )
+                        _save_window_state(path=state_path, state=state)
+                    except OSError:
+                        return
+
+                _register_window_event(events, "closing", _persist_window_state)
+
+        def _on_webview_start(window_ref: Any) -> None:
+            if maximize_state["maximized"]:
+                maximize = getattr(window_ref, "maximize", None)
+                if callable(maximize):
+                    try:
+                        maximize()
+                    except Exception:
+                        return
+
+        webview.start(_on_webview_start, window, debug=debug)
     finally:
         server.should_exit = True
         server_thread.join(timeout=5.0)
@@ -117,6 +268,33 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Desktop window height.",
     )
     parser.add_argument(
+        "--min-width",
+        type=int,
+        default=1024,
+        help="Minimum desktop window width.",
+    )
+    parser.add_argument(
+        "--min-height",
+        type=int,
+        default=720,
+        help="Minimum desktop window height.",
+    )
+    parser.add_argument(
+        "--maximized",
+        action="store_true",
+        help="Open the desktop window maximized.",
+    )
+    parser.add_argument(
+        "--window-state-path",
+        default=None,
+        help="Optional JSON file path used to persist desktop window position/size.",
+    )
+    parser.add_argument(
+        "--no-window-state",
+        action="store_true",
+        help="Disable persistent desktop window state.",
+    )
+    parser.add_argument(
         "--title",
         default="Goal Ops Console",
         help="Desktop window title.",
@@ -138,6 +316,11 @@ def main(argv: list[str] | None = None) -> int:
             port=(args.port if args.port > 0 else None),
             width=args.width,
             height=args.height,
+            min_width=args.min_width,
+            min_height=args.min_height,
+            start_maximized=args.maximized,
+            remember_window=(not args.no_window_state),
+            window_state_path=args.window_state_path,
             window_title=args.title,
             debug=args.debug,
         )

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -12,6 +12,7 @@ const SECTION_IDS = [
   "health-section",
   "states-section",
 ];
+const IS_DESKTOP_MODE = new URLSearchParams(window.location.search).get("desktop") === "1";
 const VISUAL_PRESETS = [
   {
     id: "warm",
@@ -169,7 +170,10 @@ function updateToolbarStatus() {
   const densityPart = `Density: ${densityMode}.`;
   const activeVisualPreset = VISUAL_PRESETS.find((preset) => preset.id === visualMode) || VISUAL_PRESETS[0];
   const visualPart = `Visual: ${activeVisualPreset.label}.`;
-  status.textContent = `${filterPart} ${refreshPart} ${densityPart} ${visualPart}`;
+  const desktopPart = IS_DESKTOP_MODE
+    ? "Desktop shortcuts: Ctrl+1/2/3 visual, Ctrl+Shift+F filter, Ctrl+Shift+R refresh."
+    : "";
+  status.textContent = `${filterPart} ${refreshPart} ${densityPart} ${visualPart}${desktopPart ? ` ${desktopPart}` : ""}`;
 }
 
 function setDensityMode(mode) {
@@ -1100,6 +1104,41 @@ document.getElementById("toggle-visual-mode").addEventListener("click", () => {
   toggleVisualMode();
 });
 
+function isTextInputTarget(target) {
+  return target instanceof HTMLInputElement
+    || target instanceof HTMLTextAreaElement
+    || target instanceof HTMLSelectElement
+    || target?.isContentEditable;
+}
+
+function handleDesktopShortcut(event) {
+  if (!IS_DESKTOP_MODE || !event.ctrlKey || event.altKey) {
+    return false;
+  }
+  const key = String(event.key || "").toLowerCase();
+  if (event.shiftKey && key === "f") {
+    event.preventDefault();
+    const filterInput = document.getElementById("global-filter");
+    filterInput?.focus();
+    filterInput?.select();
+    return true;
+  }
+  if (event.shiftKey && key === "r") {
+    event.preventDefault();
+    refreshAll().catch((error) => {
+      showError("system-feedback", error);
+    });
+    return true;
+  }
+  if (!event.shiftKey && ["1", "2", "3"].includes(key) && !isTextInputTarget(event.target)) {
+    event.preventDefault();
+    const presetByShortcut = { "1": "warm", "2": "graphite", "3": "signal" };
+    setVisualMode(presetByShortcut[key]);
+    return true;
+  }
+  return false;
+}
+
 window.addEventListener("scroll", () => {
   if (jumpScrollScheduled) {
     return;
@@ -1112,15 +1151,13 @@ window.addEventListener("scroll", () => {
 }, { passive: true });
 
 document.addEventListener("keydown", (event) => {
+  if (handleDesktopShortcut(event)) {
+    return;
+  }
   if (event.key !== "/") {
     return;
   }
-  const target = event.target;
-  const isTextInput = target instanceof HTMLInputElement
-    || target instanceof HTMLTextAreaElement
-    || target instanceof HTMLSelectElement
-    || target?.isContentEditable;
-  if (isTextInput) {
+  if (isTextInputTarget(event.target)) {
     return;
   }
   event.preventDefault();

--- a/scripts/start-desktop.ps1
+++ b/scripts/start-desktop.ps1
@@ -2,7 +2,12 @@ param(
     [string]$DatabaseUrl = "goal_ops.db",
     [int]$Port = 0,
     [int]$Width = 1440,
-    [int]$Height = 900
+    [int]$Height = 900,
+    [int]$MinWidth = 1024,
+    [int]$MinHeight = 720,
+    [switch]$Maximized,
+    [switch]$NoWindowState,
+    [string]$WindowStatePath = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -24,10 +29,21 @@ $args = @(
     "-m", "goal_ops_console.desktop",
     "--database-url", $DatabaseUrl,
     "--width", $Width,
-    "--height", $Height
+    "--height", $Height,
+    "--min-width", $MinWidth,
+    "--min-height", $MinHeight
 )
 if ($Port -gt 0) {
     $args += @("--port", $Port)
+}
+if ($Maximized) {
+    $args += "--maximized"
+}
+if ($NoWindowState) {
+    $args += "--no-window-state"
+}
+if (-not [string]::IsNullOrWhiteSpace($WindowStatePath)) {
+    $args += @("--window-state-path", $WindowStatePath)
 }
 
 python @args

--- a/tests/test_desktop_launcher.py
+++ b/tests/test_desktop_launcher.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import json
+import shutil
+import time
+from pathlib import Path
+
 import goal_ops_console.desktop as desktop
 
 
@@ -20,8 +25,118 @@ def test_parse_args_defaults():
     assert args.port == 0
     assert args.width == 1440
     assert args.height == 900
+    assert args.min_width == 1024
+    assert args.min_height == 720
+    assert args.maximized is False
+    assert args.window_state_path is None
+    assert args.no_window_state is False
     assert args.title == "Goal Ops Console"
     assert args.debug is False
+
+
+def _local_test_dir() -> Path:
+    base = Path(".tmp") / "pytest-local-window-state"
+    base.mkdir(parents=True, exist_ok=True)
+    target = base / f"case-{time.time_ns()}"
+    target.mkdir(parents=True, exist_ok=False)
+    return target
+
+
+def test_load_window_state_uses_defaults_when_file_missing():
+    test_dir = _local_test_dir()
+    try:
+        state = desktop._load_window_state(
+            path=test_dir / "missing.json",
+            width=1400,
+            height=880,
+            min_width=1024,
+            min_height=720,
+            start_maximized=False,
+        )
+        assert state["width"] == 1400
+        assert state["height"] == 880
+        assert state["x"] is None
+        assert state["y"] is None
+        assert state["maximized"] is False
+    finally:
+        shutil.rmtree(test_dir, ignore_errors=True)
+
+
+def test_load_window_state_reads_saved_geometry():
+    test_dir = _local_test_dir()
+    try:
+        state_file = test_dir / "window_state.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    "width": 1600,
+                    "height": 1000,
+                    "x": 120,
+                    "y": 80,
+                    "maximized": True,
+                }
+            ),
+            encoding="utf-8",
+        )
+        state = desktop._load_window_state(
+            path=state_file,
+            width=1300,
+            height=820,
+            min_width=1024,
+            min_height=720,
+            start_maximized=False,
+        )
+        assert state["width"] == 1600
+        assert state["height"] == 1000
+        assert state["x"] == 120
+        assert state["y"] == 80
+        assert state["maximized"] is True
+    finally:
+        shutil.rmtree(test_dir, ignore_errors=True)
+
+
+def test_capture_window_state_applies_minimums():
+    class _Window:
+        width = 800
+        height = 640
+        x = 50
+        y = 40
+
+    state = desktop._capture_window_state(
+        window=_Window(),
+        min_width=1024,
+        min_height=720,
+        maximized=False,
+    )
+    assert state["width"] == 1024
+    assert state["height"] == 720
+    assert state["x"] == 50
+    assert state["y"] == 40
+    assert state["maximized"] is False
+
+
+def test_save_window_state_writes_json():
+    test_dir = _local_test_dir()
+    try:
+        state_file = test_dir / "nested" / "window_state.json"
+        desktop._save_window_state(
+            path=state_file,
+            state={
+                "width": 1200,
+                "height": 800,
+                "x": 30,
+                "y": 40,
+                "maximized": False,
+            },
+        )
+        payload = json.loads(state_file.read_text(encoding="utf-8"))
+        assert payload["width"] == 1200
+        assert payload["height"] == 800
+        assert payload["x"] == 30
+        assert payload["y"] == 40
+        assert payload["maximized"] is False
+    finally:
+        shutil.rmtree(test_dir, ignore_errors=True)
 
 
 def test_main_returns_nonzero_when_launch_fails(monkeypatch, capsys):
@@ -53,6 +168,13 @@ def test_main_maps_port_zero_to_none(monkeypatch):
             "1200",
             "--height",
             "800",
+            "--min-width",
+            "1100",
+            "--min-height",
+            "760",
+            "--maximized",
+            "--window-state-path",
+            "demo-window-state.json",
             "--title",
             "Demo",
             "--debug",
@@ -64,6 +186,11 @@ def test_main_maps_port_zero_to_none(monkeypatch):
     assert captured_kwargs["port"] is None
     assert captured_kwargs["width"] == 1200
     assert captured_kwargs["height"] == 800
+    assert captured_kwargs["min_width"] == 1100
+    assert captured_kwargs["min_height"] == 760
+    assert captured_kwargs["start_maximized"] is True
+    assert captured_kwargs["window_state_path"] == "demo-window-state.json"
+    assert captured_kwargs["remember_window"] is True
     assert captured_kwargs["window_title"] == "Demo"
     assert captured_kwargs["debug"] is True
 
@@ -79,3 +206,16 @@ def test_main_passes_explicit_port(monkeypatch):
 
     assert exit_code == 0
     assert captured_kwargs["port"] == 8124
+
+
+def test_main_can_disable_window_state(monkeypatch):
+    captured_kwargs = {}
+
+    def _fake_run_desktop(**kwargs):
+        captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr(desktop, "run_desktop", _fake_run_desktop)
+    exit_code = desktop.main(["--database-url", "demo.db", "--no-window-state"])
+
+    assert exit_code == 0
+    assert captured_kwargs["remember_window"] is False


### PR DESCRIPTION
## Summary
- add desktop-first shell behavior with persistent window state (size/position/maximized) and optional custom state path
- extend desktop launcher options (`--min-width`, `--min-height`, `--maximized`, `--window-state-path`, `--no-window-state`)
- add desktop-mode URL flag and operator shortcuts (`Ctrl+1/2/3`, `Ctrl+Shift+F`, `Ctrl+Shift+R`) in the dashboard
- document desktop startup and shortcut behavior in README
- expand desktop launcher tests for state handling and new CLI mapping

## Validation
- local tests: `./scripts/run-tests.ps1` (58 passed)