### PR TITLE
[codex] Add desktop distribution packaging polish

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -69,32 +69,35 @@ jobs:
         run: |
           .\scripts\build-desktop.ps1 -Mode onefile -Name GoalOpsConsole -Clean
 
-      - name: Stage desktop artifacts
+      - name: Resolve release metadata
+        id: release
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Path artifacts -Force | Out-Null
-
-          if (Test-Path -LiteralPath "dist/GoalOpsConsole/GoalOpsConsole.exe") {
-            Compress-Archive -Path "dist/GoalOpsConsole/*" -DestinationPath "artifacts/GoalOpsConsole-onedir.zip" -Force
+          $modeInput = "${{ github.event.inputs.mode }}"
+          if ([string]::IsNullOrWhiteSpace($modeInput)) {
+            $modeInput = "both"
           }
 
-          if (Test-Path -LiteralPath "dist/GoalOpsConsole.exe") {
-            Copy-Item -LiteralPath "dist/GoalOpsConsole.exe" -Destination "artifacts/GoalOpsConsole-onefile.exe" -Force
+          $channel = "snapshot"
+          $version = "0.1.0-ci.$env:GITHUB_RUN_NUMBER"
+          if ($env:GITHUB_REF -like "refs/tags/v*") {
+            $channel = "stable"
+            $version = $env:GITHUB_REF.Substring("refs/tags/v".Length)
           }
 
-      - name: Generate checksums
+          "package_mode=$modeInput" >> $env:GITHUB_OUTPUT
+          "channel=$channel" >> $env:GITHUB_OUTPUT
+          "version=$version" >> $env:GITHUB_OUTPUT
+
+      - name: Package desktop release artifacts
         shell: pwsh
         run: |
-          $files = Get-ChildItem -LiteralPath artifacts -File
-          if (-not $files) {
-            throw "No desktop artifacts were produced."
-          }
-          $lines = @()
-          foreach ($file in $files) {
-            $hash = Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256
-            $lines += "$($hash.Hash)  $($file.Name)"
-          }
-          $lines | Set-Content -LiteralPath "artifacts/SHA256SUMS.txt"
+          .\scripts\package-desktop-release.ps1 `
+            -Name GoalOpsConsole `
+            -Version "${{ steps.release.outputs.version }}" `
+            -Channel "${{ steps.release.outputs.channel }}" `
+            -Mode "${{ steps.release.outputs.package_mode }}" `
+            -OutputDir "artifacts"
 
       - name: Upload desktop artifacts
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -114,6 +114,25 @@ Build `onefile`:
 .\scripts\build-desktop.ps1 -Mode onefile
 ```
 
+Package a desktop distribution bundle (release-ready artifacts):
+
+```powershell
+.\scripts\package-desktop-release.ps1 -Version "0.1.0" -Channel stable -Mode both -OutputDir artifacts
+```
+
+Optional signing during packaging:
+
+```powershell
+.\scripts\package-desktop-release.ps1 `
+  -Version "0.1.0" `
+  -Channel stable `
+  -Mode both `
+  -Sign `
+  -SignToolPath "C:\Program Files (x86)\Windows Kits\10\bin\x64\signtool.exe" `
+  -CertThumbprint "<CERT_THUMBPRINT>" `
+  -TimeStampUrl "http://timestamp.digicert.com"
+```
+
 Optional:
 
 ```powershell
@@ -126,6 +145,13 @@ Optional:
 Output paths:
 - `onedir`: `dist\GoalOpsConsole\GoalOpsConsole.exe`
 - `onefile`: `dist\GoalOpsConsole.exe`
+
+Distribution bundle outputs (via `package-desktop-release.ps1`):
+- `GoalOpsConsole-onedir-<version>.zip`
+- `GoalOpsConsole-onefile-<version>.exe`
+- `GoalOpsConsole-install-<version>.ps1` (portable installer script)
+- `desktop-update-manifest.json` (auto-update feed preparation)
+- `SHA256SUMS.txt`
 
 Note:
 - `pywebview` on Windows requires WebView2 runtime.
@@ -142,8 +168,10 @@ Triggers:
 - push of tags matching `v*` (for release-style builds)
 
 Published artifacts:
-- `GoalOpsConsole-onedir.zip` (if `onedir` was built)
-- `GoalOpsConsole-onefile.exe` (if `onefile` was built)
+- `GoalOpsConsole-onedir-<version>.zip` (if `onedir` was built)
+- `GoalOpsConsole-onefile-<version>.exe` (if `onefile` was built)
+- `GoalOpsConsole-install-<version>.ps1` (if `onefile` was built)
+- `desktop-update-manifest.json` (version/channel + artifact hashes)
 - `SHA256SUMS.txt` (checksums for uploaded files)
 
 ## Stop And Restart
@@ -458,6 +486,7 @@ If a value is rejected:
 - [start-server.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/start-server.ps1)
 - [start-desktop.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/start-desktop.ps1)
 - [build-desktop.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/build-desktop.ps1)
+- [package-desktop-release.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/package-desktop-release.ps1)
 - [reset-db.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/reset-db.ps1)
 - [run-tests.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-tests.ps1)
 - [test_goal_ops.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_goal_ops.py)

--- a/scripts/package-desktop-release.ps1
+++ b/scripts/package-desktop-release.ps1
@@ -1,0 +1,190 @@
+param(
+    [string]$Name = "GoalOpsConsole",
+    [string]$Version = "0.1.0-dev",
+    [ValidateSet("snapshot", "stable", "beta")]
+    [string]$Channel = "snapshot",
+    [ValidateSet("onedir", "onefile", "both")]
+    [string]$Mode = "both",
+    [string]$OutputDir = "artifacts",
+    [string]$BaseDownloadUrl = "",
+    [switch]$Sign,
+    [string]$SignToolPath = "signtool.exe",
+    [string]$CertThumbprint = "",
+    [string]$TimeStampUrl = "http://timestamp.digicert.com"
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$safeVersion = ($Version -replace "[^0-9A-Za-z\.\-_]", "-")
+$resolvedOutputDir = Join-Path $ProjectRoot $OutputDir
+$oneDirRoot = Join-Path $ProjectRoot "dist/$Name"
+$oneDirExe = Join-Path $oneDirRoot "$Name.exe"
+$oneFileExe = Join-Path $ProjectRoot "dist/$Name.exe"
+$includeOneDir = $Mode -in @("onedir", "both")
+$includeOneFile = $Mode -in @("onefile", "both")
+
+function Invoke-SignBinary {
+    param(
+        [string]$PathToSign
+    )
+
+    if (-not $Sign) {
+        return
+    }
+    if ([string]::IsNullOrWhiteSpace($CertThumbprint)) {
+        throw "Signing requested but -CertThumbprint is empty."
+    }
+
+    $arguments = @(
+        "sign",
+        "/sha1", $CertThumbprint,
+        "/fd", "SHA256",
+        "/tr", $TimeStampUrl,
+        "/td", "SHA256",
+        "/d", $Name,
+        "/v",
+        $PathToSign
+    )
+    Write-Host "Signing $PathToSign" -ForegroundColor Cyan
+    & $SignToolPath @arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Signing failed for $PathToSign (exit code $LASTEXITCODE)."
+    }
+}
+
+if ($includeOneDir -and -not (Test-Path -LiteralPath $oneDirExe)) {
+    throw "Onedir desktop executable not found at $oneDirExe"
+}
+if ($includeOneFile -and -not (Test-Path -LiteralPath $oneFileExe)) {
+    throw "Onefile desktop executable not found at $oneFileExe"
+}
+
+New-Item -ItemType Directory -Force -Path $resolvedOutputDir | Out-Null
+
+if ($includeOneDir) {
+    Invoke-SignBinary -PathToSign $oneDirExe
+}
+if ($includeOneFile) {
+    Invoke-SignBinary -PathToSign $oneFileExe
+}
+
+$artifacts = @()
+
+function Add-ArtifactMetadata {
+    param(
+        [string]$Kind,
+        [string]$ArtifactPath
+    )
+
+    $item = Get-Item -LiteralPath $ArtifactPath
+    $hash = (Get-FileHash -LiteralPath $item.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+    $url = if ([string]::IsNullOrWhiteSpace($BaseDownloadUrl)) {
+        $item.Name
+    } else {
+        "$($BaseDownloadUrl.TrimEnd('/'))/$($item.Name)"
+    }
+    $script:artifacts += [pscustomobject]@{
+        kind = $Kind
+        file = $item.Name
+        sha256 = $hash
+        size_bytes = [int64]$item.Length
+        url = $url
+    }
+}
+
+if ($includeOneDir) {
+    $oneDirArchiveName = "$Name-onedir-$safeVersion.zip"
+    $oneDirArchivePath = Join-Path $resolvedOutputDir $oneDirArchiveName
+    if (Test-Path -LiteralPath $oneDirArchivePath) {
+        Remove-Item -LiteralPath $oneDirArchivePath -Force
+    }
+    Compress-Archive -Path (Join-Path $oneDirRoot "*") -DestinationPath $oneDirArchivePath -Force
+    Add-ArtifactMetadata -Kind "onedir" -ArtifactPath $oneDirArchivePath
+}
+
+$oneFileArtifactName = ""
+if ($includeOneFile) {
+    $oneFileArtifactName = "$Name-onefile-$safeVersion.exe"
+    $oneFileArtifactPath = Join-Path $resolvedOutputDir $oneFileArtifactName
+    Copy-Item -LiteralPath $oneFileExe -Destination $oneFileArtifactPath -Force
+    Add-ArtifactMetadata -Kind "onefile" -ArtifactPath $oneFileArtifactPath
+}
+
+if ($includeOneFile) {
+    $installerScriptName = "$Name-install-$safeVersion.ps1"
+    $installerScriptPath = Join-Path $resolvedOutputDir $installerScriptName
+    $installerContent = @"
+param(
+    [string]`$InstallDir = "`$env:LOCALAPPDATA\$Name",
+    [switch]`$DesktopShortcut
+)
+
+`$ErrorActionPreference = "Stop"
+
+`$SourceExe = Join-Path `$PSScriptRoot "$oneFileArtifactName"
+if (-not (Test-Path -LiteralPath `$SourceExe)) {
+    throw "Desktop executable not found next to installer script: `$SourceExe"
+}
+
+New-Item -ItemType Directory -Force -Path `$InstallDir | Out-Null
+`$TargetExe = Join-Path `$InstallDir "$Name.exe"
+Copy-Item -LiteralPath `$SourceExe -Destination `$TargetExe -Force
+
+`$ProgramsPath = [Environment]::GetFolderPath("Programs")
+`$ShortcutDir = Join-Path `$ProgramsPath "Goal Ops Console"
+New-Item -ItemType Directory -Force -Path `$ShortcutDir | Out-Null
+`$ShortcutPath = Join-Path `$ShortcutDir "Goal Ops Console.lnk"
+
+`$shell = New-Object -ComObject WScript.Shell
+`$shortcut = `$shell.CreateShortcut(`$ShortcutPath)
+`$shortcut.TargetPath = `$TargetExe
+`$shortcut.WorkingDirectory = `$InstallDir
+`$shortcut.IconLocation = "`$TargetExe,0"
+`$shortcut.Save()
+
+if (`$DesktopShortcut) {
+    `$desktopPath = [Environment]::GetFolderPath("Desktop")
+    `$desktopLinkPath = Join-Path `$desktopPath "Goal Ops Console.lnk"
+    `$desktopLink = `$shell.CreateShortcut(`$desktopLinkPath)
+    `$desktopLink.TargetPath = `$TargetExe
+    `$desktopLink.WorkingDirectory = `$InstallDir
+    `$desktopLink.IconLocation = "`$TargetExe,0"
+    `$desktopLink.Save()
+}
+
+Write-Host "Installed Goal Ops Console to: `$TargetExe" -ForegroundColor Green
+Write-Host "Start Menu shortcut: `$ShortcutPath" -ForegroundColor Green
+"@
+    Set-Content -LiteralPath $installerScriptPath -Value $installerContent -Encoding UTF8
+    Add-ArtifactMetadata -Kind "installer_script" -ArtifactPath $installerScriptPath
+}
+
+if (-not $artifacts.Count) {
+    throw "No release artifacts were created."
+}
+
+$checksumsPath = Join-Path $resolvedOutputDir "SHA256SUMS.txt"
+$checksumLines = @()
+foreach ($artifact in $artifacts) {
+    $checksumLines += "$($artifact.sha256)  $($artifact.file)"
+}
+$checksumLines | Set-Content -LiteralPath $checksumsPath -Encoding UTF8
+
+$manifestPath = Join-Path $resolvedOutputDir "desktop-update-manifest.json"
+$manifest = [pscustomobject]@{
+    app_id = "goal-ops-console"
+    name = $Name
+    version = $Version
+    channel = $Channel
+    published_at_utc = (Get-Date).ToUniversalTime().ToString("o")
+    artifacts = $artifacts
+}
+$manifest | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $manifestPath -Encoding UTF8
+
+Write-Host "Desktop release package ready." -ForegroundColor Green
+Write-Host "Output directory: $resolvedOutputDir" -ForegroundColor Green
+Write-Host "Manifest: $manifestPath" -ForegroundColor Green
+Write-Host "Checksums: $checksumsPath" -ForegroundColor Green


### PR DESCRIPTION
## Summary
- add `scripts/package-desktop-release.ps1` to assemble desktop distribution artifacts from `dist` outputs
- generate `desktop-update-manifest.json` and `SHA256SUMS.txt` for auto-update feed preparation and integrity checks
- include an install helper script artifact (`GoalOpsConsole-install-<version>.ps1`) for onefile distribution
- add optional signing hooks (`-Sign`, `-SignToolPath`, `-CertThumbprint`, timestamp URL) for release hardening
- wire GitHub Actions desktop workflow to run the new packaging script with derived version/channel metadata
- update README with distribution, signing, and artifact details

## Validation
- local tests: `./scripts/run-tests.ps1` (58 passed)
- local packaging smoke run: `./scripts/package-desktop-release.ps1 -Mode onedir -Version 0.1.0-ci-local -OutputDir .tmp/release-local`