### PR TITLE
[codex] Add CI-driven desktop code signing flow

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -89,15 +89,80 @@ jobs:
           "channel=$channel" >> $env:GITHUB_OUTPUT
           "version=$version" >> $env:GITHUB_OUTPUT
 
+      - name: Resolve signing inputs
+        id: signing
+        shell: pwsh
+        env:
+          SIGN_PFX_BASE64: ${{ secrets.DESKTOP_SIGN_PFX_BASE64 }}
+          SIGN_PFX_PASSWORD: ${{ secrets.DESKTOP_SIGN_PFX_PASSWORD }}
+          SIGN_CERT_THUMBPRINT: ${{ secrets.DESKTOP_SIGN_CERT_THUMBPRINT }}
+          SIGN_TIMESTAMP_URL: ${{ secrets.DESKTOP_SIGN_TIMESTAMP_URL }}
+        run: |
+          $signMode = "none"
+          $signPfxPath = ""
+          $signTimestamp = if (-not [string]::IsNullOrWhiteSpace($env:SIGN_TIMESTAMP_URL)) {
+            $env:SIGN_TIMESTAMP_URL
+          } else {
+            "https://timestamp.digicert.com"
+          }
+
+          if (
+            -not [string]::IsNullOrWhiteSpace($env:SIGN_PFX_BASE64) -and
+            -not [string]::IsNullOrWhiteSpace($env:SIGN_PFX_PASSWORD)
+          ) {
+            $signMode = "pfx"
+            $signPfxPath = Join-Path $env:RUNNER_TEMP "goal-ops-codesign.pfx"
+            $bytes = [Convert]::FromBase64String($env:SIGN_PFX_BASE64)
+            [IO.File]::WriteAllBytes($signPfxPath, $bytes)
+          } elseif (-not [string]::IsNullOrWhiteSpace($env:SIGN_CERT_THUMBPRINT)) {
+            $signMode = "thumbprint"
+          }
+
+          "sign_mode=$signMode" >> $env:GITHUB_OUTPUT
+          "sign_pfx_path=$signPfxPath" >> $env:GITHUB_OUTPUT
+          "sign_timestamp=$signTimestamp" >> $env:GITHUB_OUTPUT
+
       - name: Package desktop release artifacts
         shell: pwsh
         run: |
-          .\scripts\package-desktop-release.ps1 `
-            -Name GoalOpsConsole `
-            -Version "${{ steps.release.outputs.version }}" `
-            -Channel "${{ steps.release.outputs.channel }}" `
-            -Mode "${{ steps.release.outputs.package_mode }}" `
-            -OutputDir "artifacts"
+          if ("${{ steps.signing.outputs.sign_mode }}" -eq "pfx") {
+            .\scripts\package-desktop-release.ps1 `
+              -Name GoalOpsConsole `
+              -Version "${{ steps.release.outputs.version }}" `
+              -Channel "${{ steps.release.outputs.channel }}" `
+              -Mode "${{ steps.release.outputs.package_mode }}" `
+              -OutputDir "artifacts" `
+              -Sign `
+              -PfxPath "${{ steps.signing.outputs.sign_pfx_path }}" `
+              -PfxPassword "${{ secrets.DESKTOP_SIGN_PFX_PASSWORD }}" `
+              -TimeStampUrl "${{ steps.signing.outputs.sign_timestamp }}"
+          } elseif ("${{ steps.signing.outputs.sign_mode }}" -eq "thumbprint") {
+            .\scripts\package-desktop-release.ps1 `
+              -Name GoalOpsConsole `
+              -Version "${{ steps.release.outputs.version }}" `
+              -Channel "${{ steps.release.outputs.channel }}" `
+              -Mode "${{ steps.release.outputs.package_mode }}" `
+              -OutputDir "artifacts" `
+              -Sign `
+              -CertThumbprint "${{ secrets.DESKTOP_SIGN_CERT_THUMBPRINT }}" `
+              -TimeStampUrl "${{ steps.signing.outputs.sign_timestamp }}"
+          } else {
+            .\scripts\package-desktop-release.ps1 `
+              -Name GoalOpsConsole `
+              -Version "${{ steps.release.outputs.version }}" `
+              -Channel "${{ steps.release.outputs.channel }}" `
+              -Mode "${{ steps.release.outputs.package_mode }}" `
+              -OutputDir "artifacts"
+          }
+
+      - name: Cleanup signing material
+        if: always()
+        shell: pwsh
+        run: |
+          $pfxPath = "${{ steps.signing.outputs.sign_pfx_path }}"
+          if (-not [string]::IsNullOrWhiteSpace($pfxPath) -and (Test-Path -LiteralPath $pfxPath)) {
+            Remove-Item -LiteralPath $pfxPath -Force
+          }
 
       - name: Upload desktop artifacts
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -130,7 +130,20 @@ Optional signing during packaging:
   -Sign `
   -SignToolPath "C:\Program Files (x86)\Windows Kits\10\bin\x64\signtool.exe" `
   -CertThumbprint "<CERT_THUMBPRINT>" `
-  -TimeStampUrl "http://timestamp.digicert.com"
+  -TimeStampUrl "https://timestamp.digicert.com"
+```
+
+Alternative signing via PFX file:
+
+```powershell
+.\scripts\package-desktop-release.ps1 `
+  -Version "0.1.0" `
+  -Channel stable `
+  -Mode both `
+  -Sign `
+  -PfxPath ".\codesign\goal-ops.pfx" `
+  -PfxPassword "<PFX_PASSWORD>" `
+  -TimeStampUrl "https://timestamp.digicert.com"
 ```
 
 Optional:
@@ -173,6 +186,17 @@ Published artifacts:
 - `GoalOpsConsole-install-<version>.ps1` (if `onefile` was built)
 - `desktop-update-manifest.json` (version/channel + artifact hashes)
 - `SHA256SUMS.txt` (checksums for uploaded files)
+
+Optional CI signing (GitHub Secrets):
+- `DESKTOP_SIGN_PFX_BASE64`: base64-encoded PFX certificate payload.
+- `DESKTOP_SIGN_PFX_PASSWORD`: password for the PFX file.
+- `DESKTOP_SIGN_CERT_THUMBPRINT`: optional fallback for self-hosted runners with cert in store.
+- `DESKTOP_SIGN_TIMESTAMP_URL`: optional timestamp URL override (default: `https://timestamp.digicert.com`).
+
+Signing behavior in CI:
+- If `DESKTOP_SIGN_PFX_BASE64` + `DESKTOP_SIGN_PFX_PASSWORD` are present, artifacts are signed via PFX.
+- Else, if `DESKTOP_SIGN_CERT_THUMBPRINT` is present, artifacts are signed via certificate thumbprint.
+- Else, packaging runs unsigned (same artifact layout).
 
 ## Stop And Restart
 

--- a/scripts/package-desktop-release.ps1
+++ b/scripts/package-desktop-release.ps1
@@ -10,7 +10,9 @@ param(
     [switch]$Sign,
     [string]$SignToolPath = "signtool.exe",
     [string]$CertThumbprint = "",
-    [string]$TimeStampUrl = "http://timestamp.digicert.com"
+    [string]$PfxPath = "",
+    [string]$PfxPassword = "",
+    [string]$TimeStampUrl = "https://timestamp.digicert.com"
 )
 
 $ErrorActionPreference = "Stop"
@@ -25,6 +27,10 @@ $oneDirExe = Join-Path $oneDirRoot "$Name.exe"
 $oneFileExe = Join-Path $ProjectRoot "dist/$Name.exe"
 $includeOneDir = $Mode -in @("onedir", "both")
 $includeOneFile = $Mode -in @("onefile", "both")
+$resolvedPfxPath = ""
+if (-not [string]::IsNullOrWhiteSpace($PfxPath)) {
+    $resolvedPfxPath = (Resolve-Path -LiteralPath $PfxPath).Path
+}
 
 function Invoke-SignBinary {
     param(
@@ -34,25 +40,40 @@ function Invoke-SignBinary {
     if (-not $Sign) {
         return
     }
-    if ([string]::IsNullOrWhiteSpace($CertThumbprint)) {
-        throw "Signing requested but -CertThumbprint is empty."
-    }
 
     $arguments = @(
         "sign",
-        "/sha1", $CertThumbprint,
         "/fd", "SHA256",
         "/tr", $TimeStampUrl,
         "/td", "SHA256",
         "/d", $Name,
-        "/v",
-        $PathToSign
+        "/v"
     )
+
+    if (-not [string]::IsNullOrWhiteSpace($resolvedPfxPath)) {
+        $arguments += @("/f", $resolvedPfxPath)
+        if (-not [string]::IsNullOrWhiteSpace($PfxPassword)) {
+            $arguments += @("/p", $PfxPassword)
+        }
+    } elseif (-not [string]::IsNullOrWhiteSpace($CertThumbprint)) {
+        $arguments += @("/sha1", $CertThumbprint)
+    } else {
+        throw "Signing requested but no certificate source provided. Use -CertThumbprint or -PfxPath."
+    }
+
+    $arguments += $PathToSign
+
     Write-Host "Signing $PathToSign" -ForegroundColor Cyan
     & $SignToolPath @arguments
     if ($LASTEXITCODE -ne 0) {
         throw "Signing failed for $PathToSign (exit code $LASTEXITCODE)."
     }
+
+    $signature = Get-AuthenticodeSignature -LiteralPath $PathToSign
+    if ($signature.Status -ne "Valid") {
+        throw "Signature verification failed for $PathToSign. Status=$($signature.Status). $($signature.StatusMessage)"
+    }
+    Write-Host "Signature valid for $PathToSign" -ForegroundColor Green
 }
 
 if ($includeOneDir -and -not (Test-Path -LiteralPath $oneDirExe)) {


### PR DESCRIPTION
## Summary
- add CI-ready desktop signing support via GitHub Secrets in `.github/workflows/desktop-build.yml`
- support two signing modes in CI packaging:
  - PFX secret mode (`DESKTOP_SIGN_PFX_BASE64` + `DESKTOP_SIGN_PFX_PASSWORD`)
  - thumbprint mode (`DESKTOP_SIGN_CERT_THUMBPRINT`) for runners with pre-installed cert
- add secret-based timestamp URL override (`DESKTOP_SIGN_TIMESTAMP_URL`)
- ensure workflow cleans temporary PFX material after packaging
- extend `scripts/package-desktop-release.ps1` with `-PfxPath` and `-PfxPassword`
- verify Authenticode status after signing and fail packaging if signature is not valid
- document CI signing setup and behavior in README

## Validation
- local tests: `./scripts/run-tests.ps1` (58 passed)
- local packaging smoke run (unsigned):
  `./scripts/package-desktop-release.ps1 -Name GoalOpsConsole -Version 0.1.0-ci-signing -Channel snapshot -Mode onedir -OutputDir .tmp/release-ci-signing`