### PR TITLE
[codex] Publish desktop artifacts to GitHub Releases on tags

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -25,7 +25,7 @@ jobs:
     name: Windows Desktop Artifact
     runs-on: windows-latest
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout
@@ -170,3 +170,14 @@ jobs:
           name: desktop-${{ github.run_number }}
           path: artifacts/*
           if-no-files-found: error
+
+      - name: Publish GitHub release assets
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Goal Ops Console ${{ github.ref_name }}
+          generate_release_notes: true
+          overwrite_files: true
+          files: |
+            artifacts/*

--- a/README.md
+++ b/README.md
@@ -198,6 +198,17 @@ Signing behavior in CI:
 - Else, if `DESKTOP_SIGN_CERT_THUMBPRINT` is present, artifacts are signed via certificate thumbprint.
 - Else, packaging runs unsigned (same artifact layout).
 
+GitHub release publishing on tag builds:
+- On `v*` tag pushes, workflow also creates/updates a GitHub Release and uploads all `artifacts/*` files as release assets.
+- Re-running the workflow for the same tag overwrites release asset files (`overwrite_files: true`).
+
+Release trigger example:
+
+```powershell
+git tag v0.2.0
+git push origin v0.2.0
+```
+
 ## Stop And Restart
 
 Stop the server in the terminal where `uvicorn` is running:


### PR DESCRIPTION
## Summary
- enable GitHub Release publishing for desktop artifacts on `v*` tag workflow runs
- raise desktop workflow `contents` permission to `write` for release asset upload
- add `softprops/action-gh-release@v2` step with `overwrite_files: true` to make reruns deterministic
- document tag-triggered release flow in README with an explicit `git tag` / `git push` example

## Validation
- local tests: `./scripts/run-tests.ps1` (58 passed)