### PR TITLE
Upgrade GitHub Actions to Node24-compatible majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -165,7 +165,7 @@ jobs:
           }
 
       - name: Upload desktop artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: desktop-${{ github.run_number }}
           path: artifacts/*
@@ -173,7 +173,7 @@ jobs:
 
       - name: Publish GitHub release assets
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: Goal Ops Console ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- upgrade actions/checkout from v4 to v5 in CI + desktop workflows
- upgrade actions/setup-python from v5 to v6 in CI + desktop workflows
- upgrade actions/upload-artifact from v4 to v7 in desktop workflow
- upgrade softprops/action-gh-release from v2 to v3 in desktop workflow

## Why
GitHub flagged Node.js 20 deprecation warnings in the desktop build run. These versions use Node24 runtimes and remove that risk ahead of the June/Sep 2026 runner changes.

## Validation
- python -m pytest -q (58 passed)
