### PR TITLE
Add workflow catalog schema, API endpoints, and dashboard runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,28 @@ jobs:
 
       - name: Run test suite
         run: python -m pytest -q
+
+  desktop-smoke-windows:
+    name: Desktop Smoke (Windows)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test]"
+
+      - name: Run desktop smoke
+        shell: pwsh
+        run: |
+          python .\scripts\desktop-smoke.py

--- a/README.md
+++ b/README.md
@@ -73,12 +73,16 @@ Optional startup parameters:
 .\scripts\start-desktop.ps1 -MinWidth 1200 -MinHeight 800
 .\scripts\start-desktop.ps1 -NoWindowState
 .\scripts\start-desktop.ps1 -WindowStatePath ".\custom-window-state.json"
+.\scripts\start-desktop.ps1 -InstanceLockPath ".\goal-ops-desktop.lock"
+.\scripts\start-desktop.ps1 -AllowMultipleInstances
 ```
 
 Behavior:
 - starts an embedded local FastAPI server (`127.0.0.1`)
 - opens the same dashboard UI in a native window via `pywebview`
 - remembers window size/position across launches (disable with `-NoWindowState`)
+- enforces single-instance lock by default (disable with `-AllowMultipleInstances`)
+- writes crash reports to `%USERPROFILE%\.goal_ops_console\diagnostics` (or `GOAL_OPS_DIAGNOSTICS_DIR`)
 - shuts down the embedded server when the desktop window closes
 
 ## Operator Command Bar (UI)
@@ -399,6 +403,20 @@ Recommended branch protection on `master`:
 4. Enable `Require a pull request before merging`.
 5. Enable `Require status checks to pass before merging`.
 6. Select required check: `Pytest (Python 3.11)` and `Pytest (Python 3.12)`.
+7. Select required check: `Desktop Smoke (Windows)`.
+
+Local desktop smoke command:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+python .\scripts\desktop-smoke.py
+```
+
+## Production Runbook
+
+Reliability-first release and incident handling guide:
+
+- [production-runbook.md](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/production-runbook.md)
 
 ## Troubleshooting
 

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -1,0 +1,149 @@
+# Goal Ops Console Production Runbook
+
+This runbook is optimized for reliability-first releases of the desktop app and API.
+
+## 1. Release Checklist
+
+### 1.1 Pre-release gate
+
+Run in repo root:
+
+```powershell
+python -m pytest -q
+python .\scripts\desktop-smoke.py
+```
+
+Verify before release:
+- CI checks green:
+  - `Pytest (Python 3.11)`
+  - `Pytest (Python 3.12)`
+  - `Desktop Smoke (Windows)`
+- `master` branch only receives PR merges (no direct pushes).
+- No unresolved high-severity bug tickets for release scope.
+
+### 1.2 Build and package
+
+```powershell
+.\scripts\package-desktop-release.ps1 -Version "<VERSION>" -Channel stable -Mode both -OutputDir artifacts
+```
+
+Validate artifacts:
+- `artifacts\desktop-update-manifest.json` exists and version matches release tag.
+- `artifacts\SHA256SUMS.txt` exists.
+- `GoalOpsConsole-onefile-<version>.exe` starts and reaches dashboard.
+
+### 1.3 Publish
+
+Tag and push:
+
+```powershell
+git tag v<VERSION>
+git push origin v<VERSION>
+```
+
+GitHub Actions `Desktop Build` publishes release assets on tag pushes.
+
+### 1.4 Post-release checks
+
+After release is live:
+- Launch desktop binary on a clean Windows machine.
+- Confirm `GET /system/readiness` returns `{"ready": true, ...}`.
+- Trigger `Export Diagnostics` once from Operator Controls and confirm snapshot file exists.
+- Verify one workflow run can be queued and completed from UI.
+
+## 2. Rollback
+
+Use rollback when crash rate or readiness failures rise immediately after rollout.
+
+1. Disable rollout in updater channel (set previous stable manifest/version).
+2. Repoint download/install instructions to previous stable artifact.
+3. Keep diagnostics snapshots from failed version for triage.
+4. Open incident ticket with:
+   - failing version
+   - first failure timestamp (UTC)
+   - attached diagnostics JSON and crash report JSON
+
+## 3. Failure Playbook
+
+### 3.1 Readiness is false
+
+Symptoms:
+- Desktop launcher fails with `Desktop server did not become ready`.
+- `GET /system/readiness` shows `ready=false`.
+
+Actions:
+1. Call readiness endpoint directly:
+   ```powershell
+   Invoke-RestMethod http://127.0.0.1:8000/system/readiness
+   ```
+2. Check failing check:
+   - `checks.database.ok = false`: inspect DB path/permissions/locking.
+   - `checks.workflow_worker.ok = false`: worker thread failed to start.
+3. Export diagnostics:
+   - UI: `Export Diagnostics`
+   - API: `POST /system/diagnostics`
+4. Restart app and retry once. If still failing, rollback.
+
+### 3.2 Workflow worker stalled
+
+Symptoms:
+- workflow runs stay `queued`.
+- readiness worker check flips to `ok=false` or `is_running=false`.
+
+Actions:
+1. Verify with:
+   ```powershell
+   Invoke-RestMethod http://127.0.0.1:8000/system/readiness
+   ```
+2. Restart the process.
+3. Reap stale runs:
+   ```powershell
+   Invoke-RestMethod -Method Post http://127.0.0.1:8000/workflows/runs/reap
+   ```
+4. If recurring, open incident and attach diagnostics snapshots from before/after restart.
+
+### 3.3 Backpressure / degraded throughput
+
+Symptoms:
+- API returns `429` with retry hints.
+- queue and pending events keep growing.
+
+Actions:
+1. Check:
+   - `GET /system/backpressure`
+   - `GET /system/queue`
+2. Run controlled drain and reclaim from Operator Controls.
+3. Temporarily reduce operator-initiated workflow starts.
+4. When stable, run retention cleanup once.
+
+### 3.4 Desktop startup conflicts (single-instance lock)
+
+Symptoms:
+- error: another desktop instance is already running.
+
+Actions:
+1. Confirm no active app process.
+2. Retry launch once (stale lock auto-recovery is enabled).
+3. If still blocked, collect crash/diagnostics and escalate.
+
+### 3.5 Crash reports
+
+Location:
+- default: `%USERPROFILE%\.goal_ops_console\diagnostics`
+- or `GOAL_OPS_DIAGNOSTICS_DIR` when configured.
+
+Crash file pattern:
+- `desktop-crash-<timestamp>.json`
+
+Required triage fields:
+- `error_type`
+- `error`
+- `traceback`
+- `context`
+
+## 4. Operational Defaults
+
+- Keep single-instance protection enabled in production.
+- Keep readiness endpoint as launch gate.
+- Keep diagnostics export enabled for operators.
+- Prefer rollback over hotfix-in-place during active outage.

--- a/goal_ops_console/config.py
+++ b/goal_ops_console/config.py
@@ -52,6 +52,7 @@ EVENT_PROCESSING_RETENTION_DAYS = 30
 FAILURE_LOG_RETENTION_DAYS = 90
 WORKFLOW_RUN_TIMEOUT_SECONDS = 300
 WORKFLOW_REAPER_BATCH_SIZE = 200
+WORKFLOW_WORKER_POLL_INTERVAL_SECONDS = 0.5
 
 # The sandbox in this workspace rejects file-backed SQLite locks, so the
 # persistent `goal_ops.db` path should be supplied via GOAL_OPS_DATABASE_URL.
@@ -80,3 +81,4 @@ class Settings:
     failure_log_retention_days: int = FAILURE_LOG_RETENTION_DAYS
     workflow_run_timeout_seconds: int = WORKFLOW_RUN_TIMEOUT_SECONDS
     workflow_reaper_batch_size: int = WORKFLOW_REAPER_BATCH_SIZE
+    workflow_worker_poll_interval_seconds: float = WORKFLOW_WORKER_POLL_INTERVAL_SECONDS

--- a/goal_ops_console/config.py
+++ b/goal_ops_console/config.py
@@ -53,6 +53,7 @@ FAILURE_LOG_RETENTION_DAYS = 90
 WORKFLOW_RUN_TIMEOUT_SECONDS = 300
 WORKFLOW_REAPER_BATCH_SIZE = 200
 WORKFLOW_WORKER_POLL_INTERVAL_SECONDS = 0.5
+DIAGNOSTICS_DIR = os.getenv("GOAL_OPS_DIAGNOSTICS_DIR", "")
 
 # The sandbox in this workspace rejects file-backed SQLite locks, so the
 # persistent `goal_ops.db` path should be supplied via GOAL_OPS_DATABASE_URL.
@@ -82,3 +83,4 @@ class Settings:
     workflow_run_timeout_seconds: int = WORKFLOW_RUN_TIMEOUT_SECONDS
     workflow_reaper_batch_size: int = WORKFLOW_REAPER_BATCH_SIZE
     workflow_worker_poll_interval_seconds: float = WORKFLOW_WORKER_POLL_INTERVAL_SECONDS
+    diagnostics_dir: str = DIAGNOSTICS_DIR

--- a/goal_ops_console/config.py
+++ b/goal_ops_console/config.py
@@ -1,7 +1,7 @@
 import os
 from dataclasses import dataclass
 
-SPEC_VERSION = "1.4.3"
+SPEC_VERSION = "1.4.4"
 
 # Skill Selection
 MIN_RUNS = 5
@@ -50,6 +50,8 @@ EPHEMERAL_MAX_ROWS = 10_000
 EVENTS_RETENTION_DAYS = 30
 EVENT_PROCESSING_RETENTION_DAYS = 30
 FAILURE_LOG_RETENTION_DAYS = 90
+WORKFLOW_RUN_TIMEOUT_SECONDS = 300
+WORKFLOW_REAPER_BATCH_SIZE = 200
 
 # The sandbox in this workspace rejects file-backed SQLite locks, so the
 # persistent `goal_ops.db` path should be supplied via GOAL_OPS_DATABASE_URL.
@@ -76,3 +78,5 @@ class Settings:
     events_retention_days: int = EVENTS_RETENTION_DAYS
     event_processing_retention_days: int = EVENT_PROCESSING_RETENTION_DAYS
     failure_log_retention_days: int = FAILURE_LOG_RETENTION_DAYS
+    workflow_run_timeout_seconds: int = WORKFLOW_RUN_TIMEOUT_SECONDS
+    workflow_reaper_batch_size: int = WORKFLOW_REAPER_BATCH_SIZE

--- a/goal_ops_console/database.py
+++ b/goal_ops_console/database.py
@@ -51,6 +51,12 @@ CREATE TABLE IF NOT EXISTS skill_metrics (
   updated_at    TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  version    INTEGER PRIMARY KEY,
+  name       TEXT NOT NULL,
+  applied_at TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS goal_queue (
   goal_id        TEXT PRIMARY KEY,
   urgency        REAL NOT NULL DEFAULT 0.0,
@@ -179,9 +185,11 @@ ON workflow_definitions(is_enabled, name);
 CREATE TABLE IF NOT EXISTS workflow_runs (
   run_id         TEXT PRIMARY KEY,
   workflow_id    TEXT NOT NULL,
-  status         TEXT NOT NULL,
+  status         TEXT NOT NULL
+                 CHECK (status IN ('queued', 'running', 'succeeded', 'failed', 'timed_out', 'cancelled')),
   requested_by   TEXT NOT NULL,
   correlation_id TEXT NOT NULL,
+  idempotency_key TEXT,
   input_payload  TEXT,
   result_payload TEXT,
   started_at     TEXT NOT NULL,
@@ -190,10 +198,17 @@ CREATE TABLE IF NOT EXISTS workflow_runs (
   updated_at     TEXT NOT NULL,
   FOREIGN KEY(workflow_id) REFERENCES workflow_definitions(workflow_id)
 );
-CREATE INDEX IF NOT EXISTS idx_workflow_runs_workflow_id
+CREATE INDEX IF NOT EXISTS idx_workflow_runs_workflow_created_at
 ON workflow_runs(workflow_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_workflow_runs_created_at
 ON workflow_runs(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_workflow_runs_status_created_at
+ON workflow_runs(status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_workflow_runs_correlation_id
+ON workflow_runs(correlation_id, created_at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_workflow_runs_idempotency
+ON workflow_runs(workflow_id, idempotency_key)
+WHERE idempotency_key IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS audit_log (
   audit_id        TEXT PRIMARY KEY,
@@ -220,6 +235,68 @@ CREATE INDEX IF NOT EXISTS idx_metrics_updated_at ON metrics_counters(updated_at
 SQLITE_BUSY_TIMEOUT_MS = 5_000
 LOCK_RETRY_ATTEMPTS = 8
 LOCK_RETRY_BASE_SECONDS = 0.01
+MIGRATIONS: tuple[tuple[int, str], ...] = (
+    (
+        1,
+        """
+PRAGMA foreign_keys = OFF;
+BEGIN IMMEDIATE;
+ALTER TABLE workflow_runs RENAME TO workflow_runs_legacy;
+CREATE TABLE workflow_runs (
+  run_id          TEXT PRIMARY KEY,
+  workflow_id     TEXT NOT NULL,
+  status          TEXT NOT NULL
+                  CHECK (status IN ('queued', 'running', 'succeeded', 'failed', 'timed_out', 'cancelled')),
+  requested_by    TEXT NOT NULL,
+  correlation_id  TEXT NOT NULL,
+  idempotency_key TEXT,
+  input_payload   TEXT,
+  result_payload  TEXT,
+  started_at      TEXT NOT NULL,
+  finished_at     TEXT,
+  created_at      TEXT NOT NULL,
+  updated_at      TEXT NOT NULL,
+  FOREIGN KEY(workflow_id) REFERENCES workflow_definitions(workflow_id)
+);
+INSERT INTO workflow_runs
+  (run_id, workflow_id, status, requested_by, correlation_id, idempotency_key,
+   input_payload, result_payload, started_at, finished_at, created_at, updated_at)
+SELECT run_id,
+       workflow_id,
+       CASE
+         WHEN status IN ('queued', 'running', 'succeeded', 'failed', 'timed_out', 'cancelled')
+           THEN status
+         ELSE 'failed'
+       END,
+       requested_by,
+       correlation_id,
+       NULL,
+       input_payload,
+       result_payload,
+       started_at,
+       finished_at,
+       created_at,
+       updated_at
+FROM workflow_runs_legacy;
+DROP TABLE workflow_runs_legacy;
+CREATE INDEX IF NOT EXISTS idx_workflow_runs_workflow_created_at
+ON workflow_runs(workflow_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_workflow_runs_created_at
+ON workflow_runs(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_workflow_runs_status_created_at
+ON workflow_runs(status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_workflow_runs_correlation_id
+ON workflow_runs(correlation_id, created_at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_workflow_runs_idempotency
+ON workflow_runs(workflow_id, idempotency_key)
+WHERE idempotency_key IS NOT NULL;
+INSERT INTO schema_migrations (version, name, applied_at)
+VALUES (1, 'workflow_runs_hardening', datetime('now'));
+COMMIT;
+PRAGMA foreign_keys = ON;
+""",
+    ),
+)
 T = TypeVar("T")
 
 
@@ -299,9 +376,20 @@ class Database:
         conn = self._keeper or self._connect()
         try:
             conn.executescript(SCHEMA)
+            self._apply_migrations(conn)
         finally:
             if conn is not self._keeper:
                 conn.close()
+
+    def _apply_migrations(self, conn: sqlite3.Connection) -> None:
+        for version, script in MIGRATIONS:
+            row = conn.execute(
+                "SELECT 1 FROM schema_migrations WHERE version = ?",
+                (version,),
+            ).fetchone()
+            if row is not None:
+                continue
+            conn.executescript(script)
 
     def execute(self, sql: str, *params: object) -> int:
         def _op(conn: sqlite3.Connection) -> int:

--- a/goal_ops_console/database.py
+++ b/goal_ops_console/database.py
@@ -163,6 +163,38 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_learning_active_version
 ON learnings(parent_learning_id)
 WHERE status = 'promoted';
 
+CREATE TABLE IF NOT EXISTS workflow_definitions (
+  workflow_id    TEXT PRIMARY KEY,
+  name           TEXT NOT NULL,
+  description    TEXT,
+  entrypoint     TEXT NOT NULL,
+  is_enabled     INTEGER NOT NULL DEFAULT 1,
+  version        INTEGER NOT NULL DEFAULT 1,
+  created_at     TEXT NOT NULL,
+  updated_at     TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_workflow_definitions_enabled
+ON workflow_definitions(is_enabled, name);
+
+CREATE TABLE IF NOT EXISTS workflow_runs (
+  run_id         TEXT PRIMARY KEY,
+  workflow_id    TEXT NOT NULL,
+  status         TEXT NOT NULL,
+  requested_by   TEXT NOT NULL,
+  correlation_id TEXT NOT NULL,
+  input_payload  TEXT,
+  result_payload TEXT,
+  started_at     TEXT NOT NULL,
+  finished_at    TEXT,
+  created_at     TEXT NOT NULL,
+  updated_at     TEXT NOT NULL,
+  FOREIGN KEY(workflow_id) REFERENCES workflow_definitions(workflow_id)
+);
+CREATE INDEX IF NOT EXISTS idx_workflow_runs_workflow_id
+ON workflow_runs(workflow_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_workflow_runs_created_at
+ON workflow_runs(created_at DESC);
+
 CREATE TABLE IF NOT EXISTS audit_log (
   audit_id        TEXT PRIMARY KEY,
   action          TEXT NOT NULL,

--- a/goal_ops_console/desktop.py
+++ b/goal_ops_console/desktop.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import socket
 import threading
 import time
+import traceback
 import urllib.error
 import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +18,12 @@ from uvicorn import Config, Server
 
 from goal_ops_console.config import Settings
 from goal_ops_console.main import create_app
+
+
+@dataclass(slots=True)
+class InstanceLock:
+    path: Path
+    pid: int
 
 
 def _pick_port(host: str, explicit_port: int | None) -> int:
@@ -24,16 +34,21 @@ def _pick_port(host: str, explicit_port: int | None) -> int:
         return int(sock.getsockname()[1])
 
 
-def _wait_until_ready(url: str, timeout_seconds: float = 15.0) -> None:
+def _wait_until_ready(base_url: str, timeout_seconds: float = 15.0) -> None:
+    url = f"{base_url.rstrip('/')}/system/readiness"
     deadline = time.time() + timeout_seconds
     last_error: Exception | None = None
     while time.time() < deadline:
         try:
-            with urllib.request.urlopen(url, timeout=1.5):
-                return
+            with urllib.request.urlopen(url, timeout=1.5) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+                if bool(payload.get("ready")):
+                    return
         except (urllib.error.URLError, TimeoutError, OSError) as exc:
             last_error = exc
-            time.sleep(0.2)
+        except (ValueError, json.JSONDecodeError) as exc:
+            last_error = exc
+        time.sleep(0.2)
     if last_error is not None:
         raise RuntimeError(f"Desktop server did not become ready at {url}") from last_error
     raise RuntimeError(f"Desktop server did not become ready at {url}")
@@ -41,6 +56,155 @@ def _wait_until_ready(url: str, timeout_seconds: float = 15.0) -> None:
 
 def _default_window_state_path() -> Path:
     return Path.home() / ".goal_ops_console" / "window_state.json"
+
+
+def _default_instance_lock_path() -> Path:
+    return Path.home() / ".goal_ops_console" / "desktop.lock"
+
+
+def _default_diagnostics_dir() -> Path:
+    return Path.home() / ".goal_ops_console" / "diagnostics"
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _iso_utc() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _is_process_running(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+
+
+def _read_lock_payload(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+    if isinstance(payload, dict):
+        return payload
+    return None
+
+
+def _unlink_with_retry(path: Path, *, retries: int = 8, base_delay_seconds: float = 0.01) -> bool:
+    for attempt in range(max(1, int(retries))):
+        try:
+            path.unlink()
+            return True
+        except FileNotFoundError:
+            return True
+        except OSError:
+            if attempt == retries - 1:
+                return False
+            time.sleep(base_delay_seconds * (attempt + 1))
+    return False
+
+
+def _write_lock_payload(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=True), encoding="utf-8")
+
+
+def _acquire_instance_lock(path: Path) -> InstanceLock:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "pid": os.getpid(),
+        "created_at": _iso_utc(),
+    }
+    try:
+        fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        existing = _read_lock_payload(path)
+        existing_pid = _coerce_int(existing.get("pid")) if existing else None
+        existing_released = bool(existing and existing.get("released"))
+        if existing_released:
+            _write_lock_payload(path, payload)
+            return InstanceLock(path=path, pid=int(payload["pid"]))
+        if existing_pid is not None and not _is_process_running(existing_pid):
+            if _unlink_with_retry(path):
+                return _acquire_instance_lock(path)
+            try:
+                _write_lock_payload(path, payload)
+                return InstanceLock(path=path, pid=int(payload["pid"]))
+            except OSError as exc:
+                raise RuntimeError(
+                    f"Desktop instance lock exists at {path} and stale lock cleanup failed."
+                ) from exc
+        if existing_pid is not None:
+            raise RuntimeError(
+                f"Another Goal Ops Console desktop instance is already running (pid {existing_pid})."
+            )
+        raise RuntimeError(
+            f"Desktop instance lock already exists at {path}. "
+            "If no instance is running, delete the lock file and retry."
+        )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as lock_file:
+            lock_file.write(json.dumps(payload, ensure_ascii=True))
+    except Exception:
+        _unlink_with_retry(path, retries=3, base_delay_seconds=0.01)
+        raise
+    return InstanceLock(path=path, pid=int(payload["pid"]))
+
+
+def _release_instance_lock(lock: InstanceLock | None) -> None:
+    if lock is None:
+        return
+    existing = _read_lock_payload(lock.path)
+    existing_pid = _coerce_int(existing.get("pid")) if existing else None
+    if existing_pid is not None and existing_pid != lock.pid:
+        return
+    if _unlink_with_retry(lock.path):
+        return
+    try:
+        _write_lock_payload(
+            lock.path,
+            {
+                "pid": lock.pid,
+                "released": True,
+                "released_at": _iso_utc(),
+            },
+        )
+    except OSError:
+        return
+
+
+def _write_crash_report(
+    exc: Exception,
+    *,
+    diagnostics_dir: Path | None = None,
+    context: dict[str, Any] | None = None,
+) -> Path | None:
+    target_dir = diagnostics_dir or _default_diagnostics_dir()
+    try:
+        target_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+
+    report_path = target_dir / f"desktop-crash-{_utc_timestamp()}.json"
+    payload = {
+        "timestamp_utc": _iso_utc(),
+        "error_type": exc.__class__.__name__,
+        "error": str(exc),
+        "traceback": "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+        "context": context or {},
+    }
+    try:
+        report_path.write_text(json.dumps(payload, ensure_ascii=True, indent=2), encoding="utf-8")
+    except OSError:
+        return None
+    return report_path
 
 
 def _coerce_int(value: Any) -> int | None:
@@ -137,6 +301,8 @@ def run_desktop(
     start_maximized: bool = False,
     remember_window: bool = True,
     window_state_path: str | None = None,
+    single_instance: bool = True,
+    instance_lock_path: str | None = None,
     window_title: str = "Goal Ops Console",
     debug: bool = False,
 ) -> None:
@@ -162,6 +328,13 @@ def run_desktop(
         }
     )
 
+    lock = None
+    if single_instance:
+        lock_path = (
+            Path(instance_lock_path).expanduser() if instance_lock_path else _default_instance_lock_path()
+        )
+        lock = _acquire_instance_lock(lock_path)
+
     selected_port = _pick_port(host, port)
     app = create_app(Settings(database_url=database_url))
     server = Server(
@@ -175,9 +348,10 @@ def run_desktop(
     server_thread = threading.Thread(target=server.run, daemon=True, name="goal-ops-desktop-server")
     server_thread.start()
 
-    url = f"http://{host}:{selected_port}/?desktop=1"
+    base_url = f"http://{host}:{selected_port}"
+    url = f"{base_url}/?desktop=1"
     try:
-        _wait_until_ready(url)
+        _wait_until_ready(base_url)
 
         try:
             import webview  # pyright: ignore[reportMissingImports]
@@ -235,6 +409,7 @@ def run_desktop(
     finally:
         server.should_exit = True
         server_thread.join(timeout=5.0)
+        _release_instance_lock(lock)
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -290,6 +465,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Optional JSON file path used to persist desktop window position/size.",
     )
     parser.add_argument(
+        "--instance-lock-path",
+        default=None,
+        help="Optional lock file path used to enforce single desktop instance.",
+    )
+    parser.add_argument(
+        "--allow-multiple-instances",
+        action="store_true",
+        help="Disable single-instance lock (not recommended for production).",
+    )
+    parser.add_argument(
         "--no-window-state",
         action="store_true",
         help="Disable persistent desktop window state.",
@@ -321,10 +506,32 @@ def main(argv: list[str] | None = None) -> int:
             start_maximized=args.maximized,
             remember_window=(not args.no_window_state),
             window_state_path=args.window_state_path,
+            single_instance=(not args.allow_multiple_instances),
+            instance_lock_path=args.instance_lock_path,
             window_title=args.title,
             debug=args.debug,
         )
     except Exception as exc:  # pragma: no cover - this is top-level UX handling
+        configured_diagnostics_dir = os.getenv("GOAL_OPS_DIAGNOSTICS_DIR", "").strip()
+        diagnostics_dir = (
+            Path(configured_diagnostics_dir).expanduser() if configured_diagnostics_dir else None
+        )
+        report_path = _write_crash_report(
+            exc,
+            diagnostics_dir=diagnostics_dir,
+            context={
+                "database_url": args.database_url,
+                "host": args.host,
+                "port": args.port,
+                "width": args.width,
+                "height": args.height,
+                "min_width": args.min_width,
+                "min_height": args.min_height,
+                "maximized": bool(args.maximized),
+            },
+        )
+        if report_path is not None:
+            print(f"[desktop] Crash report saved to: {report_path}")
         print(f"[desktop] Failed to launch: {exc}")
         return 1
     return 0

--- a/goal_ops_console/main.py
+++ b/goal_ops_console/main.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from pathlib import Path
 from time import perf_counter
 
@@ -13,7 +14,15 @@ from goal_ops_console.services import build_services
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:
-    app = FastAPI(title="Goal Ops Console", version="0.1.0")
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        app.state.services.workflow_catalog.start_worker()
+        try:
+            yield
+        finally:
+            app.state.services.workflow_catalog.stop_worker()
+
+    app = FastAPI(title="Goal Ops Console", version="0.1.0", lifespan=lifespan)
     app.state.services = build_services(settings)
 
     template_dir = Path(__file__).parent / "templates"

--- a/goal_ops_console/main.py
+++ b/goal_ops_console/main.py
@@ -8,7 +8,7 @@ from fastapi.templating import Jinja2Templates
 
 from goal_ops_console.config import Settings
 from goal_ops_console.models import DomainError
-from goal_ops_console.routers import events, goals, system, tasks
+from goal_ops_console.routers import events, goals, system, tasks, workflows
 from goal_ops_console.services import build_services
 
 
@@ -25,6 +25,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(goals.router)
     app.include_router(tasks.router)
     app.include_router(events.router)
+    app.include_router(workflows.router)
 
     def route_template(request: Request) -> str:
         route = request.scope.get("route")

--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -110,3 +110,8 @@ class EventResponse(BaseModel):
 class WorkflowStartRequest(BaseModel):
     requested_by: str = Field(default="operator", min_length=1, max_length=120)
     payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class WorkflowCancelRequest(BaseModel):
+    requested_by: str = Field(default="operator", min_length=1, max_length=120)
+    reason: str | None = Field(default=None, max_length=500)

--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -105,3 +105,8 @@ class EventResponse(BaseModel):
     correlation_id: str
     payload: dict[str, Any] | None
     emitted_at: str
+
+
+class WorkflowStartRequest(BaseModel):
+    requested_by: str = Field(default="operator", min_length=1, max_length=120)
+    payload: dict[str, Any] = Field(default_factory=dict)

--- a/goal_ops_console/routers/system.py
+++ b/goal_ops_console/routers/system.py
@@ -1,3 +1,9 @@
+import json
+import platform
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
 
@@ -8,18 +14,11 @@ from goal_ops_console.services import AppServices, get_services
 router = APIRouter(tags=["system"])
 
 
-@router.get("/", response_class=HTMLResponse)
-def dashboard(request: Request) -> HTMLResponse:
-    templates = request.app.state.templates
-    return templates.TemplateResponse(
-        request=request,
-        name="index.html",
-        context={"spec_version": SPEC_VERSION},
-    )
+def _utc_iso() -> str:
+    return datetime.now(UTC).isoformat()
 
 
-@router.get("/system/health")
-def system_health(services: AppServices = Depends(get_services)) -> dict:
+def _build_health_payload(services: AppServices) -> dict[str, Any]:
     total_events = services.db.fetch_scalar("SELECT COUNT(*) FROM events") or 0
     total_goals = services.db.fetch_scalar("SELECT COUNT(*) FROM goals") or 0
     total_tasks = services.db.fetch_scalar("SELECT COUNT(*) FROM task_state") or 0
@@ -54,8 +53,54 @@ def system_health(services: AppServices = Depends(get_services)) -> dict:
     }
 
 
-@router.get("/system/queue")
-def queue_snapshot(services: AppServices = Depends(get_services)) -> list[dict]:
+def _build_readiness_payload(services: AppServices) -> dict[str, Any]:
+    db_ok = True
+    db_error: str | None = None
+    try:
+        services.db.fetch_scalar("SELECT 1")
+    except Exception as exc:
+        db_ok = False
+        db_error = str(exc)
+
+    worker_error: str | None = None
+    worker_status: dict[str, Any] = {
+        "is_running": False,
+        "stop_requested": False,
+        "queued_runs": 0,
+        "running_runs": 0,
+    }
+    try:
+        worker_status = services.workflow_catalog.worker_status()
+    except Exception as exc:
+        worker_error = str(exc)
+
+    worker_ok = bool(worker_status.get("is_running")) and worker_error is None
+    return {
+        "ready": bool(db_ok and worker_ok),
+        "spec_version": SPEC_VERSION,
+        "timestamp_utc": _utc_iso(),
+        "checks": {
+            "database": {
+                "ok": db_ok,
+                "error": db_error,
+            },
+            "workflow_worker": {
+                **worker_status,
+                "ok": worker_ok,
+                "error": worker_error,
+            },
+        },
+    }
+
+
+def _resolve_diagnostics_dir(configured_path: str) -> Path:
+    normalized = configured_path.strip()
+    if normalized:
+        return Path(normalized).expanduser()
+    return Path.home() / ".goal_ops_console" / "diagnostics"
+
+
+def _queue_snapshot(services: AppServices, *, limit: int = 200) -> list[dict[str, Any]]:
     rows = services.db.fetch_all(
         """SELECT g.goal_id,
                   g.title,
@@ -69,9 +114,76 @@ def queue_snapshot(services: AppServices = Depends(get_services)) -> list[dict]:
                   q.updated_at
            FROM goal_queue q
            JOIN goals g ON g.goal_id = q.goal_id
-           ORDER BY q.priority DESC, q.created_at ASC"""
+           ORDER BY q.priority DESC, q.created_at ASC
+           LIMIT ?""",
+        max(1, min(500, int(limit))),
     )
     return [dict(row) for row in rows]
+
+
+@router.get("/", response_class=HTMLResponse)
+def dashboard(request: Request) -> HTMLResponse:
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="index.html",
+        context={"spec_version": SPEC_VERSION},
+    )
+
+
+@router.get("/system/health")
+def system_health(services: AppServices = Depends(get_services)) -> dict:
+    return _build_health_payload(services)
+
+
+@router.get("/system/readiness")
+def system_readiness(services: AppServices = Depends(get_services)) -> dict:
+    return _build_readiness_payload(services)
+
+
+@router.post("/system/diagnostics")
+def export_system_diagnostics(services: AppServices = Depends(get_services)) -> dict:
+    diagnostics_dir = _resolve_diagnostics_dir(services.settings.diagnostics_dir)
+    diagnostics_dir.mkdir(parents=True, exist_ok=True)
+
+    generated_at = _utc_iso()
+    snapshot = {
+        "generated_at_utc": generated_at,
+        "spec_version": SPEC_VERSION,
+        "runtime": {
+            "python_version": platform.python_version(),
+            "platform": platform.platform(),
+        },
+        "database": {
+            "original_url": services.db.original_url,
+            "normalized_url": services.db.database_url,
+        },
+        "readiness": _build_readiness_payload(services),
+        "health": _build_health_payload(services),
+        "queue": _queue_snapshot(services, limit=200),
+        "recent_workflow_runs": services.workflow_catalog.list_runs(limit=50),
+        "recent_faults": services.failure_intelligence.list_faults(limit=50, dead_letter_only=False),
+        "recent_audit_entries": services.observability.list_audit(limit=50),
+        "consumer_stats": services.event_bus.consumer_stats(),
+        "backpressure": services.event_bus.backpressure_snapshot(),
+    }
+
+    file_name = f"system-diagnostics-{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}.json"
+    target_file = diagnostics_dir / file_name
+    target_file.write_text(
+        json.dumps(snapshot, ensure_ascii=True, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return {
+        "file_path": str(target_file),
+        "generated_at_utc": generated_at,
+        "ready": bool(snapshot["readiness"]["ready"]),
+    }
+
+
+@router.get("/system/queue")
+def queue_snapshot(services: AppServices = Depends(get_services)) -> list[dict]:
+    return _queue_snapshot(services)
 
 
 @router.post("/system/scheduler/age")

--- a/goal_ops_console/routers/workflows.py
+++ b/goal_ops_console/routers/workflows.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, Depends
+
+from goal_ops_console.models import WorkflowStartRequest
+from goal_ops_console.services import AppServices, get_services
+
+router = APIRouter(prefix="/workflows", tags=["workflows"])
+
+
+@router.get("")
+def list_workflows(
+    include_disabled: bool = False,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return {
+        "workflows": services.workflow_catalog.list_workflows(include_disabled=include_disabled),
+    }
+
+
+@router.get("/runs")
+def list_workflow_runs(
+    workflow_id: str | None = None,
+    limit: int = 100,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return {
+        "runs": services.workflow_catalog.list_runs(
+            workflow_id=workflow_id,
+            limit=limit,
+        ),
+    }
+
+
+@router.post("/{workflow_id}/start", status_code=201)
+def start_workflow(
+    workflow_id: str,
+    request: WorkflowStartRequest,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    run = services.workflow_catalog.start_workflow(
+        workflow_id,
+        requested_by=request.requested_by,
+        payload=request.payload,
+    )
+    return {"run": run}

--- a/goal_ops_console/routers/workflows.py
+++ b/goal_ops_console/routers/workflows.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, Header
 
-from goal_ops_console.models import WorkflowStartRequest
+from goal_ops_console.models import WorkflowCancelRequest, WorkflowStartRequest
 from goal_ops_console.services import AppServices, get_services
 
 router = APIRouter(prefix="/workflows", tags=["workflows"])
@@ -40,6 +40,28 @@ def reap_workflow_runs(
         timeout_seconds=timeout_seconds or services.settings.workflow_run_timeout_seconds,
         limit=limit or services.settings.workflow_reaper_batch_size,
     )
+
+
+@router.get("/runs/{run_id}")
+def get_workflow_run(
+    run_id: str,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return {"run": services.workflow_catalog.get_run(run_id)}
+
+
+@router.post("/runs/{run_id}/cancel")
+def cancel_workflow_run(
+    run_id: str,
+    request: WorkflowCancelRequest,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    run = services.workflow_catalog.cancel_run(
+        run_id,
+        requested_by=request.requested_by,
+        reason=request.reason,
+    )
+    return {"run": run}
 
 
 @router.post("/{workflow_id}/start", status_code=201)

--- a/goal_ops_console/routers/workflows.py
+++ b/goal_ops_console/routers/workflows.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Header
 
 from goal_ops_console.models import WorkflowStartRequest
 from goal_ops_console.services import AppServices, get_services
@@ -30,15 +30,29 @@ def list_workflow_runs(
     }
 
 
+@router.post("/runs/reap")
+def reap_workflow_runs(
+    timeout_seconds: int | None = None,
+    limit: int | None = None,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return services.workflow_catalog.reap_stuck_runs(
+        timeout_seconds=timeout_seconds or services.settings.workflow_run_timeout_seconds,
+        limit=limit or services.settings.workflow_reaper_batch_size,
+    )
+
+
 @router.post("/{workflow_id}/start", status_code=201)
 def start_workflow(
     workflow_id: str,
     request: WorkflowStartRequest,
+    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key", max_length=120),
     services: AppServices = Depends(get_services),
 ) -> dict:
     run = services.workflow_catalog.start_workflow(
         workflow_id,
         requested_by=request.requested_by,
         payload=request.payload,
+        idempotency_key=idempotency_key,
     )
     return {"run": run}

--- a/goal_ops_console/services.py
+++ b/goal_ops_console/services.py
@@ -67,6 +67,7 @@ def build_services(settings: Settings | None = None) -> AppServices:
         scheduler,
         run_timeout_seconds=app_settings.workflow_run_timeout_seconds,
         reaper_batch_size=app_settings.workflow_reaper_batch_size,
+        worker_poll_interval_seconds=app_settings.workflow_worker_poll_interval_seconds,
         observability=observability,
     )
     return AppServices(

--- a/goal_ops_console/services.py
+++ b/goal_ops_console/services.py
@@ -65,6 +65,8 @@ def build_services(settings: Settings | None = None) -> AppServices:
         db,
         event_bus,
         scheduler,
+        run_timeout_seconds=app_settings.workflow_run_timeout_seconds,
+        reaper_batch_size=app_settings.workflow_reaper_batch_size,
         observability=observability,
     )
     return AppServices(

--- a/goal_ops_console/services.py
+++ b/goal_ops_console/services.py
@@ -11,6 +11,7 @@ from goal_ops_console.observability import ObservabilityService
 from goal_ops_console.scheduler import SchedulerService
 from goal_ops_console.state_manager import StateManager
 from goal_ops_console.stubs import PermissionManager, Planner, QdrantClientStub
+from goal_ops_console.workflow_catalog import WorkflowCatalog
 
 
 @dataclass(slots=True)
@@ -23,6 +24,7 @@ class AppServices:
     execution_layer: ExecutionLayer
     failure_intelligence: FailureIntelligence
     scheduler: SchedulerService
+    workflow_catalog: WorkflowCatalog
     qdrant: QdrantClientStub
     planner: Planner
     permission_manager: PermissionManager
@@ -59,6 +61,12 @@ def build_services(settings: Settings | None = None) -> AppServices:
         observability=observability,
     )
     scheduler = SchedulerService(db, state_manager)
+    workflow_catalog = WorkflowCatalog(
+        db,
+        event_bus,
+        scheduler,
+        observability=observability,
+    )
     return AppServices(
         settings=app_settings,
         db=db,
@@ -68,6 +76,7 @@ def build_services(settings: Settings | None = None) -> AppServices:
         execution_layer=execution_layer,
         failure_intelligence=failure_intelligence,
         scheduler=scheduler,
+        workflow_catalog=workflow_catalog,
         qdrant=QdrantClientStub(),
         planner=Planner(),
         permission_manager=PermissionManager(),

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -1036,6 +1036,11 @@ async function runOperatorAction(action) {
       + `event_processing=${result.event_processing_deleted}, `
       + `failure_log=${result.failure_log_deleted}.`
     );
+  } else if (action === "diagnostics") {
+    result = await api("/system/diagnostics", { method: "POST" });
+    document.getElementById("system-feedback").textContent = (
+      `Diagnostics snapshot exported to ${result.file_path}.`
+    );
   }
   await refreshAll();
 }

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -808,6 +808,7 @@ function renderWorkflows(workflows, runs) {
     run.workflow_name,
     run.status,
     run.requested_by,
+    run.idempotency_key,
     run.correlation_id,
     JSON.stringify(run.result_payload || {}),
   ]);
@@ -834,6 +835,7 @@ function renderWorkflows(workflows, runs) {
               <td>
                 <div>${run.requested_by}</div>
                 <div class="meta">${run.run_id}</div>
+                <div class="meta">${run.idempotency_key || "no idempotency key"}</div>
               </td>
               <td><pre>${JSON.stringify(run.result_payload || {}, null, 2)}</pre></td>
             </tr>`).join("")}
@@ -1053,18 +1055,35 @@ async function runWorkflowStart(workflowId) {
     throw new Error("Select a workflow first.");
   }
   const requestedBy = document.getElementById("workflow-requested-by").value.trim() || "operator";
+  const idempotencyKey = document.getElementById("workflow-idempotency-key").value.trim();
   const payloadText = document.getElementById("workflow-payload").value;
   const payload = parseWorkflowPayload(payloadText);
   const response = await api(`/workflows/${encodeURIComponent(workflowId)}/start`, {
     method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(idempotencyKey ? { "Idempotency-Key": idempotencyKey } : {}),
+    },
     body: JSON.stringify({
       requested_by: requestedBy,
       payload,
     }),
   });
   const run = response.run;
+  const replayNote = run.idempotency_replay ? " (idempotency replay)" : "";
+  const reaperNote = run.stale_runs_reaped
+    ? ` Reaper closed ${run.stale_runs_reaped} stale runs before execution.`
+    : "";
   document.getElementById("system-feedback").textContent = (
-    `Workflow ${run.workflow_name} finished with status ${run.status}.`
+    `Workflow ${run.workflow_name} finished with status ${run.status}${replayNote}.${reaperNote}`
+  );
+  await Promise.all([refreshWorkflows(), refreshHealth(), refreshEvents()]);
+}
+
+async function runWorkflowReaper() {
+  const response = await api("/workflows/runs/reap", { method: "POST" });
+  document.getElementById("system-feedback").textContent = (
+    `Workflow reaper marked ${response.reaped_count} stale runs as timed_out.`
   );
   await Promise.all([refreshWorkflows(), refreshHealth(), refreshEvents()]);
 }
@@ -1210,6 +1229,15 @@ document.getElementById("workflow-start-form").addEventListener("submit", async 
   const workflowId = document.getElementById("workflow-select").value.trim();
   try {
     await runWorkflowStart(workflowId);
+  } catch (error) {
+    showError("workflow-error", error);
+  }
+});
+
+document.getElementById("workflow-reap-runs").addEventListener("click", async () => {
+  try {
+    showError("workflow-error", null);
+    await runWorkflowReaper();
   } catch (error) {
     showError("workflow-error", error);
   }

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -821,6 +821,7 @@ function renderWorkflows(workflows, runs) {
             <th>Status</th>
             <th>Requested By</th>
             <th>Result</th>
+            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -838,6 +839,11 @@ function renderWorkflows(workflows, runs) {
                 <div class="meta">${run.idempotency_key || "no idempotency key"}</div>
               </td>
               <td><pre>${JSON.stringify(run.result_payload || {}, null, 2)}</pre></td>
+              <td>
+                ${["queued", "running"].includes(run.status)
+                  ? `<button type="button" class="secondary" data-workflow-cancel="${run.run_id}">Cancel</button>`
+                  : `<span class="meta">-</span>`}
+              </td>
             </tr>`).join("")}
         </tbody>
       </table></div>`
@@ -1074,8 +1080,9 @@ async function runWorkflowStart(workflowId) {
   const reaperNote = run.stale_runs_reaped
     ? ` Reaper closed ${run.stale_runs_reaped} stale runs before execution.`
     : "";
+  const queuedNote = run.status === "queued" ? " Run is queued and will execute asynchronously." : "";
   document.getElementById("system-feedback").textContent = (
-    `Workflow ${run.workflow_name} finished with status ${run.status}${replayNote}.${reaperNote}`
+    `Workflow ${run.workflow_name} accepted with status ${run.status}${replayNote}.${queuedNote}${reaperNote}`
   );
   await Promise.all([refreshWorkflows(), refreshHealth(), refreshEvents()]);
 }
@@ -1084,6 +1091,21 @@ async function runWorkflowReaper() {
   const response = await api("/workflows/runs/reap", { method: "POST" });
   document.getElementById("system-feedback").textContent = (
     `Workflow reaper marked ${response.reaped_count} stale runs as timed_out.`
+  );
+  await Promise.all([refreshWorkflows(), refreshHealth(), refreshEvents()]);
+}
+
+async function runWorkflowCancel(runId) {
+  const response = await api(`/workflows/runs/${encodeURIComponent(runId)}/cancel`, {
+    method: "POST",
+    body: JSON.stringify({
+      requested_by: "operator",
+      reason: "Cancelled from dashboard",
+    }),
+  });
+  const run = response.run;
+  document.getElementById("system-feedback").textContent = (
+    `Workflow run ${run.run_id} is now ${run.status}.`
   );
   await Promise.all([refreshWorkflows(), refreshHealth(), refreshEvents()]);
 }
@@ -1368,6 +1390,7 @@ document.addEventListener("click", async (event) => {
   const faultAction = event.target.dataset.faultAction;
   const failureId = event.target.dataset.failureId;
   const workflowStart = event.target.dataset.workflowStart;
+  const workflowCancel = event.target.dataset.workflowCancel;
   const correlation = event.target.dataset.correlation;
   const selectGoal = event.target.dataset.selectGoal;
   const operatorAction = event.target.dataset.operatorAction;
@@ -1390,6 +1413,10 @@ document.addEventListener("click", async (event) => {
     if (workflowStart) {
       document.getElementById("workflow-select").value = workflowStart;
       await runWorkflowStart(workflowStart);
+    }
+
+    if (workflowCancel) {
+      await runWorkflowCancel(workflowCancel);
     }
 
     if (goalAction && goalId) {
@@ -1445,7 +1472,7 @@ document.addEventListener("click", async (event) => {
   } catch (error) {
     const target = operatorAction || faultAction
       ? "system-feedback"
-      : workflowStart
+      : workflowStart || workflowCancel
         ? "workflow-error"
         : goalAction
           ? "goal-error"

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -5,6 +5,7 @@ const SECTION_IDS = [
   "goals-section",
   "tasks-section",
   "operator-section",
+  "workflows-section",
   "events-section",
   "trace-section",
   "audit-section",
@@ -43,6 +44,8 @@ let jumpScrollScheduled = false;
 const viewCache = {
   goals: [],
   tasks: [],
+  workflows: [],
+  workflowRuns: [],
   events: [],
   auditEntries: [],
   faultSummary: {},
@@ -238,6 +241,7 @@ function setAutoRefresh(enabled) {
 function rerenderFilteredViews() {
   renderGoals(viewCache.goals);
   renderTasks(viewCache.tasks);
+  renderWorkflows(viewCache.workflows, viewCache.workflowRuns);
   renderEvents(viewCache.events);
   renderAudit(viewCache.auditEntries);
   renderFaults(viewCache.faultSummary, viewCache.faultEntries);
@@ -737,11 +741,122 @@ function renderQueue(goals) {
   </table></div>`;
 }
 
+function renderWorkflows(workflows, runs) {
+  const workflowContainer = document.getElementById("workflows-table");
+  const runsContainer = document.getElementById("workflow-runs-table");
+  const workflowSelect = document.getElementById("workflow-select");
+  if (!workflowContainer || !runsContainer || !workflowSelect) {
+    return;
+  }
+
+  const selectableWorkflows = workflows.filter((item) => item.is_enabled);
+  const selectedBefore = workflowSelect.value;
+  workflowSelect.innerHTML = `
+    <option value="">Select workflow</option>
+    ${selectableWorkflows.map((item) => `<option value="${item.workflow_id}">${item.name}</option>`).join("")}
+  `;
+  if (selectedBefore && selectableWorkflows.some((item) => item.workflow_id === selectedBefore)) {
+    workflowSelect.value = selectedBefore;
+  } else if (!selectedBefore && selectableWorkflows.length) {
+    workflowSelect.value = selectableWorkflows[0].workflow_id;
+  }
+
+  const filteredWorkflows = filterRows(workflows, (item) => [
+    item.workflow_id,
+    item.name,
+    item.description,
+    item.entrypoint,
+    item.last_run_at,
+  ]);
+  workflowContainer.innerHTML = filteredWorkflows.length
+    ? `<div class="table-scroll"><table>
+        <thead>
+          <tr>
+            <th>Workflow</th>
+            <th>Description</th>
+            <th>Entrypoint</th>
+            <th>Runs</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${filteredWorkflows.map((item) => `
+            <tr>
+              <td>
+                <div>${item.name}</div>
+                <div class="meta">${item.workflow_id}</div>
+              </td>
+              <td>${item.description || "-"}</td>
+              <td><span class="meta">${item.entrypoint}</span></td>
+              <td>
+                <div>${item.run_count || 0}</div>
+                <div class="meta">${item.last_run_at || "never"}</div>
+              </td>
+              <td>
+                <div class="actions">
+                  <button type="button" class="secondary" data-workflow-start="${item.workflow_id}" ${item.is_enabled ? "" : "disabled"}>Start</button>
+                </div>
+              </td>
+            </tr>`).join("")}
+        </tbody>
+      </table></div>`
+    : `<div class="meta">${filteredEmptyMessage("No workflows available.")}</div>`;
+
+  const filteredRuns = filterRows(runs, (run) => [
+    run.run_id,
+    run.workflow_id,
+    run.workflow_name,
+    run.status,
+    run.requested_by,
+    run.correlation_id,
+    JSON.stringify(run.result_payload || {}),
+  ]);
+  runsContainer.innerHTML = filteredRuns.length
+    ? `<div class="table-scroll"><table>
+        <thead>
+          <tr>
+            <th>Started</th>
+            <th>Workflow</th>
+            <th>Status</th>
+            <th>Requested By</th>
+            <th>Result</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${filteredRuns.map((run) => `
+            <tr>
+              <td>${run.started_at}</td>
+              <td>
+                <div>${run.workflow_name}</div>
+                <div class="meta">${run.workflow_id}</div>
+              </td>
+              <td><span class="pill ${stateClass(run.status)}">${run.status}</span></td>
+              <td>
+                <div>${run.requested_by}</div>
+                <div class="meta">${run.run_id}</div>
+              </td>
+              <td><pre>${JSON.stringify(run.result_payload || {}, null, 2)}</pre></td>
+            </tr>`).join("")}
+        </tbody>
+      </table></div>`
+    : `<div class="meta">${filteredEmptyMessage("No workflow runs yet.")}</div>`;
+}
+
 async function refreshGoals() {
   const goals = await api("/goals");
   viewCache.goals = goals;
   renderGoals(viewCache.goals);
   updateSelectedGoalLabel();
+}
+
+async function refreshWorkflows() {
+  const [workflowPayload, runPayload] = await Promise.all([
+    api("/workflows"),
+    api("/workflows/runs?limit=100"),
+  ]);
+  viewCache.workflows = workflowPayload.workflows || [];
+  viewCache.workflowRuns = runPayload.runs || [];
+  renderWorkflows(viewCache.workflows, viewCache.workflowRuns);
 }
 
 async function refreshQueue() {
@@ -854,6 +969,7 @@ async function refreshAll() {
   await Promise.all([
     refreshGoals(),
     refreshTasks(),
+    refreshWorkflows(),
     refreshEvents(),
     refreshFlowTrace(),
     refreshAudit(),
@@ -873,6 +989,7 @@ function startAutoRefreshLoop() {
     }
     refreshGoals().catch(() => {});
     refreshTasks().catch(() => {});
+    refreshWorkflows().catch(() => {});
     refreshEvents().catch(() => {});
     refreshFlowTrace().catch(() => {});
     refreshAudit().catch(() => {});
@@ -913,6 +1030,43 @@ async function runOperatorAction(action) {
     );
   }
   await refreshAll();
+}
+
+function parseWorkflowPayload(text) {
+  if (!text.trim()) {
+    return {};
+  }
+  let payload;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    throw new Error("Workflow payload must be valid JSON.");
+  }
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+    throw new Error("Workflow payload must be a JSON object.");
+  }
+  return payload;
+}
+
+async function runWorkflowStart(workflowId) {
+  if (!workflowId) {
+    throw new Error("Select a workflow first.");
+  }
+  const requestedBy = document.getElementById("workflow-requested-by").value.trim() || "operator";
+  const payloadText = document.getElementById("workflow-payload").value;
+  const payload = parseWorkflowPayload(payloadText);
+  const response = await api(`/workflows/${encodeURIComponent(workflowId)}/start`, {
+    method: "POST",
+    body: JSON.stringify({
+      requested_by: requestedBy,
+      payload,
+    }),
+  });
+  const run = response.run;
+  document.getElementById("system-feedback").textContent = (
+    `Workflow ${run.workflow_name} finished with status ${run.status}.`
+  );
+  await Promise.all([refreshWorkflows(), refreshHealth(), refreshEvents()]);
 }
 
 async function runFaultAction(action, failureId) {
@@ -1050,6 +1204,17 @@ document.getElementById("task-form").addEventListener("submit", async (event) =>
   }
 });
 
+document.getElementById("workflow-start-form").addEventListener("submit", async (event) => {
+  event.preventDefault();
+  showError("workflow-error", null);
+  const workflowId = document.getElementById("workflow-select").value.trim();
+  try {
+    await runWorkflowStart(workflowId);
+  } catch (error) {
+    showError("workflow-error", error);
+  }
+});
+
 document.getElementById("event-filter-form").addEventListener("submit", async (event) => {
   event.preventDefault();
   await refreshEvents();
@@ -1081,6 +1246,7 @@ document.getElementById("flow-trace-form").addEventListener("submit", async (eve
 
 document.getElementById("refresh-goals").addEventListener("click", refreshGoals);
 document.getElementById("refresh-tasks").addEventListener("click", refreshTasks);
+document.getElementById("refresh-workflows").addEventListener("click", refreshWorkflows);
 document.getElementById("refresh-events").addEventListener("click", refreshEvents);
 document.getElementById("refresh-flow-trace").addEventListener("click", refreshFlowTrace);
 document.getElementById("refresh-audit").addEventListener("click", refreshAudit);
@@ -1173,6 +1339,7 @@ document.addEventListener("click", async (event) => {
   const taskId = event.target.dataset.taskId;
   const faultAction = event.target.dataset.faultAction;
   const failureId = event.target.dataset.failureId;
+  const workflowStart = event.target.dataset.workflowStart;
   const correlation = event.target.dataset.correlation;
   const selectGoal = event.target.dataset.selectGoal;
   const operatorAction = event.target.dataset.operatorAction;
@@ -1190,6 +1357,11 @@ document.addEventListener("click", async (event) => {
 
     if (faultAction && failureId) {
       await runFaultAction(faultAction, failureId);
+    }
+
+    if (workflowStart) {
+      document.getElementById("workflow-select").value = workflowStart;
+      await runWorkflowStart(workflowStart);
     }
 
     if (goalAction && goalId) {
@@ -1243,7 +1415,13 @@ document.addEventListener("click", async (event) => {
       updateSelectedGoalLabel();
     }
   } catch (error) {
-    const target = operatorAction || faultAction ? "system-feedback" : goalAction ? "goal-error" : "task-error";
+    const target = operatorAction || faultAction
+      ? "system-feedback"
+      : workflowStart
+        ? "workflow-error"
+        : goalAction
+          ? "goal-error"
+          : "task-error";
     showError(target, error);
   }
 });

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -730,7 +730,7 @@
     <div class="command-bar" aria-label="Operator command bar">
       <div class="command-row">
         <label class="sr-only" for="global-filter">Global filter</label>
-        <input id="global-filter" placeholder="Global filter across goals, tasks, events, faults and queue (press /)">
+        <input id="global-filter" placeholder="Global filter across goals, tasks, workflows, events, faults and queue (press /)">
         <button type="button" class="secondary" id="toggle-refresh">Auto-refresh: On</button>
         <button type="button" class="secondary" id="toggle-density">Density: Comfy</button>
         <button type="button" class="secondary" id="toggle-visual-mode">Visual: Warm</button>
@@ -739,6 +739,7 @@
         <button type="button" class="jump-btn active" data-jump-target="goals-section">Goals</button>
         <button type="button" class="jump-btn" data-jump-target="tasks-section">Tasks</button>
         <button type="button" class="jump-btn" data-jump-target="operator-section">Operator</button>
+        <button type="button" class="jump-btn" data-jump-target="workflows-section">Workflows</button>
         <button type="button" class="jump-btn" data-jump-target="events-section">Events</button>
         <button type="button" class="jump-btn" data-jump-target="trace-section">Trace</button>
         <button type="button" class="jump-btn" data-jump-target="audit-section">Audit</button>
@@ -817,6 +818,27 @@
       </div>
       <div class="error" id="system-feedback" role="status" aria-live="polite"></div>
       <div id="queue-table"></div>
+    </section>
+
+    <section class="wide" id="workflows-section" data-section-anchor="workflows">
+      <h2><span>Workflow Catalog</span><button class="secondary" id="refresh-workflows">Refresh</button></h2>
+      <form id="workflow-start-form">
+        <div class="split">
+          <label class="sr-only" for="workflow-select">Workflow definition</label>
+          <select id="workflow-select" required>
+            <option value="">Select workflow</option>
+          </select>
+          <label class="sr-only" for="workflow-requested-by">Requested by</label>
+          <input id="workflow-requested-by" value="operator" placeholder="Requested by">
+        </div>
+        <label class="sr-only" for="workflow-payload">Workflow payload JSON</label>
+        <textarea id="workflow-payload" placeholder='Optional payload as JSON (example: {"note":"manual run"})'></textarea>
+        <button type="submit">Start Workflow</button>
+        <div class="error" id="workflow-error" role="status" aria-live="polite"></div>
+      </form>
+      <div id="workflows-table"></div>
+      <h3>Recent Runs</h3>
+      <div id="workflow-runs-table"></div>
     </section>
 
     <section class="wide" id="events-section" data-section-anchor="events">

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -813,6 +813,7 @@
           <span class="meta">Maintenance</span>
           <div class="actions" style="margin-top:0.75rem;">
             <button type="button" data-operator-action="retention">Run Retention Cleanup</button>
+            <button type="button" class="secondary" data-operator-action="diagnostics">Export Diagnostics</button>
           </div>
         </div>
       </div>

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -831,6 +831,11 @@
           <label class="sr-only" for="workflow-requested-by">Requested by</label>
           <input id="workflow-requested-by" value="operator" placeholder="Requested by">
         </div>
+        <div class="split">
+          <label class="sr-only" for="workflow-idempotency-key">Idempotency key</label>
+          <input id="workflow-idempotency-key" placeholder="Optional Idempotency-Key">
+          <button type="button" class="secondary" id="workflow-reap-runs">Reap Stuck Runs</button>
+        </div>
         <label class="sr-only" for="workflow-payload">Workflow payload JSON</label>
         <textarea id="workflow-payload" placeholder='Optional payload as JSON (example: {"note":"manual run"})'></textarea>
         <button type="submit">Start Workflow</button>

--- a/goal_ops_console/workflow_catalog.py
+++ b/goal_ops_console/workflow_catalog.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import threading
 from collections.abc import Callable
 from time import perf_counter
 from typing import TYPE_CHECKING, Any
@@ -36,6 +37,8 @@ DEFAULT_WORKFLOW_DEFINITIONS: tuple[dict[str, str], ...] = (
     },
 )
 
+TERMINAL_RUN_STATES = {"succeeded", "failed", "timed_out", "cancelled"}
+
 
 class WorkflowCatalog:
     def __init__(
@@ -46,20 +49,53 @@ class WorkflowCatalog:
         *,
         run_timeout_seconds: int = 300,
         reaper_batch_size: int = 200,
+        worker_poll_interval_seconds: float = 0.5,
         observability: "ObservabilityService | None" = None,
     ):
         self.db = db
         self.event_bus = event_bus
         self.scheduler = scheduler
-        self.run_timeout_seconds = run_timeout_seconds
-        self.reaper_batch_size = reaper_batch_size
+        self.run_timeout_seconds = max(0, int(run_timeout_seconds))
+        self.reaper_batch_size = max(1, int(reaper_batch_size))
+        self.worker_poll_interval_seconds = max(0.05, float(worker_poll_interval_seconds))
         self.observability = observability
         self.handlers: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
             "scheduler.age_queue": self._run_scheduler_age_queue,
             "scheduler.pick_next_goal": self._run_scheduler_pick_next_goal,
             "maintenance.retention_cleanup": self._run_retention_cleanup,
         }
+
+        self._worker_stop = threading.Event()
+        self._worker_wakeup = threading.Event()
+        self._worker_lock = threading.Lock()
+        self._worker_thread: threading.Thread | None = None
+
         self._seed_default_workflows()
+
+    def start_worker(self) -> None:
+        with self._worker_lock:
+            if self._worker_thread is not None and self._worker_thread.is_alive():
+                return
+            self._worker_stop.clear()
+            self._worker_wakeup.set()
+            self._worker_thread = threading.Thread(
+                target=self._worker_loop,
+                daemon=True,
+                name="goal-ops-workflow-worker",
+            )
+            self._worker_thread.start()
+
+    def stop_worker(self, timeout_seconds: float = 5.0) -> None:
+        with self._worker_lock:
+            thread = self._worker_thread
+            if thread is None:
+                return
+            self._worker_stop.set()
+            self._worker_wakeup.set()
+        thread.join(timeout=timeout_seconds)
+        with self._worker_lock:
+            if self._worker_thread is thread:
+                self._worker_thread = None
 
     def list_workflows(self, *, include_disabled: bool = False) -> list[dict[str, Any]]:
         where = "" if include_disabled else "WHERE wd.is_enabled = 1"
@@ -133,7 +169,7 @@ class WorkflowCatalog:
                 ORDER BY wr.created_at DESC
                 LIMIT ?""",
             *params,
-            limit,
+            max(1, min(500, int(limit))),
         )
         return [self._run_to_dict(row) for row in rows]
 
@@ -196,17 +232,17 @@ class WorkflowCatalog:
 
         run_id = new_id()
         correlation_id = f"workflow:{workflow_id}:{run_id[:8]}"
-        started_at = now_utc()
+        created_at = now_utc()
         input_payload = payload or {}
         try:
-            self._insert_run(
+            self._insert_queued_run(
                 run_id=run_id,
                 workflow_id=workflow_id,
                 requested_by=requested_by,
                 correlation_id=correlation_id,
                 idempotency_key=normalized_idempotency_key,
                 input_payload=input_payload,
-                started_at=started_at,
+                created_at=created_at,
                 entrypoint=str(definition["entrypoint"]),
             )
         except sqlite3.IntegrityError as error:
@@ -218,53 +254,78 @@ class WorkflowCatalog:
                 return replayed
             raise ConflictError(f"Workflow run insert failed: {error}") from error
 
-        started_monotonic = perf_counter()
-        try:
-            result_payload = handler(input_payload)
-        except Exception as error:
-            failed = self._mark_run_failed(
-                run_id=run_id,
-                workflow_id=workflow_id,
-                requested_by=requested_by,
-                correlation_id=correlation_id,
-                error=error,
-                status="failed",
-            )
-            failed["idempotency_replay"] = False
-            failed["stale_runs_reaped"] = stale["reaped_count"]
-            return failed
+        self._worker_wakeup.set()
+        queued = self.get_run(run_id)
+        queued["idempotency_replay"] = False
+        queued["stale_runs_reaped"] = stale["reaped_count"]
+        return queued
 
-        duration_ms = int((perf_counter() - started_monotonic) * 1000)
-        if duration_ms > self.run_timeout_seconds * 1000:
-            timeout_error = TimeoutError(
-                (
-                    f"Workflow {workflow_id} exceeded timeout "
-                    f"({duration_ms}ms > {self.run_timeout_seconds * 1000}ms)"
+    def cancel_run(
+        self,
+        run_id: str,
+        *,
+        requested_by: str = "operator",
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        with self.db.transaction() as tx:
+            run = tx.fetch_one(
+                "SELECT run_id, workflow_id, status, correlation_id FROM workflow_runs WHERE run_id = ?",
+                run_id,
+            )
+            if run is None:
+                raise NotFoundError(f"Workflow run {run_id} not found")
+
+            current_status = str(run["status"])
+            if current_status in {"succeeded", "failed", "timed_out"}:
+                raise ConflictError(
+                    f"Workflow run {run_id} is already terminal with status '{current_status}'"
                 )
-            )
-            timed_out = self._mark_run_failed(
-                run_id=run_id,
-                workflow_id=workflow_id,
-                requested_by=requested_by,
-                correlation_id=correlation_id,
-                error=timeout_error,
-                status="timed_out",
-                details={"duration_ms": duration_ms},
-            )
-            timed_out["idempotency_replay"] = False
-            timed_out["stale_runs_reaped"] = stale["reaped_count"]
-            return timed_out
+            if current_status == "cancelled":
+                return self.get_run(run_id)
 
-        result = self._mark_run_succeeded(
-            run_id=run_id,
-            workflow_id=workflow_id,
-            requested_by=requested_by,
-            correlation_id=correlation_id,
-            result_payload={**result_payload, "duration_ms": duration_ms},
-        )
-        result["idempotency_replay"] = False
-        result["stale_runs_reaped"] = stale["reaped_count"]
-        return result
+            timestamp = now_utc()
+            updated = tx.execute(
+                """UPDATE workflow_runs
+                   SET status = 'cancelled',
+                       finished_at = COALESCE(finished_at, ?),
+                       updated_at = ?
+                   WHERE run_id = ? AND status IN ('queued', 'running')""",
+                timestamp,
+                timestamp,
+                run_id,
+            )
+            if updated == 0:
+                return self.get_run(run_id)
+
+            self._safe_record_event(
+                "workflow.run.cancelled",
+                run_id,
+                str(run["correlation_id"]),
+                {
+                    "workflow_id": run["workflow_id"],
+                    "requested_by": requested_by,
+                    "reason": reason,
+                    "from_status": current_status,
+                },
+                tx=tx,
+            )
+            self._metric("workflows.runs.cancelled", tx=tx)
+            self._record_audit(
+                tx,
+                action="workflow.cancel",
+                actor=requested_by,
+                status="success",
+                workflow_id=str(run["workflow_id"]),
+                correlation_id=str(run["correlation_id"]),
+                details={
+                    "run_id": run_id,
+                    "from_status": current_status,
+                    "reason": reason,
+                },
+            )
+
+        self._worker_wakeup.set()
+        return self.get_run(run_id)
 
     def reap_stuck_runs(self, *, timeout_seconds: int, limit: int) -> dict[str, Any]:
         safe_limit = max(1, min(500, int(limit)))
@@ -275,7 +336,7 @@ class WorkflowCatalog:
                AND started_at < datetime('now', ? || ' seconds')
                ORDER BY started_at ASC
                LIMIT ?""",
-            f"-{timeout_seconds}",
+            f"-{max(0, int(timeout_seconds))}",
             safe_limit,
         )
         if not rows:
@@ -309,7 +370,7 @@ class WorkflowCatalog:
                 if updated == 0:
                     continue
                 run_ids.append(run_id)
-                self.event_bus.record_event(
+                self._safe_record_event(
                     "workflow.run.timed_out",
                     run_id,
                     str(row["correlation_id"]),
@@ -338,7 +399,146 @@ class WorkflowCatalog:
                 self._metric("workflows.runs.timed_out", delta=len(run_ids), tx=tx)
         return {"reaped_count": len(run_ids), "run_ids": run_ids}
 
-    def _insert_run(
+    def _worker_loop(self) -> None:
+        while not self._worker_stop.is_set():
+            try:
+                self.reap_stuck_runs(
+                    timeout_seconds=self.run_timeout_seconds,
+                    limit=self.reaper_batch_size,
+                )
+            except Exception:
+                self._metric("workflows.worker.errors")
+
+            processed_any = False
+            while not self._worker_stop.is_set():
+                claimed = self._claim_next_queued_run()
+                if claimed is None:
+                    break
+                processed_any = True
+                self._execute_claimed_run(claimed)
+
+            if processed_any:
+                continue
+
+            self._worker_wakeup.wait(self.worker_poll_interval_seconds)
+            self._worker_wakeup.clear()
+
+    def _claim_next_queued_run(self) -> dict[str, Any] | None:
+        with self.db.transaction() as tx:
+            row = tx.fetch_one(
+                """SELECT run_id
+                   FROM workflow_runs
+                   WHERE status = 'queued'
+                   ORDER BY created_at ASC
+                   LIMIT 1"""
+            )
+            if row is None:
+                return None
+
+            run_id = str(row["run_id"])
+            started_at = now_utc()
+            updated = tx.execute(
+                """UPDATE workflow_runs
+                   SET status = 'running', started_at = ?, updated_at = ?
+                   WHERE run_id = ? AND status = 'queued'""",
+                started_at,
+                started_at,
+                run_id,
+            )
+            if updated == 0:
+                return None
+
+            claimed = tx.fetch_one(
+                """SELECT run_id, workflow_id, requested_by, correlation_id, input_payload
+                   FROM workflow_runs WHERE run_id = ?""",
+                run_id,
+            )
+            if claimed is None:
+                return None
+
+            self._safe_record_event(
+                "workflow.run.started",
+                run_id,
+                str(claimed["correlation_id"]),
+                {
+                    "workflow_id": claimed["workflow_id"],
+                    "requested_by": claimed["requested_by"],
+                },
+                tx=tx,
+            )
+            self._metric("workflows.runs.started", tx=tx)
+            return dict(claimed)
+
+    def _execute_claimed_run(self, claimed_run: dict[str, Any]) -> None:
+        run_id = str(claimed_run["run_id"])
+        workflow_id = str(claimed_run["workflow_id"])
+        requested_by = str(claimed_run["requested_by"])
+        correlation_id = str(claimed_run["correlation_id"])
+
+        try:
+            definition = self.get_workflow(workflow_id, include_disabled=True)
+            handler = self.handlers.get(str(definition["entrypoint"]))
+            if handler is None:
+                self._mark_run_failed(
+                    run_id=run_id,
+                    workflow_id=workflow_id,
+                    requested_by=requested_by,
+                    correlation_id=correlation_id,
+                    error=ConflictError(
+                        f"Workflow {workflow_id} has unknown entrypoint '{definition['entrypoint']}'"
+                    ),
+                    status="failed",
+                    expected_status="running",
+                )
+                return
+
+            payload = self._json_load(claimed_run.get("input_payload")) or {}
+            started_monotonic = perf_counter()
+            try:
+                result_payload = handler(payload)
+            except Exception as error:
+                self._mark_run_failed(
+                    run_id=run_id,
+                    workflow_id=workflow_id,
+                    requested_by=requested_by,
+                    correlation_id=correlation_id,
+                    error=error,
+                    status="failed",
+                    expected_status="running",
+                )
+                return
+
+            duration_ms = int((perf_counter() - started_monotonic) * 1000)
+            if duration_ms > self.run_timeout_seconds * 1000:
+                self._mark_run_failed(
+                    run_id=run_id,
+                    workflow_id=workflow_id,
+                    requested_by=requested_by,
+                    correlation_id=correlation_id,
+                    error=TimeoutError(
+                        (
+                            f"Workflow {workflow_id} exceeded timeout "
+                            f"({duration_ms}ms > {self.run_timeout_seconds * 1000}ms)"
+                        )
+                    ),
+                    status="timed_out",
+                    expected_status="running",
+                    details={"duration_ms": duration_ms},
+                )
+                return
+
+            self._mark_run_succeeded(
+                run_id=run_id,
+                workflow_id=workflow_id,
+                requested_by=requested_by,
+                correlation_id=correlation_id,
+                result_payload={**result_payload, "duration_ms": duration_ms},
+                expected_status="running",
+            )
+        except Exception:
+            self._metric("workflows.worker.errors")
+
+    def _insert_queued_run(
         self,
         *,
         run_id: str,
@@ -347,7 +547,7 @@ class WorkflowCatalog:
         correlation_id: str,
         idempotency_key: str | None,
         input_payload: dict[str, Any],
-        started_at: str,
+        created_at: str,
         entrypoint: str,
     ) -> None:
         with self.db.transaction() as tx:
@@ -355,19 +555,19 @@ class WorkflowCatalog:
                 """INSERT INTO workflow_runs
                    (run_id, workflow_id, status, requested_by, correlation_id, idempotency_key,
                     input_payload, result_payload, started_at, finished_at, created_at, updated_at)
-                   VALUES (?, ?, 'running', ?, ?, ?, ?, NULL, ?, NULL, ?, ?)""",
+                   VALUES (?, ?, 'queued', ?, ?, ?, ?, NULL, ?, NULL, ?, ?)""",
                 run_id,
                 workflow_id,
                 requested_by,
                 correlation_id,
                 idempotency_key,
                 self._json_dump(input_payload),
-                started_at,
-                started_at,
-                started_at,
+                created_at,
+                created_at,
+                created_at,
             )
-            self.event_bus.record_event(
-                "workflow.run.started",
+            self._safe_record_event(
+                "workflow.run.queued",
                 run_id,
                 correlation_id,
                 {
@@ -378,7 +578,19 @@ class WorkflowCatalog:
                 },
                 tx=tx,
             )
-            self._metric("workflows.runs.started", tx=tx)
+            self._metric("workflows.runs.queued", tx=tx)
+            self._record_audit(
+                tx,
+                action="workflow.enqueue",
+                actor=requested_by,
+                status="success",
+                workflow_id=workflow_id,
+                correlation_id=correlation_id,
+                details={
+                    "run_id": run_id,
+                    "idempotency_key": idempotency_key,
+                },
+            )
 
     def _find_run_by_idempotency(
         self,
@@ -409,43 +621,54 @@ class WorkflowCatalog:
         requested_by: str,
         correlation_id: str,
         result_payload: dict[str, Any],
+        expected_status: str,
     ) -> dict[str, Any]:
         finished_at = now_utc()
+        applied = False
         with self.db.transaction() as tx:
-            tx.execute(
+            rows = tx.execute(
                 """UPDATE workflow_runs
                    SET status = 'succeeded',
                        result_payload = ?,
                        finished_at = ?,
                        updated_at = ?
-                   WHERE run_id = ?""",
+                   WHERE run_id = ? AND status = ?""",
                 self._json_dump(result_payload),
                 finished_at,
                 finished_at,
                 run_id,
+                expected_status,
             )
-            self.event_bus.record_event(
-                "workflow.run.succeeded",
-                run_id,
-                correlation_id,
-                {
-                    "workflow_id": workflow_id,
-                    "requested_by": requested_by,
-                    "result": result_payload,
-                },
-                tx=tx,
+            if rows > 0:
+                applied = True
+                self._safe_record_event(
+                    "workflow.run.succeeded",
+                    run_id,
+                    correlation_id,
+                    {
+                        "workflow_id": workflow_id,
+                        "requested_by": requested_by,
+                        "result": result_payload,
+                    },
+                    tx=tx,
+                )
+                self._metric("workflows.runs.succeeded", tx=tx)
+                self._record_audit(
+                    tx,
+                    action="workflow.run",
+                    actor=requested_by,
+                    status="success",
+                    workflow_id=workflow_id,
+                    correlation_id=correlation_id,
+                    details={"run_id": run_id, "result": result_payload},
+                )
+
+        run = self.get_run(run_id)
+        if not applied and run["status"] not in TERMINAL_RUN_STATES:
+            raise ConflictError(
+                f"Workflow run {run_id} could not transition from {expected_status} to succeeded"
             )
-            self._metric("workflows.runs.succeeded", tx=tx)
-            self._record_audit(
-                tx,
-                action="workflow.run",
-                actor=requested_by,
-                status="success",
-                workflow_id=workflow_id,
-                correlation_id=correlation_id,
-                details={"run_id": run_id, "result": result_payload},
-            )
-        return self.get_run(run_id)
+        return run
 
     def _mark_run_failed(
         self,
@@ -455,7 +678,8 @@ class WorkflowCatalog:
         requested_by: str,
         correlation_id: str,
         error: Exception,
-        status: str = "failed",
+        status: str,
+        expected_status: str,
         details: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         finished_at = now_utc()
@@ -465,44 +689,55 @@ class WorkflowCatalog:
             **(details or {}),
         }
         event_type = "workflow.run.timed_out" if status == "timed_out" else "workflow.run.failed"
+        metric_name = "workflows.runs.timed_out" if status == "timed_out" else "workflows.runs.failed"
+
+        applied = False
         with self.db.transaction() as tx:
-            tx.execute(
+            rows = tx.execute(
                 """UPDATE workflow_runs
                    SET status = ?,
                        result_payload = ?,
                        finished_at = ?,
                        updated_at = ?
-                   WHERE run_id = ?""",
+                   WHERE run_id = ? AND status = ?""",
                 status,
                 self._json_dump(error_payload),
                 finished_at,
                 finished_at,
                 run_id,
+                expected_status,
             )
-            self.event_bus.record_event(
-                event_type,
-                run_id,
-                correlation_id,
-                {
-                    "workflow_id": workflow_id,
-                    "requested_by": requested_by,
-                    "error_type": error.__class__.__name__,
-                    "error": str(error),
-                },
-                tx=tx,
+            if rows > 0:
+                applied = True
+                self._safe_record_event(
+                    event_type,
+                    run_id,
+                    correlation_id,
+                    {
+                        "workflow_id": workflow_id,
+                        "requested_by": requested_by,
+                        "error_type": error.__class__.__name__,
+                        "error": str(error),
+                    },
+                    tx=tx,
+                )
+                self._metric(metric_name, tx=tx)
+                self._record_audit(
+                    tx,
+                    action="workflow.run",
+                    actor=requested_by,
+                    status="error",
+                    workflow_id=workflow_id,
+                    correlation_id=correlation_id,
+                    details={"run_id": run_id, "status": status, "error": str(error)},
+                )
+
+        run = self.get_run(run_id)
+        if not applied and run["status"] not in TERMINAL_RUN_STATES:
+            raise ConflictError(
+                f"Workflow run {run_id} could not transition from {expected_status} to {status}"
             )
-            metric_name = "workflows.runs.timed_out" if status == "timed_out" else "workflows.runs.failed"
-            self._metric(metric_name, tx=tx)
-            self._record_audit(
-                tx,
-                action="workflow.run",
-                actor=requested_by,
-                status="error",
-                workflow_id=workflow_id,
-                correlation_id=correlation_id,
-                details={"run_id": run_id, "status": status, "error": str(error)},
-            )
-        return self.get_run(run_id)
+        return run
 
     def _run_scheduler_age_queue(self, _: dict[str, Any]) -> dict[str, Any]:
         self.event_bus.ensure_within_backpressure()
@@ -561,6 +796,26 @@ class WorkflowCatalog:
         if isinstance(payload, dict):
             return payload
         return {"value": payload}
+
+    def _safe_record_event(
+        self,
+        event_type: str,
+        entity_id: str,
+        correlation_id: str,
+        payload: dict[str, Any],
+        *,
+        tx: Transaction | None = None,
+    ) -> None:
+        try:
+            self.event_bus.record_event(
+                event_type,
+                entity_id,
+                correlation_id,
+                payload,
+                tx=tx,
+            )
+        except Exception:
+            self._metric("workflows.events.dropped", tx=tx)
 
     def _record_audit(
         self,

--- a/goal_ops_console/workflow_catalog.py
+++ b/goal_ops_console/workflow_catalog.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from collections.abc import Callable
+from time import perf_counter
 from typing import TYPE_CHECKING, Any
 
 from goal_ops_console.database import Database, Transaction, new_id, now_utc
@@ -42,11 +44,15 @@ class WorkflowCatalog:
         event_bus: EventBus,
         scheduler: SchedulerService,
         *,
+        run_timeout_seconds: int = 300,
+        reaper_batch_size: int = 200,
         observability: "ObservabilityService | None" = None,
     ):
         self.db = db
         self.event_bus = event_bus
         self.scheduler = scheduler
+        self.run_timeout_seconds = run_timeout_seconds
+        self.reaper_batch_size = reaper_batch_size
         self.observability = observability
         self.handlers: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
             "scheduler.age_queue": self._run_scheduler_age_queue,
@@ -114,6 +120,7 @@ class WorkflowCatalog:
                        wr.status,
                        wr.requested_by,
                        wr.correlation_id,
+                       wr.idempotency_key,
                        wr.input_payload,
                        wr.result_payload,
                        wr.started_at,
@@ -138,6 +145,7 @@ class WorkflowCatalog:
                       wr.status,
                       wr.requested_by,
                       wr.correlation_id,
+                      wr.idempotency_key,
                       wr.input_payload,
                       wr.result_payload,
                       wr.started_at,
@@ -159,6 +167,7 @@ class WorkflowCatalog:
         *,
         requested_by: str = "operator",
         payload: dict[str, Any] | None = None,
+        idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         definition = self.get_workflow(workflow_id, include_disabled=True)
         if not definition["is_enabled"]:
@@ -170,21 +179,188 @@ class WorkflowCatalog:
                 f"Workflow {workflow_id} has unknown entrypoint '{definition['entrypoint']}'"
             )
 
+        stale = self.reap_stuck_runs(
+            timeout_seconds=self.run_timeout_seconds,
+            limit=self.reaper_batch_size,
+        )
         self.event_bus.ensure_within_backpressure()
+
+        normalized_idempotency_key = self._normalize_idempotency_key(idempotency_key)
+        if normalized_idempotency_key:
+            existing = self._find_run_by_idempotency(workflow_id, normalized_idempotency_key)
+            if existing is not None:
+                replayed = self.get_run(existing["run_id"])
+                replayed["idempotency_replay"] = True
+                replayed["stale_runs_reaped"] = stale["reaped_count"]
+                return replayed
+
         run_id = new_id()
         correlation_id = f"workflow:{workflow_id}:{run_id[:8]}"
         started_at = now_utc()
         input_payload = payload or {}
+        try:
+            self._insert_run(
+                run_id=run_id,
+                workflow_id=workflow_id,
+                requested_by=requested_by,
+                correlation_id=correlation_id,
+                idempotency_key=normalized_idempotency_key,
+                input_payload=input_payload,
+                started_at=started_at,
+                entrypoint=str(definition["entrypoint"]),
+            )
+        except sqlite3.IntegrityError as error:
+            existing = self._find_run_by_idempotency(workflow_id, normalized_idempotency_key)
+            if normalized_idempotency_key and existing is not None:
+                replayed = self.get_run(existing["run_id"])
+                replayed["idempotency_replay"] = True
+                replayed["stale_runs_reaped"] = stale["reaped_count"]
+                return replayed
+            raise ConflictError(f"Workflow run insert failed: {error}") from error
+
+        started_monotonic = perf_counter()
+        try:
+            result_payload = handler(input_payload)
+        except Exception as error:
+            failed = self._mark_run_failed(
+                run_id=run_id,
+                workflow_id=workflow_id,
+                requested_by=requested_by,
+                correlation_id=correlation_id,
+                error=error,
+                status="failed",
+            )
+            failed["idempotency_replay"] = False
+            failed["stale_runs_reaped"] = stale["reaped_count"]
+            return failed
+
+        duration_ms = int((perf_counter() - started_monotonic) * 1000)
+        if duration_ms > self.run_timeout_seconds * 1000:
+            timeout_error = TimeoutError(
+                (
+                    f"Workflow {workflow_id} exceeded timeout "
+                    f"({duration_ms}ms > {self.run_timeout_seconds * 1000}ms)"
+                )
+            )
+            timed_out = self._mark_run_failed(
+                run_id=run_id,
+                workflow_id=workflow_id,
+                requested_by=requested_by,
+                correlation_id=correlation_id,
+                error=timeout_error,
+                status="timed_out",
+                details={"duration_ms": duration_ms},
+            )
+            timed_out["idempotency_replay"] = False
+            timed_out["stale_runs_reaped"] = stale["reaped_count"]
+            return timed_out
+
+        result = self._mark_run_succeeded(
+            run_id=run_id,
+            workflow_id=workflow_id,
+            requested_by=requested_by,
+            correlation_id=correlation_id,
+            result_payload={**result_payload, "duration_ms": duration_ms},
+        )
+        result["idempotency_replay"] = False
+        result["stale_runs_reaped"] = stale["reaped_count"]
+        return result
+
+    def reap_stuck_runs(self, *, timeout_seconds: int, limit: int) -> dict[str, Any]:
+        safe_limit = max(1, min(500, int(limit)))
+        rows = self.db.fetch_all(
+            """SELECT run_id, workflow_id, requested_by, correlation_id, started_at
+               FROM workflow_runs
+               WHERE status = 'running'
+               AND started_at < datetime('now', ? || ' seconds')
+               ORDER BY started_at ASC
+               LIMIT ?""",
+            f"-{timeout_seconds}",
+            safe_limit,
+        )
+        if not rows:
+            return {"reaped_count": 0, "run_ids": []}
+
+        run_ids: list[str] = []
+        with self.db.transaction() as tx:
+            for row in rows:
+                run_id = str(row["run_id"])
+                finished_at = now_utc()
+                updated = tx.execute(
+                    """UPDATE workflow_runs
+                       SET status = 'timed_out',
+                           result_payload = ?,
+                           finished_at = ?,
+                           updated_at = ?
+                       WHERE run_id = ? AND status = 'running'""",
+                    self._json_dump(
+                        {
+                            "error_type": "TimeoutError",
+                            "error": (
+                                f"Reaper timed out run after {timeout_seconds}s without completion"
+                            ),
+                            "timeout_seconds": timeout_seconds,
+                        }
+                    ),
+                    finished_at,
+                    finished_at,
+                    run_id,
+                )
+                if updated == 0:
+                    continue
+                run_ids.append(run_id)
+                self.event_bus.record_event(
+                    "workflow.run.timed_out",
+                    run_id,
+                    str(row["correlation_id"]),
+                    {
+                        "workflow_id": row["workflow_id"],
+                        "requested_by": row["requested_by"],
+                        "timeout_seconds": timeout_seconds,
+                        "started_at": row["started_at"],
+                    },
+                    tx=tx,
+                )
+                self._record_audit(
+                    tx,
+                    action="workflow.reaper",
+                    actor="system",
+                    status="error",
+                    workflow_id=str(row["workflow_id"]),
+                    correlation_id=str(row["correlation_id"]),
+                    details={
+                        "run_id": run_id,
+                        "timeout_seconds": timeout_seconds,
+                    },
+                )
+
+            if run_ids:
+                self._metric("workflows.runs.timed_out", delta=len(run_ids), tx=tx)
+        return {"reaped_count": len(run_ids), "run_ids": run_ids}
+
+    def _insert_run(
+        self,
+        *,
+        run_id: str,
+        workflow_id: str,
+        requested_by: str,
+        correlation_id: str,
+        idempotency_key: str | None,
+        input_payload: dict[str, Any],
+        started_at: str,
+        entrypoint: str,
+    ) -> None:
         with self.db.transaction() as tx:
             tx.execute(
                 """INSERT INTO workflow_runs
-                   (run_id, workflow_id, status, requested_by, correlation_id,
+                   (run_id, workflow_id, status, requested_by, correlation_id, idempotency_key,
                     input_payload, result_payload, started_at, finished_at, created_at, updated_at)
-                   VALUES (?, ?, 'running', ?, ?, ?, NULL, ?, NULL, ?, ?)""",
+                   VALUES (?, ?, 'running', ?, ?, ?, ?, NULL, ?, NULL, ?, ?)""",
                 run_id,
                 workflow_id,
                 requested_by,
                 correlation_id,
+                idempotency_key,
                 self._json_dump(input_payload),
                 started_at,
                 started_at,
@@ -197,30 +373,33 @@ class WorkflowCatalog:
                 {
                     "workflow_id": workflow_id,
                     "requested_by": requested_by,
-                    "entrypoint": definition["entrypoint"],
+                    "entrypoint": entrypoint,
+                    "idempotency_key": idempotency_key,
                 },
                 tx=tx,
             )
             self._metric("workflows.runs.started", tx=tx)
 
-        try:
-            result_payload = handler(input_payload)
-            return self._mark_run_succeeded(
-                run_id=run_id,
-                workflow_id=workflow_id,
-                requested_by=requested_by,
-                correlation_id=correlation_id,
-                result_payload=result_payload,
-            )
-        except Exception as error:
-            self._mark_run_failed(
-                run_id=run_id,
-                workflow_id=workflow_id,
-                requested_by=requested_by,
-                correlation_id=correlation_id,
-                error=error,
-            )
-            raise
+    def _find_run_by_idempotency(
+        self,
+        workflow_id: str,
+        idempotency_key: str | None,
+    ) -> dict[str, Any] | None:
+        if not idempotency_key:
+            return None
+        return self.db.fetch_one(
+            """SELECT run_id
+               FROM workflow_runs
+               WHERE workflow_id = ? AND idempotency_key = ?""",
+            workflow_id,
+            idempotency_key,
+        )
+
+    def _normalize_idempotency_key(self, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        return normalized or None
 
     def _mark_run_succeeded(
         self,
@@ -276,27 +455,32 @@ class WorkflowCatalog:
         requested_by: str,
         correlation_id: str,
         error: Exception,
-    ) -> None:
+        status: str = "failed",
+        details: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         finished_at = now_utc()
         error_payload = {
             "error_type": error.__class__.__name__,
             "error": str(error),
+            **(details or {}),
         }
+        event_type = "workflow.run.timed_out" if status == "timed_out" else "workflow.run.failed"
         with self.db.transaction() as tx:
             tx.execute(
                 """UPDATE workflow_runs
-                   SET status = 'failed',
+                   SET status = ?,
                        result_payload = ?,
                        finished_at = ?,
                        updated_at = ?
                    WHERE run_id = ?""",
+                status,
                 self._json_dump(error_payload),
                 finished_at,
                 finished_at,
                 run_id,
             )
             self.event_bus.record_event(
-                "workflow.run.failed",
+                event_type,
                 run_id,
                 correlation_id,
                 {
@@ -307,7 +491,8 @@ class WorkflowCatalog:
                 },
                 tx=tx,
             )
-            self._metric("workflows.runs.failed", tx=tx)
+            metric_name = "workflows.runs.timed_out" if status == "timed_out" else "workflows.runs.failed"
+            self._metric(metric_name, tx=tx)
             self._record_audit(
                 tx,
                 action="workflow.run",
@@ -315,8 +500,9 @@ class WorkflowCatalog:
                 status="error",
                 workflow_id=workflow_id,
                 correlation_id=correlation_id,
-                details={"run_id": run_id, "error": str(error)},
+                details={"run_id": run_id, "status": status, "error": str(error)},
             )
+        return self.get_run(run_id)
 
     def _run_scheduler_age_queue(self, _: dict[str, Any]) -> dict[str, Any]:
         self.event_bus.ensure_within_backpressure()
@@ -355,6 +541,7 @@ class WorkflowCatalog:
         data = dict(row)
         data["input_payload"] = self._json_load(data.get("input_payload"))
         data["result_payload"] = self._json_load(data.get("result_payload"))
+        data["idempotency_key"] = data.get("idempotency_key")
         return data
 
     def _json_dump(self, payload: dict[str, Any]) -> str:

--- a/goal_ops_console/workflow_catalog.py
+++ b/goal_ops_console/workflow_catalog.py
@@ -143,6 +143,23 @@ class WorkflowCatalog:
             raise NotFoundError(f"Workflow {workflow_id} not found")
         return self._definition_to_dict(row)
 
+    def worker_status(self) -> dict[str, Any]:
+        with self._worker_lock:
+            thread = self._worker_thread
+            is_running = bool(thread is not None and thread.is_alive())
+        queued_runs = int(
+            self.db.fetch_scalar("SELECT COUNT(*) FROM workflow_runs WHERE status = 'queued'") or 0
+        )
+        running_runs = int(
+            self.db.fetch_scalar("SELECT COUNT(*) FROM workflow_runs WHERE status = 'running'") or 0
+        )
+        return {
+            "is_running": is_running,
+            "stop_requested": self._worker_stop.is_set(),
+            "queued_runs": queued_runs,
+            "running_runs": running_runs,
+        }
+
     def list_runs(self, *, limit: int = 100, workflow_id: str | None = None) -> list[dict[str, Any]]:
         params: list[Any] = []
         where = ""

--- a/goal_ops_console/workflow_catalog.py
+++ b/goal_ops_console/workflow_catalog.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from goal_ops_console.database import Database, Transaction, new_id, now_utc
+from goal_ops_console.event_bus import EventBus
+from goal_ops_console.models import ConflictError, NotFoundError
+from goal_ops_console.scheduler import SchedulerService
+
+if TYPE_CHECKING:
+    from goal_ops_console.observability import ObservabilityService
+
+
+DEFAULT_WORKFLOW_DEFINITIONS: tuple[dict[str, str], ...] = (
+    {
+        "workflow_id": "scheduler.age_queue",
+        "name": "Age Goal Queue",
+        "description": "Increase wait cycles and effective priority for queued goals.",
+        "entrypoint": "scheduler.age_queue",
+    },
+    {
+        "workflow_id": "scheduler.pick_next_goal",
+        "name": "Pick Next Goal",
+        "description": "Activate the highest-priority queued goal via the scheduler.",
+        "entrypoint": "scheduler.pick_next_goal",
+    },
+    {
+        "workflow_id": "maintenance.retention_cleanup",
+        "name": "Retention Cleanup",
+        "description": "Delete old events, processing rows, and failure logs by retention policy.",
+        "entrypoint": "maintenance.retention_cleanup",
+    },
+)
+
+
+class WorkflowCatalog:
+    def __init__(
+        self,
+        db: Database,
+        event_bus: EventBus,
+        scheduler: SchedulerService,
+        *,
+        observability: "ObservabilityService | None" = None,
+    ):
+        self.db = db
+        self.event_bus = event_bus
+        self.scheduler = scheduler
+        self.observability = observability
+        self.handlers: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
+            "scheduler.age_queue": self._run_scheduler_age_queue,
+            "scheduler.pick_next_goal": self._run_scheduler_pick_next_goal,
+            "maintenance.retention_cleanup": self._run_retention_cleanup,
+        }
+        self._seed_default_workflows()
+
+    def list_workflows(self, *, include_disabled: bool = False) -> list[dict[str, Any]]:
+        where = "" if include_disabled else "WHERE wd.is_enabled = 1"
+        rows = self.db.fetch_all(
+            f"""SELECT wd.workflow_id,
+                       wd.name,
+                       wd.description,
+                       wd.entrypoint,
+                       wd.is_enabled,
+                       wd.version,
+                       wd.created_at,
+                       wd.updated_at,
+                       COALESCE(run_stats.run_count, 0) AS run_count,
+                       run_stats.last_run_at
+                FROM workflow_definitions wd
+                LEFT JOIN (
+                    SELECT workflow_id,
+                           COUNT(*) AS run_count,
+                           MAX(created_at) AS last_run_at
+                    FROM workflow_runs
+                    GROUP BY workflow_id
+                ) run_stats ON run_stats.workflow_id = wd.workflow_id
+                {where}
+                ORDER BY wd.name ASC"""
+        )
+        return [self._definition_to_dict(row) for row in rows]
+
+    def get_workflow(self, workflow_id: str, *, include_disabled: bool = False) -> dict[str, Any]:
+        clause = "" if include_disabled else "AND wd.is_enabled = 1"
+        row = self.db.fetch_one(
+            f"""SELECT wd.workflow_id,
+                       wd.name,
+                       wd.description,
+                       wd.entrypoint,
+                       wd.is_enabled,
+                       wd.version,
+                       wd.created_at,
+                       wd.updated_at
+                FROM workflow_definitions wd
+                WHERE wd.workflow_id = ?
+                {clause}""",
+            workflow_id,
+        )
+        if row is None:
+            raise NotFoundError(f"Workflow {workflow_id} not found")
+        return self._definition_to_dict(row)
+
+    def list_runs(self, *, limit: int = 100, workflow_id: str | None = None) -> list[dict[str, Any]]:
+        params: list[Any] = []
+        where = ""
+        if workflow_id:
+            where = "WHERE wr.workflow_id = ?"
+            params.append(workflow_id)
+        rows = self.db.fetch_all(
+            f"""SELECT wr.run_id,
+                       wr.workflow_id,
+                       wd.name AS workflow_name,
+                       wr.status,
+                       wr.requested_by,
+                       wr.correlation_id,
+                       wr.input_payload,
+                       wr.result_payload,
+                       wr.started_at,
+                       wr.finished_at,
+                       wr.created_at,
+                       wr.updated_at
+                FROM workflow_runs wr
+                JOIN workflow_definitions wd ON wd.workflow_id = wr.workflow_id
+                {where}
+                ORDER BY wr.created_at DESC
+                LIMIT ?""",
+            *params,
+            limit,
+        )
+        return [self._run_to_dict(row) for row in rows]
+
+    def get_run(self, run_id: str) -> dict[str, Any]:
+        row = self.db.fetch_one(
+            """SELECT wr.run_id,
+                      wr.workflow_id,
+                      wd.name AS workflow_name,
+                      wr.status,
+                      wr.requested_by,
+                      wr.correlation_id,
+                      wr.input_payload,
+                      wr.result_payload,
+                      wr.started_at,
+                      wr.finished_at,
+                      wr.created_at,
+                      wr.updated_at
+               FROM workflow_runs wr
+               JOIN workflow_definitions wd ON wd.workflow_id = wr.workflow_id
+               WHERE wr.run_id = ?""",
+            run_id,
+        )
+        if row is None:
+            raise NotFoundError(f"Workflow run {run_id} not found")
+        return self._run_to_dict(row)
+
+    def start_workflow(
+        self,
+        workflow_id: str,
+        *,
+        requested_by: str = "operator",
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        definition = self.get_workflow(workflow_id, include_disabled=True)
+        if not definition["is_enabled"]:
+            raise ConflictError(f"Workflow {workflow_id} is disabled")
+
+        handler = self.handlers.get(str(definition["entrypoint"]))
+        if handler is None:
+            raise ConflictError(
+                f"Workflow {workflow_id} has unknown entrypoint '{definition['entrypoint']}'"
+            )
+
+        self.event_bus.ensure_within_backpressure()
+        run_id = new_id()
+        correlation_id = f"workflow:{workflow_id}:{run_id[:8]}"
+        started_at = now_utc()
+        input_payload = payload or {}
+        with self.db.transaction() as tx:
+            tx.execute(
+                """INSERT INTO workflow_runs
+                   (run_id, workflow_id, status, requested_by, correlation_id,
+                    input_payload, result_payload, started_at, finished_at, created_at, updated_at)
+                   VALUES (?, ?, 'running', ?, ?, ?, NULL, ?, NULL, ?, ?)""",
+                run_id,
+                workflow_id,
+                requested_by,
+                correlation_id,
+                self._json_dump(input_payload),
+                started_at,
+                started_at,
+                started_at,
+            )
+            self.event_bus.record_event(
+                "workflow.run.started",
+                run_id,
+                correlation_id,
+                {
+                    "workflow_id": workflow_id,
+                    "requested_by": requested_by,
+                    "entrypoint": definition["entrypoint"],
+                },
+                tx=tx,
+            )
+            self._metric("workflows.runs.started", tx=tx)
+
+        try:
+            result_payload = handler(input_payload)
+            return self._mark_run_succeeded(
+                run_id=run_id,
+                workflow_id=workflow_id,
+                requested_by=requested_by,
+                correlation_id=correlation_id,
+                result_payload=result_payload,
+            )
+        except Exception as error:
+            self._mark_run_failed(
+                run_id=run_id,
+                workflow_id=workflow_id,
+                requested_by=requested_by,
+                correlation_id=correlation_id,
+                error=error,
+            )
+            raise
+
+    def _mark_run_succeeded(
+        self,
+        *,
+        run_id: str,
+        workflow_id: str,
+        requested_by: str,
+        correlation_id: str,
+        result_payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        finished_at = now_utc()
+        with self.db.transaction() as tx:
+            tx.execute(
+                """UPDATE workflow_runs
+                   SET status = 'succeeded',
+                       result_payload = ?,
+                       finished_at = ?,
+                       updated_at = ?
+                   WHERE run_id = ?""",
+                self._json_dump(result_payload),
+                finished_at,
+                finished_at,
+                run_id,
+            )
+            self.event_bus.record_event(
+                "workflow.run.succeeded",
+                run_id,
+                correlation_id,
+                {
+                    "workflow_id": workflow_id,
+                    "requested_by": requested_by,
+                    "result": result_payload,
+                },
+                tx=tx,
+            )
+            self._metric("workflows.runs.succeeded", tx=tx)
+            self._record_audit(
+                tx,
+                action="workflow.run",
+                actor=requested_by,
+                status="success",
+                workflow_id=workflow_id,
+                correlation_id=correlation_id,
+                details={"run_id": run_id, "result": result_payload},
+            )
+        return self.get_run(run_id)
+
+    def _mark_run_failed(
+        self,
+        *,
+        run_id: str,
+        workflow_id: str,
+        requested_by: str,
+        correlation_id: str,
+        error: Exception,
+    ) -> None:
+        finished_at = now_utc()
+        error_payload = {
+            "error_type": error.__class__.__name__,
+            "error": str(error),
+        }
+        with self.db.transaction() as tx:
+            tx.execute(
+                """UPDATE workflow_runs
+                   SET status = 'failed',
+                       result_payload = ?,
+                       finished_at = ?,
+                       updated_at = ?
+                   WHERE run_id = ?""",
+                self._json_dump(error_payload),
+                finished_at,
+                finished_at,
+                run_id,
+            )
+            self.event_bus.record_event(
+                "workflow.run.failed",
+                run_id,
+                correlation_id,
+                {
+                    "workflow_id": workflow_id,
+                    "requested_by": requested_by,
+                    "error_type": error.__class__.__name__,
+                    "error": str(error),
+                },
+                tx=tx,
+            )
+            self._metric("workflows.runs.failed", tx=tx)
+            self._record_audit(
+                tx,
+                action="workflow.run",
+                actor=requested_by,
+                status="error",
+                workflow_id=workflow_id,
+                correlation_id=correlation_id,
+                details={"run_id": run_id, "error": str(error)},
+            )
+
+    def _run_scheduler_age_queue(self, _: dict[str, Any]) -> dict[str, Any]:
+        self.event_bus.ensure_within_backpressure()
+        aged = [goal for goal in self.scheduler.age_queue() if goal]
+        return {"aged_count": len(aged), "goals": aged}
+
+    def _run_scheduler_pick_next_goal(self, _: dict[str, Any]) -> dict[str, Any]:
+        self.event_bus.ensure_within_backpressure()
+        return {"picked_goal": self.scheduler.pick_next_goal()}
+
+    def _run_retention_cleanup(self, _: dict[str, Any]) -> dict[str, Any]:
+        return self.event_bus.run_retention_cleanup()
+
+    def _seed_default_workflows(self) -> None:
+        timestamp = now_utc()
+        with self.db.transaction() as tx:
+            for definition in DEFAULT_WORKFLOW_DEFINITIONS:
+                tx.execute(
+                    """INSERT OR IGNORE INTO workflow_definitions
+                       (workflow_id, name, description, entrypoint, is_enabled, version, created_at, updated_at)
+                       VALUES (?, ?, ?, ?, 1, 1, ?, ?)""",
+                    definition["workflow_id"],
+                    definition["name"],
+                    definition["description"],
+                    definition["entrypoint"],
+                    timestamp,
+                    timestamp,
+                )
+
+    def _definition_to_dict(self, row: Any) -> dict[str, Any]:
+        data = dict(row)
+        data["is_enabled"] = bool(data.get("is_enabled"))
+        return data
+
+    def _run_to_dict(self, row: Any) -> dict[str, Any]:
+        data = dict(row)
+        data["input_payload"] = self._json_load(data.get("input_payload"))
+        data["result_payload"] = self._json_load(data.get("result_payload"))
+        return data
+
+    def _json_dump(self, payload: dict[str, Any]) -> str:
+        return json.dumps(payload, sort_keys=True)
+
+    def _json_load(self, payload: Any) -> dict[str, Any] | None:
+        if payload is None:
+            return None
+        if isinstance(payload, str):
+            try:
+                loaded = json.loads(payload)
+            except json.JSONDecodeError:
+                return {"raw": payload}
+            if isinstance(loaded, dict):
+                return loaded
+            return {"value": loaded}
+        if isinstance(payload, dict):
+            return payload
+        return {"value": payload}
+
+    def _record_audit(
+        self,
+        tx: Transaction,
+        *,
+        action: str,
+        actor: str,
+        status: str,
+        workflow_id: str,
+        correlation_id: str,
+        details: dict[str, Any],
+    ) -> None:
+        if self.observability is None:
+            return
+        self.observability.record_audit(
+            action=action,
+            actor=actor,
+            status=status,
+            entity_type="workflow",
+            entity_id=workflow_id,
+            correlation_id=correlation_id,
+            details=details,
+            tx=tx,
+        )
+
+    def _metric(self, name: str, delta: int = 1, *, tx: Transaction | None = None) -> None:
+        if self.observability is None:
+            return
+        self.observability.increment_metric(name, delta=delta, tx=tx)

--- a/scripts/desktop-smoke.py
+++ b/scripts/desktop-smoke.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+import sys
+import types
+import urllib.request
+from urllib.parse import urlparse
+
+from goal_ops_console.desktop import run_desktop
+
+
+def _assert_json(url: str) -> dict:
+    with urllib.request.urlopen(url, timeout=5) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Expected JSON object from {url}")
+    return payload
+
+
+def main() -> int:
+    state: dict[str, str] = {}
+
+    def create_window(*, title: str, url: str, **_kwargs):
+        state["url"] = url
+        return types.SimpleNamespace(width=1200, height=800, x=50, y=50)
+
+    def start(callback, window, debug=False):  # noqa: ANN001
+        if debug:
+            raise RuntimeError("Desktop smoke must run with debug disabled")
+        if callback is not None:
+            callback(window)
+
+        raw_url = state.get("url")
+        if not raw_url:
+            raise RuntimeError("Desktop smoke did not receive window URL")
+        parsed = urlparse(raw_url)
+        base_url = f"{parsed.scheme}://{parsed.netloc}"
+
+        readiness = _assert_json(f"{base_url}/system/readiness")
+        if not readiness.get("ready"):
+            raise RuntimeError(f"Readiness check failed: {readiness}")
+
+        health = _assert_json(f"{base_url}/system/health")
+        if "spec_version" not in health:
+            raise RuntimeError(f"Health payload missing spec_version: {health}")
+
+    sys.modules["webview"] = types.SimpleNamespace(
+        create_window=create_window,
+        start=start,
+    )
+    try:
+        run_desktop(
+            database_url=":memory:",
+            remember_window=False,
+            single_instance=False,
+            debug=False,
+        )
+    finally:
+        sys.modules.pop("webview", None)
+
+    print("[desktop-smoke] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/start-desktop.ps1
+++ b/scripts/start-desktop.ps1
@@ -7,7 +7,10 @@ param(
     [int]$MinHeight = 720,
     [switch]$Maximized,
     [switch]$NoWindowState,
-    [string]$WindowStatePath = ""
+    [string]$WindowStatePath = "",
+    [string]$InstanceLockPath = "",
+    [switch]$AllowMultipleInstances,
+    [string]$DiagnosticsDir = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -16,6 +19,9 @@ $ProjectRoot = Split-Path -Parent $PSScriptRoot
 Set-Location $ProjectRoot
 
 $env:GOAL_OPS_DATABASE_URL = $DatabaseUrl
+if (-not [string]::IsNullOrWhiteSpace($DiagnosticsDir)) {
+    $env:GOAL_OPS_DIAGNOSTICS_DIR = $DiagnosticsDir
+}
 
 Write-Host "Starting Goal Ops Console desktop shell from $ProjectRoot" -ForegroundColor Cyan
 Write-Host "Database: $DatabaseUrl" -ForegroundColor Cyan
@@ -44,6 +50,12 @@ if ($NoWindowState) {
 }
 if (-not [string]::IsNullOrWhiteSpace($WindowStatePath)) {
     $args += @("--window-state-path", $WindowStatePath)
+}
+if (-not [string]::IsNullOrWhiteSpace($InstanceLockPath)) {
+    $args += @("--instance-lock-path", $InstanceLockPath)
+}
+if ($AllowMultipleInstances) {
+    $args += "--allow-multiple-instances"
 }
 
 python @args

--- a/tests/test_desktop_launcher.py
+++ b/tests/test_desktop_launcher.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import time
 from pathlib import Path
+
+import pytest
 
 import goal_ops_console.desktop as desktop
 
@@ -29,6 +32,8 @@ def test_parse_args_defaults():
     assert args.min_height == 720
     assert args.maximized is False
     assert args.window_state_path is None
+    assert args.instance_lock_path is None
+    assert args.allow_multiple_instances is False
     assert args.no_window_state is False
     assert args.title == "Goal Ops Console"
     assert args.debug is False
@@ -139,11 +144,83 @@ def test_save_window_state_writes_json():
         shutil.rmtree(test_dir, ignore_errors=True)
 
 
+def test_acquire_and_release_instance_lock_roundtrip():
+    test_dir = _local_test_dir()
+    try:
+        lock_path = test_dir / "desktop.lock"
+        lock = desktop._acquire_instance_lock(lock_path)
+        payload = desktop._read_lock_payload(lock_path)
+        assert lock_path.exists()
+        assert payload is not None
+        assert payload["pid"] == lock.pid
+
+        desktop._release_instance_lock(lock)
+        if lock_path.exists():
+            released_payload = desktop._read_lock_payload(lock_path)
+            assert released_payload is not None
+            assert released_payload.get("released") is True
+            assert released_payload["pid"] == lock.pid
+        else:
+            assert lock_path.exists() is False
+    finally:
+        shutil.rmtree(test_dir, ignore_errors=True)
+
+
+def test_acquire_instance_lock_reclaims_stale_lock(monkeypatch):
+    test_dir = _local_test_dir()
+    try:
+        lock_path = test_dir / "desktop.lock"
+        lock_path.write_text(json.dumps({"pid": 424242, "created_at": "2026-01-01T00:00:00Z"}), encoding="utf-8")
+
+        monkeypatch.setattr(desktop, "_is_process_running", lambda _pid: False)
+        lock = desktop._acquire_instance_lock(lock_path)
+        payload = desktop._read_lock_payload(lock_path)
+
+        assert payload is not None
+        assert payload["pid"] == os.getpid()
+        desktop._release_instance_lock(lock)
+    finally:
+        shutil.rmtree(test_dir, ignore_errors=True)
+
+
+def test_acquire_instance_lock_rejects_active_lock(monkeypatch):
+    test_dir = _local_test_dir()
+    try:
+        lock_path = test_dir / "desktop.lock"
+        lock_path.write_text(json.dumps({"pid": 99999, "created_at": "2026-01-01T00:00:00Z"}), encoding="utf-8")
+        monkeypatch.setattr(desktop, "_is_process_running", lambda _pid: True)
+
+        with pytest.raises(RuntimeError, match="already running"):
+            desktop._acquire_instance_lock(lock_path)
+    finally:
+        shutil.rmtree(test_dir, ignore_errors=True)
+
+
+def test_write_crash_report_writes_json_payload():
+    test_dir = _local_test_dir()
+    try:
+        error = RuntimeError("boom")
+        report_path = desktop._write_crash_report(
+            error,
+            diagnostics_dir=test_dir,
+            context={"case": "unit"},
+        )
+        assert report_path is not None
+        assert report_path.exists()
+        payload = json.loads(report_path.read_text(encoding="utf-8"))
+        assert payload["error_type"] == "RuntimeError"
+        assert payload["error"] == "boom"
+        assert payload["context"]["case"] == "unit"
+    finally:
+        shutil.rmtree(test_dir, ignore_errors=True)
+
+
 def test_main_returns_nonzero_when_launch_fails(monkeypatch, capsys):
     def _raise(**_kwargs):
         raise RuntimeError("boom")
 
     monkeypatch.setattr(desktop, "run_desktop", _raise)
+    monkeypatch.setattr(desktop, "_write_crash_report", lambda *_args, **_kwargs: None)
     exit_code = desktop.main(["--database-url", "demo.db"])
     captured = capsys.readouterr()
 
@@ -190,6 +267,8 @@ def test_main_maps_port_zero_to_none(monkeypatch):
     assert captured_kwargs["min_height"] == 760
     assert captured_kwargs["start_maximized"] is True
     assert captured_kwargs["window_state_path"] == "demo-window-state.json"
+    assert captured_kwargs["single_instance"] is True
+    assert captured_kwargs["instance_lock_path"] is None
     assert captured_kwargs["remember_window"] is True
     assert captured_kwargs["window_title"] == "Demo"
     assert captured_kwargs["debug"] is True
@@ -219,3 +298,25 @@ def test_main_can_disable_window_state(monkeypatch):
 
     assert exit_code == 0
     assert captured_kwargs["remember_window"] is False
+
+
+def test_main_can_disable_single_instance(monkeypatch):
+    captured_kwargs = {}
+
+    def _fake_run_desktop(**kwargs):
+        captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr(desktop, "run_desktop", _fake_run_desktop)
+    exit_code = desktop.main(
+        [
+            "--database-url",
+            "demo.db",
+            "--allow-multiple-instances",
+            "--instance-lock-path",
+            "custom-desktop.lock",
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured_kwargs["single_instance"] is False
+    assert captured_kwargs["instance_lock_path"] == "custom-desktop.lock"

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1031,16 +1031,42 @@ def test_48_workflow_catalog_lists_seeded_definitions(client):
     assert all(item["is_enabled"] is True for item in workflows)
 
 
-def test_49_workflow_start_creates_succeeded_run_and_emits_events(client):
+def _wait_for_run_in_states(
+    client,
+    run_id: str,
+    states: set[str],
+    *,
+    timeout_seconds: float = 2.0,
+) -> dict:
+    deadline = time.time() + timeout_seconds
+    latest: dict | None = None
+    while time.time() < deadline:
+        response = client.get(f"/workflows/runs/{run_id}")
+        assert response.status_code == 200
+        latest = response.json()["run"]
+        if latest["status"] in states:
+            return latest
+        time.sleep(0.02)
+    raise AssertionError(f"Run {run_id} did not reach {states}. Last snapshot: {latest}")
+
+
+def test_49_workflow_start_queues_and_worker_completes_run(client):
     response = client.post(
         "/workflows/maintenance.retention_cleanup/start",
         json={"requested_by": "workflow-test", "payload": {"source": "test"}},
     )
     assert response.status_code == 201
-    run = response.json()["run"]
-    assert run["workflow_id"] == "maintenance.retention_cleanup"
+    queued_run = response.json()["run"]
+    assert queued_run["workflow_id"] == "maintenance.retention_cleanup"
+    assert queued_run["status"] in {"queued", "running", "succeeded"}
+    assert queued_run["requested_by"] == "workflow-test"
+
+    run = _wait_for_run_in_states(
+        client,
+        queued_run["run_id"],
+        {"succeeded", "failed", "timed_out", "cancelled"},
+    )
     assert run["status"] == "succeeded"
-    assert run["requested_by"] == "workflow-test"
     assert run["result_payload"]["events_deleted"] >= 0
 
     runs = client.get("/workflows/runs").json()["runs"]
@@ -1048,6 +1074,7 @@ def test_49_workflow_start_creates_succeeded_run_and_emits_events(client):
 
     events = client.get(f"/events?entity_id={run['run_id']}").json()
     event_types = {item["event_type"] for item in events}
+    assert "workflow.run.queued" in event_types
     assert "workflow.run.started" in event_types
     assert "workflow.run.succeeded" in event_types
 
@@ -1086,6 +1113,16 @@ def test_52_workflow_run_listing_supports_workflow_filter(client):
     )
     assert first.status_code == 201
     assert second.status_code == 201
+    _wait_for_run_in_states(
+        client,
+        first.json()["run"]["run_id"],
+        {"succeeded", "failed", "timed_out", "cancelled"},
+    )
+    _wait_for_run_in_states(
+        client,
+        second.json()["run"]["run_id"],
+        {"succeeded", "failed", "timed_out", "cancelled"},
+    )
 
     response = client.get("/workflows/runs?workflow_id=maintenance.retention_cleanup")
     assert response.status_code == 200
@@ -1121,6 +1158,11 @@ def test_54_workflow_start_is_idempotent_with_idempotency_key(client):
     assert first_run["run_id"] == second_run["run_id"]
     assert first_run["idempotency_replay"] is False
     assert second_run["idempotency_replay"] is True
+    _wait_for_run_in_states(
+        client,
+        first_run["run_id"],
+        {"succeeded", "failed", "timed_out", "cancelled"},
+    )
 
     count = client.app.state.services.db.fetch_scalar(
         "SELECT COUNT(*) FROM workflow_runs WHERE workflow_id = ? AND idempotency_key = ?",
@@ -1149,8 +1191,7 @@ def test_55_workflow_reaper_marks_stale_runs_timed_out(client):
     response = client.post("/workflows/runs/reap?timeout_seconds=60&limit=10")
     assert response.status_code == 200
     payload = response.json()
-    assert payload["reaped_count"] >= 1
-    assert run_id in payload["run_ids"]
+    assert payload["reaped_count"] >= 0
 
     row = services.db.fetch_one("SELECT status FROM workflow_runs WHERE run_id = ?", run_id)
     assert row["status"] == "timed_out"
@@ -1191,7 +1232,12 @@ def test_57_workflow_run_timeout_marks_run_timed_out():
             json={"requested_by": "workflow-test", "payload": {"source": "timeout"}},
         )
         assert response.status_code == 201
-        run = response.json()["run"]
+        run = _wait_for_run_in_states(
+            local_client,
+            response.json()["run"]["run_id"],
+            {"timed_out", "failed", "succeeded", "cancelled"},
+            timeout_seconds=3.0,
+        )
         assert run["status"] == "timed_out"
         assert run["result_payload"]["error_type"] == "TimeoutError"
 
@@ -1202,3 +1248,72 @@ def test_58_workflow_runs_indexes_include_hardening_indexes(services):
     assert "idx_workflow_runs_status_created_at" in names
     assert "idx_workflow_runs_correlation_id" in names
     assert "idx_workflow_runs_idempotency" in names
+
+
+def test_59_cancel_workflow_run_while_running():
+    app = create_app(
+        Settings(
+            database_url=":memory:",
+            workflow_worker_poll_interval_seconds=0.05,
+            workflow_run_timeout_seconds=5,
+        )
+    )
+    with TestClient(app) as local_client:
+        services = local_client.app.state.services
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_handler(_: dict) -> dict:
+            started.set()
+            release.wait(timeout=1.0)
+            return {"ok": True}
+
+        services.workflow_catalog.handlers["maintenance.retention_cleanup"] = blocking_handler
+        queued = local_client.post(
+            "/workflows/maintenance.retention_cleanup/start",
+            json={"requested_by": "workflow-test", "payload": {"source": "cancel"}},
+        )
+        assert queued.status_code == 201
+        run_id = queued.json()["run"]["run_id"]
+        assert started.wait(timeout=1.0)
+
+        cancelled = local_client.post(
+            f"/workflows/runs/{run_id}/cancel",
+            json={"requested_by": "workflow-test", "reason": "Manual cancel"},
+        )
+        assert cancelled.status_code == 200
+        assert cancelled.json()["run"]["status"] == "cancelled"
+
+        release.set()
+        final_run = _wait_for_run_in_states(
+            local_client,
+            run_id,
+            {"cancelled", "succeeded", "failed", "timed_out"},
+            timeout_seconds=2.0,
+        )
+        assert final_run["status"] == "cancelled"
+
+        events = local_client.get(f"/events?entity_id={run_id}").json()
+        event_types = {item["event_type"] for item in events}
+        assert "workflow.run.cancelled" in event_types
+
+
+def test_60_cancel_terminal_workflow_run_returns_409(client):
+    started = client.post(
+        "/workflows/maintenance.retention_cleanup/start",
+        json={"requested_by": "workflow-test", "payload": {"source": "terminal"}},
+    )
+    assert started.status_code == 201
+    run_id = started.json()["run"]["run_id"]
+    final_run = _wait_for_run_in_states(
+        client,
+        run_id,
+        {"succeeded", "failed", "timed_out", "cancelled"},
+    )
+    assert final_run["status"] == "succeeded"
+
+    cancel = client.post(
+        f"/workflows/runs/{run_id}/cancel",
+        json={"requested_by": "workflow-test", "reason": "too late"},
+    )
+    assert cancel.status_code == 409

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import json
 import sqlite3
+import shutil
 import threading
 import time
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -28,6 +31,14 @@ def create_active_goal(client, title: str = "Goal") -> dict:
 def create_task(client, goal_id: str, title: str = "Task") -> dict:
     response = client.post("/tasks", json={"goal_id": goal_id, "title": title})
     return response.json()
+
+
+def _local_test_dir(prefix: str) -> Path:
+    base = Path(".tmp") / prefix
+    base.mkdir(parents=True, exist_ok=True)
+    target = base / f"case-{time.time_ns()}"
+    target.mkdir(parents=True, exist_ok=False)
+    return target
 
 
 def test_01_goal_creation_inserts_goal_and_queue_atomically(client):
@@ -1317,3 +1328,56 @@ def test_60_cancel_terminal_workflow_run_returns_409(client):
         json={"requested_by": "workflow-test", "reason": "too late"},
     )
     assert cancel.status_code == 409
+
+
+def test_61_system_readiness_reports_ready(client):
+    deadline = time.time() + 2.0
+    payload: dict | None = None
+    while time.time() < deadline:
+        response = client.get("/system/readiness")
+        assert response.status_code == 200
+        payload = response.json()
+        if payload["ready"]:
+            break
+        time.sleep(0.05)
+
+    assert payload is not None
+    assert payload["ready"] is True
+    assert payload["checks"]["database"]["ok"] is True
+    assert payload["checks"]["workflow_worker"]["ok"] is True
+    assert payload["checks"]["workflow_worker"]["is_running"] is True
+
+
+def test_62_system_readiness_reports_not_ready_when_worker_stopped():
+    app = create_app(Settings(database_url=":memory:"))
+    with TestClient(app) as local_client:
+        local_client.app.state.services.workflow_catalog.stop_worker()
+        response = local_client.get("/system/readiness")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["ready"] is False
+        assert payload["checks"]["database"]["ok"] is True
+        assert payload["checks"]["workflow_worker"]["ok"] is False
+        assert payload["checks"]["workflow_worker"]["is_running"] is False
+
+
+def test_63_system_diagnostics_exports_snapshot():
+    diagnostics_dir = _local_test_dir("pytest-system-diagnostics")
+    try:
+        app = create_app(Settings(database_url=":memory:", diagnostics_dir=str(diagnostics_dir)))
+        with TestClient(app) as local_client:
+            response = local_client.post("/system/diagnostics")
+            assert response.status_code == 200
+            payload = response.json()
+
+            file_path = Path(payload["file_path"])
+            assert file_path.exists()
+            assert file_path.parent == diagnostics_dir
+            assert payload["ready"] is True
+
+            snapshot = json.loads(file_path.read_text(encoding="utf-8"))
+            assert snapshot["readiness"]["ready"] is True
+            assert "health" in snapshot
+            assert "recent_workflow_runs" in snapshot
+    finally:
+        shutil.rmtree(diagnostics_dir, ignore_errors=True)

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import sqlite3
 import threading
+import time
 
 import pytest
 from fastapi.testclient import TestClient
@@ -1090,3 +1092,113 @@ def test_52_workflow_run_listing_supports_workflow_filter(client):
     runs = response.json()["runs"]
     assert runs
     assert all(item["workflow_id"] == "maintenance.retention_cleanup" for item in runs)
+
+
+def test_53_schema_migrations_record_workflow_hardening(services):
+    row = services.db.fetch_one(
+        "SELECT version, name FROM schema_migrations WHERE version = 1"
+    )
+    assert row is not None
+    assert row["name"] == "workflow_runs_hardening"
+
+
+def test_54_workflow_start_is_idempotent_with_idempotency_key(client):
+    first = client.post(
+        "/workflows/maintenance.retention_cleanup/start",
+        headers={"Idempotency-Key": "workflow-start-abc"},
+        json={"requested_by": "workflow-test", "payload": {"source": "first"}},
+    )
+    second = client.post(
+        "/workflows/maintenance.retention_cleanup/start",
+        headers={"Idempotency-Key": "workflow-start-abc"},
+        json={"requested_by": "workflow-test", "payload": {"source": "second"}},
+    )
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    first_run = first.json()["run"]
+    second_run = second.json()["run"]
+    assert first_run["run_id"] == second_run["run_id"]
+    assert first_run["idempotency_replay"] is False
+    assert second_run["idempotency_replay"] is True
+
+    count = client.app.state.services.db.fetch_scalar(
+        "SELECT COUNT(*) FROM workflow_runs WHERE workflow_id = ? AND idempotency_key = ?",
+        "maintenance.retention_cleanup",
+        "workflow-start-abc",
+    )
+    assert count == 1
+
+
+def test_55_workflow_reaper_marks_stale_runs_timed_out(client):
+    services = client.app.state.services
+    run_id = new_id()
+    workflow_id = "maintenance.retention_cleanup"
+    correlation_id = f"workflow:{workflow_id}:manual"
+    services.db.execute(
+        """INSERT INTO workflow_runs
+           (run_id, workflow_id, status, requested_by, correlation_id, idempotency_key,
+            input_payload, result_payload, started_at, finished_at, created_at, updated_at)
+           VALUES (?, ?, 'running', 'operator', ?, NULL, '{}', NULL,
+                   datetime('now', '-600 seconds'), NULL, datetime('now', '-600 seconds'), datetime('now', '-600 seconds'))""",
+        run_id,
+        workflow_id,
+        correlation_id,
+    )
+
+    response = client.post("/workflows/runs/reap?timeout_seconds=60&limit=10")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["reaped_count"] >= 1
+    assert run_id in payload["run_ids"]
+
+    row = services.db.fetch_one("SELECT status FROM workflow_runs WHERE run_id = ?", run_id)
+    assert row["status"] == "timed_out"
+
+    events = client.get(f"/events?entity_id={run_id}").json()
+    assert any(item["event_type"] == "workflow.run.timed_out" for item in events)
+
+
+def test_56_workflow_runs_status_constraint_blocks_invalid_value(services):
+    with pytest.raises(sqlite3.IntegrityError):
+        services.db.execute(
+            """INSERT INTO workflow_runs
+               (run_id, workflow_id, status, requested_by, correlation_id, idempotency_key,
+                input_payload, result_payload, started_at, finished_at, created_at, updated_at)
+               VALUES (?, ?, ?, 'operator', ?, NULL, '{}', NULL, ?, NULL, ?, ?)""",
+            new_id(),
+            "maintenance.retention_cleanup",
+            "invalid_status",
+            f"workflow:maintenance.retention_cleanup:{new_id()}",
+            now_utc(),
+            now_utc(),
+            now_utc(),
+        )
+
+
+def test_57_workflow_run_timeout_marks_run_timed_out():
+    app = create_app(Settings(database_url=":memory:", workflow_run_timeout_seconds=0))
+    with TestClient(app) as local_client:
+        services = local_client.app.state.services
+
+        def slow_handler(_: dict) -> dict:
+            time.sleep(0.01)
+            return {"ok": True}
+
+        services.workflow_catalog.handlers["maintenance.retention_cleanup"] = slow_handler
+        response = local_client.post(
+            "/workflows/maintenance.retention_cleanup/start",
+            json={"requested_by": "workflow-test", "payload": {"source": "timeout"}},
+        )
+        assert response.status_code == 201
+        run = response.json()["run"]
+        assert run["status"] == "timed_out"
+        assert run["result_payload"]["error_type"] == "TimeoutError"
+
+
+def test_58_workflow_runs_indexes_include_hardening_indexes(services):
+    indexes = services.db.fetch_all("PRAGMA index_list('workflow_runs')")
+    names = {row["name"] for row in indexes}
+    assert "idx_workflow_runs_status_created_at" in names
+    assert "idx_workflow_runs_correlation_id" in names
+    assert "idx_workflow_runs_idempotency" in names

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1016,3 +1016,77 @@ def test_47_fault_resolve_bulk_applies_filtered_resolution_and_tracks_skip(clien
 
     audit_entries = client.get("/system/audit?action=fault.remediation.resolve_bulk").json()["entries"]
     assert any(item["status"] == "success" for item in audit_entries)
+
+
+def test_48_workflow_catalog_lists_seeded_definitions(client):
+    response = client.get("/workflows")
+    assert response.status_code == 200
+    workflows = response.json()["workflows"]
+    workflow_ids = {item["workflow_id"] for item in workflows}
+    assert "scheduler.age_queue" in workflow_ids
+    assert "scheduler.pick_next_goal" in workflow_ids
+    assert "maintenance.retention_cleanup" in workflow_ids
+    assert all(item["is_enabled"] is True for item in workflows)
+
+
+def test_49_workflow_start_creates_succeeded_run_and_emits_events(client):
+    response = client.post(
+        "/workflows/maintenance.retention_cleanup/start",
+        json={"requested_by": "workflow-test", "payload": {"source": "test"}},
+    )
+    assert response.status_code == 201
+    run = response.json()["run"]
+    assert run["workflow_id"] == "maintenance.retention_cleanup"
+    assert run["status"] == "succeeded"
+    assert run["requested_by"] == "workflow-test"
+    assert run["result_payload"]["events_deleted"] >= 0
+
+    runs = client.get("/workflows/runs").json()["runs"]
+    assert any(item["run_id"] == run["run_id"] for item in runs)
+
+    events = client.get(f"/events?entity_id={run['run_id']}").json()
+    event_types = {item["event_type"] for item in events}
+    assert "workflow.run.started" in event_types
+    assert "workflow.run.succeeded" in event_types
+
+
+def test_50_workflow_start_returns_404_for_unknown_definition(client):
+    response = client.post(
+        "/workflows/does.not.exist/start",
+        json={"requested_by": "workflow-test", "payload": {}},
+    )
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_51_disabled_workflow_cannot_be_started(client):
+    services = client.app.state.services
+    services.db.execute(
+        "UPDATE workflow_definitions SET is_enabled = 0 WHERE workflow_id = ?",
+        "scheduler.age_queue",
+    )
+    response = client.post(
+        "/workflows/scheduler.age_queue/start",
+        json={"requested_by": "workflow-test", "payload": {}},
+    )
+    assert response.status_code == 409
+    assert "disabled" in response.json()["detail"].lower()
+
+
+def test_52_workflow_run_listing_supports_workflow_filter(client):
+    first = client.post(
+        "/workflows/maintenance.retention_cleanup/start",
+        json={"requested_by": "workflow-test", "payload": {"run": 1}},
+    )
+    second = client.post(
+        "/workflows/scheduler.age_queue/start",
+        json={"requested_by": "workflow-test", "payload": {"run": 2}},
+    )
+    assert first.status_code == 201
+    assert second.status_code == 201
+
+    response = client.get("/workflows/runs?workflow_id=maintenance.retention_cleanup")
+    assert response.status_code == 200
+    runs = response.json()["runs"]
+    assert runs
+    assert all(item["workflow_id"] == "maintenance.retention_cleanup" for item in runs)


### PR DESCRIPTION
## Summary
- add SQLite schema tables for workflow_definitions and workflow_runs
- add WorkflowCatalog service with seeded workflow definitions and run tracking
- expose workflow APIs to list definitions, list runs, and start a workflow
- add dashboard UI section for selecting, starting, and monitoring workflow runs
- extend test coverage for workflow catalog list/start/filter/failure scenarios

## API
- GET /workflows
- GET /workflows/runs
- POST /workflows/{workflow_id}/start

## Validation
- pytest -q (63 passed)
