### PR TITLE
Add crash-loop guardrails and desktop release ring rollback controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Optional startup parameters:
 .\scripts\start-desktop.ps1 -WindowStatePath ".\custom-window-state.json"
 .\scripts\start-desktop.ps1 -InstanceLockPath ".\goal-ops-desktop.lock"
 .\scripts\start-desktop.ps1 -AllowMultipleInstances
+.\scripts\start-desktop.ps1 -CrashStatePath ".\desktop-crash-state.json"
+.\scripts\start-desktop.ps1 -CrashLoopMaxCrashes 3 -CrashLoopWindowSeconds 600
+.\scripts\start-desktop.ps1 -AllowCrashLoop
 ```
 
 Behavior:
@@ -82,6 +85,7 @@ Behavior:
 - opens the same dashboard UI in a native window via `pywebview`
 - remembers window size/position across launches (disable with `-NoWindowState`)
 - enforces single-instance lock by default (disable with `-AllowMultipleInstances`)
+- blocks startup after repeated crash loops (bypass once with `-AllowCrashLoop`)
 - writes crash reports to `%USERPROFILE%\.goal_ops_console\diagnostics` (or `GOAL_OPS_DIAGNOSTICS_DIR`)
 - shuts down the embedded server when the desktop window closes
 
@@ -168,7 +172,28 @@ Distribution bundle outputs (via `package-desktop-release.ps1`):
 - `GoalOpsConsole-onefile-<version>.exe`
 - `GoalOpsConsole-install-<version>.ps1` (portable installer script)
 - `desktop-update-manifest.json` (auto-update feed preparation)
+- `desktop-rings.json` (ring targets + rollback pointer metadata)
 - `SHA256SUMS.txt`
+
+Optional rollout-ring target override during packaging:
+
+```powershell
+.\scripts\package-desktop-release.ps1 `
+  -Version "0.2.3" `
+  -Channel stable `
+  -RolloutRing stable `
+  -Mode both `
+  -OutputDir artifacts
+```
+
+Manage ring promotion / rollback without rebuilding binaries:
+
+```powershell
+.\scripts\manage-desktop-rings.ps1 -ManifestPath ".\artifacts\desktop-rings.json" -Action show
+.\scripts\manage-desktop-rings.ps1 -ManifestPath ".\artifacts\desktop-rings.json" -Action promote -Ring canary -Version "0.2.4"
+.\scripts\manage-desktop-rings.ps1 -ManifestPath ".\artifacts\desktop-rings.json" -Action promote -Ring stable -Version "0.2.3"
+.\scripts\manage-desktop-rings.ps1 -ManifestPath ".\artifacts\desktop-rings.json" -Action rollback -Ring stable
+```
 
 Note:
 - `pywebview` on Windows requires WebView2 runtime.
@@ -540,6 +565,7 @@ If a value is rejected:
 - [start-desktop.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/start-desktop.ps1)
 - [build-desktop.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/build-desktop.ps1)
 - [package-desktop-release.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/package-desktop-release.ps1)
+- [manage-desktop-rings.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/manage-desktop-rings.ps1)
 - [reset-db.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/reset-db.ps1)
 - [run-tests.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-tests.ps1)
 - [test_goal_ops.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_goal_ops.py)

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -29,10 +29,24 @@ Verify before release:
 
 Validate artifacts:
 - `artifacts\desktop-update-manifest.json` exists and version matches release tag.
+- `artifacts\desktop-rings.json` exists and points `stable` to intended version.
 - `artifacts\SHA256SUMS.txt` exists.
 - `GoalOpsConsole-onefile-<version>.exe` starts and reaches dashboard.
 
-### 1.3 Publish
+### 1.3 Ring promotion
+
+Use one control manifest for production channel pointers:
+
+```powershell
+.\scripts\manage-desktop-rings.ps1 `
+  -ManifestPath ".\artifacts\desktop-rings.json" `
+  -Action promote `
+  -Ring stable `
+  -Version "<VERSION>" `
+  -ReleaseManifestPath ".\artifacts\desktop-update-manifest.json"
+```
+
+### 1.4 Publish
 
 Tag and push:
 
@@ -43,7 +57,7 @@ git push origin v<VERSION>
 
 GitHub Actions `Desktop Build` publishes release assets on tag pushes.
 
-### 1.4 Post-release checks
+### 1.5 Post-release checks
 
 After release is live:
 - Launch desktop binary on a clean Windows machine.
@@ -55,7 +69,13 @@ After release is live:
 
 Use rollback when crash rate or readiness failures rise immediately after rollout.
 
-1. Disable rollout in updater channel (set previous stable manifest/version).
+1. Roll back stable ring pointer (fast path):
+   ```powershell
+   .\scripts\manage-desktop-rings.ps1 `
+     -ManifestPath ".\artifacts\desktop-rings.json" `
+     -Action rollback `
+     -Ring stable
+   ```
 2. Repoint download/install instructions to previous stable artifact.
 3. Keep diagnostics snapshots from failed version for triage.
 4. Open incident ticket with:
@@ -126,7 +146,22 @@ Actions:
 2. Retry launch once (stale lock auto-recovery is enabled).
 3. If still blocked, collect crash/diagnostics and escalate.
 
-### 3.5 Crash reports
+### 3.5 Crash-loop protection triggered
+
+Symptoms:
+- launcher exits with crash-loop protection message.
+- repeated crash on startup despite restart.
+
+Actions:
+1. Review latest crash report and diagnostics snapshot.
+2. Validate fix/hypothesis before bypassing protection.
+3. Use one-time bypass only for supervised verification:
+   ```powershell
+   .\scripts\start-desktop.ps1 -AllowCrashLoop
+   ```
+4. If crash reproduces, stop and roll back ring immediately.
+
+### 3.6 Crash reports
 
 Location:
 - default: `%USERPROFILE%\.goal_ops_console\diagnostics`
@@ -146,4 +181,5 @@ Required triage fields:
 - Keep single-instance protection enabled in production.
 - Keep readiness endpoint as launch gate.
 - Keep diagnostics export enabled for operators.
+- Keep crash-loop protection enabled; only bypass for supervised triage.
 - Prefer rollback over hotfix-in-place during active outage.

--- a/goal_ops_console/desktop.py
+++ b/goal_ops_console/desktop.py
@@ -10,7 +10,7 @@ import traceback
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -24,6 +24,10 @@ from goal_ops_console.main import create_app
 class InstanceLock:
     path: Path
     pid: int
+
+
+DEFAULT_CRASH_LOOP_MAX_CRASHES = 3
+DEFAULT_CRASH_LOOP_WINDOW_SECONDS = 600
 
 
 def _pick_port(host: str, explicit_port: int | None) -> int:
@@ -64,6 +68,10 @@ def _default_instance_lock_path() -> Path:
 
 def _default_diagnostics_dir() -> Path:
     return Path.home() / ".goal_ops_console" / "diagnostics"
+
+
+def _default_crash_state_path() -> Path:
+    return Path.home() / ".goal_ops_console" / "desktop-crash-state.json"
 
 
 def _utc_timestamp() -> str:
@@ -212,6 +220,143 @@ def _coerce_int(value: Any) -> int | None:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def _coerce_crash_positive_int(value: Any, fallback: int) -> int:
+    parsed = _coerce_int(value)
+    if parsed is None or parsed <= 0:
+        return int(fallback)
+    return int(parsed)
+
+
+def _parse_utc_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _load_crash_state(path: Path) -> dict[str, Any]:
+    defaults: dict[str, Any] = {"crashes": [], "last_success_utc": None}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError):
+        return defaults
+    if not isinstance(payload, dict):
+        return defaults
+
+    crashes = payload.get("crashes")
+    sanitized_crashes: list[dict[str, Any]] = []
+    if isinstance(crashes, list):
+        for item in crashes:
+            if not isinstance(item, dict):
+                continue
+            timestamp_utc = item.get("timestamp_utc")
+            if _parse_utc_datetime(timestamp_utc) is None:
+                continue
+            sanitized_crashes.append(
+                {
+                    "timestamp_utc": str(timestamp_utc),
+                    "error_type": str(item.get("error_type") or ""),
+                    "error": str(item.get("error") or ""),
+                    "report_path": str(item.get("report_path") or ""),
+                }
+            )
+
+    return {
+        "crashes": sanitized_crashes,
+        "last_success_utc": payload.get("last_success_utc"),
+    }
+
+
+def _save_crash_state(path: Path, state: dict[str, Any]) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state, ensure_ascii=True, indent=2), encoding="utf-8")
+    except OSError:
+        return
+
+
+def _recent_crashes(
+    crashes: list[dict[str, Any]],
+    *,
+    now_utc: datetime,
+    window_seconds: int,
+) -> list[dict[str, Any]]:
+    cutoff = now_utc - timedelta(seconds=max(1, int(window_seconds)))
+    recent: list[dict[str, Any]] = []
+    for item in crashes:
+        timestamp = _parse_utc_datetime(item.get("timestamp_utc"))
+        if timestamp is None:
+            continue
+        if timestamp >= cutoff:
+            recent.append(item)
+    return recent
+
+
+def _crash_loop_status(
+    path: Path,
+    *,
+    max_crashes: int,
+    window_seconds: int,
+) -> dict[str, Any]:
+    safe_max = _coerce_crash_positive_int(max_crashes, DEFAULT_CRASH_LOOP_MAX_CRASHES)
+    safe_window = _coerce_crash_positive_int(window_seconds, DEFAULT_CRASH_LOOP_WINDOW_SECONDS)
+    state = _load_crash_state(path)
+    now = datetime.now(UTC)
+    recent = _recent_crashes(state.get("crashes", []), now_utc=now, window_seconds=safe_window)
+    if len(recent) != len(state.get("crashes", [])):
+        state["crashes"] = recent
+        _save_crash_state(path, state)
+    return {
+        "blocked": len(recent) >= safe_max,
+        "recent_count": len(recent),
+        "max_crashes": safe_max,
+        "window_seconds": safe_window,
+    }
+
+
+def _record_crash_event(
+    path: Path,
+    *,
+    exc: Exception,
+    report_path: Path | None,
+    window_seconds: int,
+) -> None:
+    safe_window = _coerce_crash_positive_int(window_seconds, DEFAULT_CRASH_LOOP_WINDOW_SECONDS)
+    state = _load_crash_state(path)
+    recent = _recent_crashes(
+        state.get("crashes", []),
+        now_utc=datetime.now(UTC),
+        window_seconds=safe_window,
+    )
+    recent.append(
+        {
+            "timestamp_utc": _iso_utc(),
+            "error_type": exc.__class__.__name__,
+            "error": str(exc),
+            "report_path": str(report_path) if report_path else "",
+        }
+    )
+    state["crashes"] = recent[-50:]
+    _save_crash_state(path, state)
+
+
+def _record_successful_launch(path: Path) -> None:
+    state = _load_crash_state(path)
+    state["crashes"] = []
+    state["last_success_utc"] = _iso_utc()
+    _save_crash_state(path, state)
 
 
 def _load_window_state(
@@ -414,6 +559,14 @@ def run_desktop(
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run Goal Ops Console in a desktop window.")
+    default_crash_loop_max = _coerce_crash_positive_int(
+        os.getenv("GOAL_OPS_DESKTOP_CRASH_LOOP_MAX_CRASHES"),
+        DEFAULT_CRASH_LOOP_MAX_CRASHES,
+    )
+    default_crash_loop_window = _coerce_crash_positive_int(
+        os.getenv("GOAL_OPS_DESKTOP_CRASH_LOOP_WINDOW_SECONDS"),
+        DEFAULT_CRASH_LOOP_WINDOW_SECONDS,
+    )
     parser.add_argument(
         "--database-url",
         default="goal_ops.db",
@@ -475,6 +628,28 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Disable single-instance lock (not recommended for production).",
     )
     parser.add_argument(
+        "--crash-state-path",
+        default=None,
+        help="Optional JSON file path for desktop crash-loop protection state.",
+    )
+    parser.add_argument(
+        "--allow-crash-loop",
+        action="store_true",
+        help="Bypass crash-loop launch protection for a single start.",
+    )
+    parser.add_argument(
+        "--crash-loop-max-crashes",
+        type=int,
+        default=default_crash_loop_max,
+        help=f"Maximum crashes allowed within crash-loop window (default: {default_crash_loop_max}).",
+    )
+    parser.add_argument(
+        "--crash-loop-window-seconds",
+        type=int,
+        default=default_crash_loop_window,
+        help=f"Crash-loop window in seconds (default: {default_crash_loop_window}).",
+    )
+    parser.add_argument(
         "--no-window-state",
         action="store_true",
         help="Disable persistent desktop window state.",
@@ -494,6 +669,26 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
+    crash_state_path = (
+        Path(args.crash_state_path).expanduser()
+        if args.crash_state_path
+        else _default_crash_state_path()
+    )
+    crash_loop_status = _crash_loop_status(
+        crash_state_path,
+        max_crashes=args.crash_loop_max_crashes,
+        window_seconds=args.crash_loop_window_seconds,
+    )
+    if crash_loop_status["blocked"] and not args.allow_crash_loop:
+        print(
+            "[desktop] Crash-loop protection active: "
+            f"{crash_loop_status['recent_count']} crashes in "
+            f"{crash_loop_status['window_seconds']}s."
+        )
+        print(
+            "[desktop] Bypass once with --allow-crash-loop after reviewing diagnostics."
+        )
+        return 2
     try:
         run_desktop(
             database_url=args.database_url,
@@ -511,6 +706,7 @@ def main(argv: list[str] | None = None) -> int:
             window_title=args.title,
             debug=args.debug,
         )
+        _record_successful_launch(crash_state_path)
     except Exception as exc:  # pragma: no cover - this is top-level UX handling
         configured_diagnostics_dir = os.getenv("GOAL_OPS_DIAGNOSTICS_DIR", "").strip()
         diagnostics_dir = (
@@ -532,6 +728,12 @@ def main(argv: list[str] | None = None) -> int:
         )
         if report_path is not None:
             print(f"[desktop] Crash report saved to: {report_path}")
+        _record_crash_event(
+            crash_state_path,
+            exc=exc,
+            report_path=report_path,
+            window_seconds=args.crash_loop_window_seconds,
+        )
         print(f"[desktop] Failed to launch: {exc}")
         return 1
     return 0

--- a/goal_ops_console/workflow_catalog.py
+++ b/goal_ops_console/workflow_catalog.py
@@ -428,7 +428,16 @@ class WorkflowCatalog:
 
             processed_any = False
             while not self._worker_stop.is_set():
-                claimed = self._claim_next_queued_run()
+                try:
+                    claimed = self._claim_next_queued_run()
+                except sqlite3.OperationalError:
+                    # SQLite lock contention is transient in concurrent test/desktop scenarios.
+                    # Keep worker alive and retry on the next wake cycle.
+                    self._metric("workflows.worker.lock_conflicts")
+                    break
+                except Exception:
+                    self._metric("workflows.worker.errors")
+                    break
                 if claimed is None:
                     break
                 processed_any = True

--- a/scripts/manage-desktop-rings.ps1
+++ b/scripts/manage-desktop-rings.ps1
@@ -1,0 +1,258 @@
+param(
+    [string]$ManifestPath = "artifacts/desktop-rings.json",
+    [ValidateSet("show", "promote", "rollback")]
+    [string]$Action = "show",
+    [ValidateSet("stable", "canary")]
+    [string]$Ring = "stable",
+    [string]$Version = "",
+    [string]$ReleaseManifestPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+function Resolve-TargetPath {
+    param(
+        [string]$PathValue
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PathValue)) {
+        return Join-Path $ProjectRoot "artifacts/desktop-rings.json"
+    }
+    if ([System.IO.Path]::IsPathRooted($PathValue)) {
+        return $PathValue
+    }
+    return Join-Path $ProjectRoot $PathValue
+}
+
+function New-RingsState {
+    return [ordered]@{
+        schema_version = 1
+        app_id = "goal-ops-console"
+        updated_at_utc = (Get-Date).ToUniversalTime().ToString("o")
+        rings = [ordered]@{
+            stable = [ordered]@{
+                version = $null
+                rollback_version = $null
+                updated_at_utc = $null
+            }
+            canary = [ordered]@{
+                version = $null
+                rollback_version = $null
+                updated_at_utc = $null
+            }
+        }
+        releases = [ordered]@{}
+    }
+}
+
+function To-NullableString {
+    param(
+        [object]$Value
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+    $text = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
+    return $text
+}
+
+function Read-RingsState {
+    param(
+        [string]$PathValue
+    )
+
+    if (-not (Test-Path -LiteralPath $PathValue)) {
+        return (New-RingsState)
+    }
+
+    try {
+        $raw = Get-Content -LiteralPath $PathValue -Raw
+        $loaded = $raw | ConvertFrom-Json
+    } catch {
+        return (New-RingsState)
+    }
+
+    $state = New-RingsState
+    if ($loaded.schema_version) {
+        $state.schema_version = [int]$loaded.schema_version
+    }
+    if ($loaded.app_id) {
+        $state.app_id = [string]$loaded.app_id
+    }
+    if ($loaded.updated_at_utc) {
+        $state.updated_at_utc = [string]$loaded.updated_at_utc
+    }
+
+    foreach ($ringKey in @("stable", "canary")) {
+        if ($loaded.rings -and $loaded.rings.$ringKey) {
+            $state.rings[$ringKey].version = To-NullableString $loaded.rings.$ringKey.version
+            $state.rings[$ringKey].rollback_version = To-NullableString $loaded.rings.$ringKey.rollback_version
+            $state.rings[$ringKey].updated_at_utc = To-NullableString $loaded.rings.$ringKey.updated_at_utc
+        }
+    }
+
+    if ($loaded.releases) {
+        foreach ($entry in $loaded.releases.PSObject.Properties) {
+            $state.releases[$entry.Name] = [ordered]@{
+                version = To-NullableString $entry.Value.version
+                channel = To-NullableString $entry.Value.channel
+                rollout_ring = To-NullableString $entry.Value.rollout_ring
+                published_at_utc = To-NullableString $entry.Value.published_at_utc
+                manifest_file = To-NullableString $entry.Value.manifest_file
+                artifacts = @($entry.Value.artifacts)
+            }
+        }
+    }
+
+    return $state
+}
+
+function Save-RingsState {
+    param(
+        [string]$PathValue,
+        [hashtable]$State
+    )
+
+    $parent = Split-Path -Parent $PathValue
+    if (-not [string]::IsNullOrWhiteSpace($parent)) {
+        New-Item -ItemType Directory -Force -Path $parent | Out-Null
+    }
+    $State.updated_at_utc = (Get-Date).ToUniversalTime().ToString("o")
+    $State | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $PathValue -Encoding UTF8
+}
+
+function Register-ReleaseEntry {
+    param(
+        [hashtable]$State,
+        [string]$VersionValue,
+        [string]$ManifestFile,
+        [string]$ChannelValue,
+        [string]$RingValue,
+        [string]$PublishedAtUtc,
+        [object[]]$Artifacts
+    )
+
+    $State.releases[$VersionValue] = [ordered]@{
+        version = $VersionValue
+        channel = $ChannelValue
+        rollout_ring = $RingValue
+        published_at_utc = $PublishedAtUtc
+        manifest_file = $ManifestFile
+        artifacts = @($Artifacts)
+    }
+}
+
+function Register-ReleaseFromManifest {
+    param(
+        [hashtable]$State,
+        [string]$ManifestFilePath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ManifestFilePath)) {
+        return
+    }
+    if (-not (Test-Path -LiteralPath $ManifestFilePath)) {
+        throw "Release manifest not found: $ManifestFilePath"
+    }
+
+    $release = (Get-Content -LiteralPath $ManifestFilePath -Raw) | ConvertFrom-Json
+    if (-not $release.version) {
+        throw "Release manifest is missing 'version'."
+    }
+
+    $channelValue = [string]$release.channel
+    $ringValue = [string]$release.rollout_ring
+    if ([string]::IsNullOrWhiteSpace($ringValue)) {
+        $ringValue = if ($channelValue -eq "stable") { "stable" } else { "canary" }
+    }
+    Register-ReleaseEntry `
+        -State $State `
+        -VersionValue ([string]$release.version) `
+        -ManifestFile (Split-Path -Leaf $ManifestFilePath) `
+        -ChannelValue $channelValue `
+        -RingValue $ringValue `
+        -PublishedAtUtc ([string]$release.published_at_utc) `
+        -Artifacts @($release.artifacts)
+}
+
+function Ensure-ReleaseStub {
+    param(
+        [hashtable]$State,
+        [string]$VersionValue,
+        [string]$RingValue
+    )
+
+    if (-not $State.releases.Contains($VersionValue)) {
+        Register-ReleaseEntry `
+            -State $State `
+            -VersionValue $VersionValue `
+            -ManifestFile "" `
+            -ChannelValue "" `
+            -RingValue $RingValue `
+            -PublishedAtUtc (Get-Date).ToUniversalTime().ToString("o") `
+            -Artifacts @()
+    }
+}
+
+$resolvedManifestPath = Resolve-TargetPath -PathValue $ManifestPath
+$state = Read-RingsState -PathValue $resolvedManifestPath
+
+if (-not [string]::IsNullOrWhiteSpace($ReleaseManifestPath)) {
+    $resolvedReleaseManifestPath = Resolve-TargetPath -PathValue $ReleaseManifestPath
+    Register-ReleaseFromManifest -State $state -ManifestFilePath $resolvedReleaseManifestPath
+}
+
+if ($Action -eq "show") {
+    $state | ConvertTo-Json -Depth 12
+    exit 0
+}
+
+if ($Action -eq "promote") {
+    if ([string]::IsNullOrWhiteSpace($Version)) {
+        throw "Version is required for Action=promote."
+    }
+    $target = [string]$Version
+    Ensure-ReleaseStub -State $state -VersionValue $target -RingValue $Ring
+
+    $previous = [string]$state.rings[$Ring].version
+    if (-not [string]::IsNullOrWhiteSpace($previous) -and $previous -ne $target) {
+        $state.rings[$Ring].rollback_version = $previous
+    }
+    $state.rings[$Ring].version = $target
+    $state.rings[$Ring].updated_at_utc = (Get-Date).ToUniversalTime().ToString("o")
+
+    Save-RingsState -PathValue $resolvedManifestPath -State $state
+    Write-Host "Ring '$Ring' promoted to version '$target'." -ForegroundColor Green
+    if (-not [string]::IsNullOrWhiteSpace($state.rings[$Ring].rollback_version)) {
+        Write-Host "Rollback target: $($state.rings[$Ring].rollback_version)" -ForegroundColor Yellow
+    }
+    Write-Host "Manifest: $resolvedManifestPath" -ForegroundColor Cyan
+    exit 0
+}
+
+if ($Action -eq "rollback") {
+    $current = [string]$state.rings[$Ring].version
+    $rollbackTarget = [string]$state.rings[$Ring].rollback_version
+    if ([string]::IsNullOrWhiteSpace($rollbackTarget)) {
+        throw "No rollback target available for ring '$Ring'."
+    }
+
+    $state.rings[$Ring].version = $rollbackTarget
+    $state.rings[$Ring].rollback_version = $current
+    $state.rings[$Ring].updated_at_utc = (Get-Date).ToUniversalTime().ToString("o")
+
+    Save-RingsState -PathValue $resolvedManifestPath -State $state
+    Write-Host "Ring '$Ring' rolled back to version '$rollbackTarget'." -ForegroundColor Green
+    if (-not [string]::IsNullOrWhiteSpace($current)) {
+        Write-Host "Previous current version stored as rollback target: $current" -ForegroundColor Yellow
+    }
+    Write-Host "Manifest: $resolvedManifestPath" -ForegroundColor Cyan
+    exit 0
+}

--- a/scripts/package-desktop-release.ps1
+++ b/scripts/package-desktop-release.ps1
@@ -3,9 +3,12 @@ param(
     [string]$Version = "0.1.0-dev",
     [ValidateSet("snapshot", "stable", "beta")]
     [string]$Channel = "snapshot",
+    [ValidateSet("auto", "stable", "canary")]
+    [string]$RolloutRing = "auto",
     [ValidateSet("onedir", "onefile", "both")]
     [string]$Mode = "both",
     [string]$OutputDir = "artifacts",
+    [string]$RingsManifestPath = "",
     [string]$BaseDownloadUrl = "",
     [switch]$Sign,
     [string]$SignToolPath = "signtool.exe",
@@ -195,17 +198,42 @@ foreach ($artifact in $artifacts) {
 $checksumLines | Set-Content -LiteralPath $checksumsPath -Encoding UTF8
 
 $manifestPath = Join-Path $resolvedOutputDir "desktop-update-manifest.json"
+$resolvedRolloutRing = if ($RolloutRing -eq "auto") {
+    if ($Channel -eq "stable") { "stable" } else { "canary" }
+} else {
+    $RolloutRing
+}
+
 $manifest = [pscustomobject]@{
     app_id = "goal-ops-console"
     name = $Name
     version = $Version
     channel = $Channel
+    rollout_ring = $resolvedRolloutRing
     published_at_utc = (Get-Date).ToUniversalTime().ToString("o")
     artifacts = $artifacts
 }
 $manifest | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $manifestPath -Encoding UTF8
 
+$resolvedRingsManifestPath = if ([string]::IsNullOrWhiteSpace($RingsManifestPath)) {
+    Join-Path $resolvedOutputDir "desktop-rings.json"
+} elseif ([System.IO.Path]::IsPathRooted($RingsManifestPath)) {
+    $RingsManifestPath
+} else {
+    Join-Path $ProjectRoot $RingsManifestPath
+}
+$ringsScriptPath = Join-Path $ProjectRoot "scripts/manage-desktop-rings.ps1"
+if (Test-Path -LiteralPath $ringsScriptPath) {
+    & $ringsScriptPath `
+        -ManifestPath $resolvedRingsManifestPath `
+        -Action promote `
+        -Ring $resolvedRolloutRing `
+        -Version $Version `
+        -ReleaseManifestPath $manifestPath | Out-Null
+}
+
 Write-Host "Desktop release package ready." -ForegroundColor Green
 Write-Host "Output directory: $resolvedOutputDir" -ForegroundColor Green
 Write-Host "Manifest: $manifestPath" -ForegroundColor Green
+Write-Host "Rings: $resolvedRingsManifestPath" -ForegroundColor Green
 Write-Host "Checksums: $checksumsPath" -ForegroundColor Green

--- a/scripts/start-desktop.ps1
+++ b/scripts/start-desktop.ps1
@@ -10,7 +10,11 @@ param(
     [string]$WindowStatePath = "",
     [string]$InstanceLockPath = "",
     [switch]$AllowMultipleInstances,
-    [string]$DiagnosticsDir = ""
+    [string]$DiagnosticsDir = "",
+    [string]$CrashStatePath = "",
+    [switch]$AllowCrashLoop,
+    [int]$CrashLoopMaxCrashes = 0,
+    [int]$CrashLoopWindowSeconds = 0
 )
 
 $ErrorActionPreference = "Stop"
@@ -56,6 +60,18 @@ if (-not [string]::IsNullOrWhiteSpace($InstanceLockPath)) {
 }
 if ($AllowMultipleInstances) {
     $args += "--allow-multiple-instances"
+}
+if (-not [string]::IsNullOrWhiteSpace($CrashStatePath)) {
+    $args += @("--crash-state-path", $CrashStatePath)
+}
+if ($AllowCrashLoop) {
+    $args += "--allow-crash-loop"
+}
+if ($CrashLoopMaxCrashes -gt 0) {
+    $args += @("--crash-loop-max-crashes", $CrashLoopMaxCrashes)
+}
+if ($CrashLoopWindowSeconds -gt 0) {
+    $args += @("--crash-loop-window-seconds", $CrashLoopWindowSeconds)
 }
 
 python @args

--- a/tests/test_desktop_launcher.py
+++ b/tests/test_desktop_launcher.py
@@ -34,6 +34,10 @@ def test_parse_args_defaults():
     assert args.window_state_path is None
     assert args.instance_lock_path is None
     assert args.allow_multiple_instances is False
+    assert args.crash_state_path is None
+    assert args.allow_crash_loop is False
+    assert args.crash_loop_max_crashes == desktop.DEFAULT_CRASH_LOOP_MAX_CRASHES
+    assert args.crash_loop_window_seconds == desktop.DEFAULT_CRASH_LOOP_WINDOW_SECONDS
     assert args.no_window_state is False
     assert args.title == "Goal Ops Console"
     assert args.debug is False
@@ -215,6 +219,73 @@ def test_write_crash_report_writes_json_payload():
         shutil.rmtree(test_dir, ignore_errors=True)
 
 
+def test_crash_loop_status_blocks_after_threshold():
+    test_dir = _local_test_dir()
+    try:
+        crash_state_path = test_dir / "crash-state.json"
+        now = desktop._iso_utc()
+        crash_state_path.write_text(
+            json.dumps(
+                {
+                    "crashes": [
+                        {"timestamp_utc": now, "error_type": "RuntimeError", "error": "A"},
+                        {"timestamp_utc": now, "error_type": "RuntimeError", "error": "B"},
+                        {"timestamp_utc": now, "error_type": "RuntimeError", "error": "C"},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        status = desktop._crash_loop_status(
+            crash_state_path,
+            max_crashes=3,
+            window_seconds=600,
+        )
+        assert status["blocked"] is True
+        assert status["recent_count"] == 3
+    finally:
+        shutil.rmtree(test_dir, ignore_errors=True)
+
+
+def test_crash_loop_status_prunes_old_crashes():
+    test_dir = _local_test_dir()
+    try:
+        crash_state_path = test_dir / "crash-state.json"
+        crash_state_path.write_text(
+            json.dumps(
+                {
+                    "crashes": [
+                        {
+                            "timestamp_utc": "2000-01-01T00:00:00+00:00",
+                            "error_type": "RuntimeError",
+                            "error": "Old",
+                        },
+                        {
+                            "timestamp_utc": desktop._iso_utc(),
+                            "error_type": "RuntimeError",
+                            "error": "New",
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        status = desktop._crash_loop_status(
+            crash_state_path,
+            max_crashes=2,
+            window_seconds=600,
+        )
+        assert status["blocked"] is False
+        assert status["recent_count"] == 1
+
+        persisted = json.loads(crash_state_path.read_text(encoding="utf-8"))
+        assert len(persisted["crashes"]) == 1
+    finally:
+        shutil.rmtree(test_dir, ignore_errors=True)
+
+
 def test_main_returns_nonzero_when_launch_fails(monkeypatch, capsys):
     def _raise(**_kwargs):
         raise RuntimeError("boom")
@@ -320,3 +391,119 @@ def test_main_can_disable_single_instance(monkeypatch):
     assert exit_code == 0
     assert captured_kwargs["single_instance"] is False
     assert captured_kwargs["instance_lock_path"] == "custom-desktop.lock"
+
+
+def test_main_blocks_launch_when_crash_loop_active(monkeypatch, capsys):
+    test_dir = _local_test_dir()
+    try:
+        crash_state_path = test_dir / "crash-state.json"
+        now = desktop._iso_utc()
+        crash_state_path.write_text(
+            json.dumps(
+                {
+                    "crashes": [
+                        {"timestamp_utc": now, "error_type": "RuntimeError", "error": "A"},
+                        {"timestamp_utc": now, "error_type": "RuntimeError", "error": "B"},
+                        {"timestamp_utc": now, "error_type": "RuntimeError", "error": "C"},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        called = {"run": False}
+
+        def _fake_run_desktop(**_kwargs):
+            called["run"] = True
+
+        monkeypatch.setattr(desktop, "run_desktop", _fake_run_desktop)
+
+        exit_code = desktop.main(
+            [
+                "--database-url",
+                "demo.db",
+                "--crash-state-path",
+                str(crash_state_path),
+                "--crash-loop-max-crashes",
+                "3",
+                "--crash-loop-window-seconds",
+                "600",
+            ]
+        )
+        captured = capsys.readouterr()
+
+        assert exit_code == 2
+        assert called["run"] is False
+        assert "Crash-loop protection active" in captured.out
+    finally:
+        shutil.rmtree(test_dir, ignore_errors=True)
+
+
+def test_main_can_bypass_crash_loop_once(monkeypatch):
+    test_dir = _local_test_dir()
+    try:
+        crash_state_path = test_dir / "crash-state.json"
+        now = desktop._iso_utc()
+        crash_state_path.write_text(
+            json.dumps(
+                {
+                    "crashes": [
+                        {"timestamp_utc": now, "error_type": "RuntimeError", "error": "A"},
+                        {"timestamp_utc": now, "error_type": "RuntimeError", "error": "B"},
+                        {"timestamp_utc": now, "error_type": "RuntimeError", "error": "C"},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        called = {"run": False}
+
+        def _fake_run_desktop(**_kwargs):
+            called["run"] = True
+
+        monkeypatch.setattr(desktop, "run_desktop", _fake_run_desktop)
+        exit_code = desktop.main(
+            [
+                "--database-url",
+                "demo.db",
+                "--crash-state-path",
+                str(crash_state_path),
+                "--allow-crash-loop",
+            ]
+        )
+
+        assert exit_code == 0
+        assert called["run"] is True
+    finally:
+        shutil.rmtree(test_dir, ignore_errors=True)
+
+
+def test_main_records_crash_event_on_failure(monkeypatch):
+    test_dir = _local_test_dir()
+    try:
+        crash_state_path = test_dir / "crash-state.json"
+        report_path = test_dir / "desktop-crash-report.json"
+
+        def _raise(**_kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(desktop, "run_desktop", _raise)
+        monkeypatch.setattr(desktop, "_write_crash_report", lambda *_args, **_kwargs: report_path)
+
+        exit_code = desktop.main(
+            [
+                "--database-url",
+                "demo.db",
+                "--crash-state-path",
+                str(crash_state_path),
+            ]
+        )
+
+        assert exit_code == 1
+        payload = json.loads(crash_state_path.read_text(encoding="utf-8"))
+        assert len(payload["crashes"]) == 1
+        assert payload["crashes"][0]["error_type"] == "RuntimeError"
+        assert payload["crashes"][0]["report_path"] == str(report_path)
+    finally:
+        shutil.rmtree(test_dir, ignore_errors=True)

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1381,3 +1381,41 @@ def test_63_system_diagnostics_exports_snapshot():
             assert "recent_workflow_runs" in snapshot
     finally:
         shutil.rmtree(diagnostics_dir, ignore_errors=True)
+
+
+def test_64_workflow_worker_survives_claim_lock_conflict(monkeypatch):
+    app = create_app(
+        Settings(
+            database_url=":memory:",
+            workflow_worker_poll_interval_seconds=0.05,
+        )
+    )
+    with TestClient(app) as local_client:
+        catalog = local_client.app.state.services.workflow_catalog
+        original_claim = catalog._claim_next_queued_run
+        fail_once = {"remaining": 1}
+
+        def _flaky_claim():
+            if fail_once["remaining"] > 0:
+                fail_once["remaining"] -= 1
+                raise sqlite3.OperationalError("database table is locked: workflow_runs")
+            return original_claim()
+
+        monkeypatch.setattr(catalog, "_claim_next_queued_run", _flaky_claim)
+
+        started = local_client.post(
+            "/workflows/maintenance.retention_cleanup/start",
+            json={"requested_by": "workflow-test", "payload": {"source": "lock-conflict"}},
+        )
+        assert started.status_code == 201
+        run_id = started.json()["run"]["run_id"]
+
+        final_run = _wait_for_run_in_states(
+            local_client,
+            run_id,
+            {"succeeded", "failed", "timed_out", "cancelled"},
+            timeout_seconds=3.0,
+        )
+        assert final_run["status"] == "succeeded"
+        assert fail_once["remaining"] == 0
+        assert catalog.worker_status()["is_running"] is True


### PR DESCRIPTION
## Summary
- add desktop crash-loop launch protection with configurable threshold/window and one-time bypass flag
- persist crash-loop state and record crash events to avoid repeated failing launches
- add desktop release ring control script for promote/rollback (scripts/manage-desktop-rings.ps1)
- extend packaging to emit ollout_ring metadata and update desktop-rings.json
- document ring promotion/rollback and crash-loop operations in README + production runbook
- harden workflow worker loop to survive transient SQLite lock conflicts

## Validation
- python .\\scripts\\desktop-smoke.py
- pytest -q (85 passed)
