### PR TITLE
Add SQLite integrity endpoint and migration backup guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Observability endpoints:
 
 - `GET /system/metrics`
 - `GET /system/audit`
+- `GET /system/database/integrity?mode=quick|full`
 - `GET /system/faults`
 - `GET /system/faults/summary`
 - `POST /system/faults/resolve_bulk`
@@ -553,6 +554,7 @@ If a value is rejected:
 - `goal_ops.db` keeps your manual test data between restarts.
 - If you see old goals or tasks, reset the local database.
 - In this sandboxed environment, file-backed SQLite can behave differently than in a normal local shell. For normal local use, keep `GOAL_OPS_DATABASE_URL="goal_ops.db"` set before starting the server.
+- Optional: set `GOAL_OPS_DB_MIGRATION_BACKUP_DIR` to control where pre-migration SQLite backups are written.
 - If you start `uvicorn` from outside the project directory, keep the `--app-dir` flag.
 
 ## Key Files

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -62,6 +62,7 @@ GitHub Actions `Desktop Build` publishes release assets on tag pushes.
 After release is live:
 - Launch desktop binary on a clean Windows machine.
 - Confirm `GET /system/readiness` returns `{"ready": true, ...}`.
+- Confirm `GET /system/database/integrity?mode=quick` returns `"ok": true`.
 - Trigger `Export Diagnostics` once from Operator Controls and confirm snapshot file exists.
 - Verify one workflow run can be queued and completed from UI.
 
@@ -99,10 +100,14 @@ Actions:
 2. Check failing check:
    - `checks.database.ok = false`: inspect DB path/permissions/locking.
    - `checks.workflow_worker.ok = false`: worker thread failed to start.
-3. Export diagnostics:
+3. If the database check fails, run integrity probe:
+   ```powershell
+   Invoke-RestMethod "http://127.0.0.1:8000/system/database/integrity?mode=quick"
+   ```
+4. Export diagnostics:
    - UI: `Export Diagnostics`
    - API: `POST /system/diagnostics`
-4. Restart app and retry once. If still failing, rollback.
+5. Restart app and retry once. If still failing, rollback.
 
 ### 3.2 Workflow worker stalled
 

--- a/goal_ops_console/config.py
+++ b/goal_ops_console/config.py
@@ -1,7 +1,7 @@
 import os
 from dataclasses import dataclass
 
-SPEC_VERSION = "1.4.4"
+SPEC_VERSION = "1.4.5"
 
 # Skill Selection
 MIN_RUNS = 5
@@ -54,6 +54,7 @@ WORKFLOW_RUN_TIMEOUT_SECONDS = 300
 WORKFLOW_REAPER_BATCH_SIZE = 200
 WORKFLOW_WORKER_POLL_INTERVAL_SECONDS = 0.5
 DIAGNOSTICS_DIR = os.getenv("GOAL_OPS_DIAGNOSTICS_DIR", "")
+DB_MIGRATION_BACKUP_DIR = os.getenv("GOAL_OPS_DB_MIGRATION_BACKUP_DIR", "")
 
 # The sandbox in this workspace rejects file-backed SQLite locks, so the
 # persistent `goal_ops.db` path should be supplied via GOAL_OPS_DATABASE_URL.
@@ -84,3 +85,4 @@ class Settings:
     workflow_reaper_batch_size: int = WORKFLOW_REAPER_BATCH_SIZE
     workflow_worker_poll_interval_seconds: float = WORKFLOW_WORKER_POLL_INTERVAL_SECONDS
     diagnostics_dir: str = DIAGNOSTICS_DIR
+    db_migration_backup_dir: str = DB_MIGRATION_BACKUP_DIR

--- a/goal_ops_console/database.py
+++ b/goal_ops_console/database.py
@@ -322,10 +322,23 @@ class Transaction:
 
 
 class Database:
-    def __init__(self, database_url: str):
+    def __init__(
+        self,
+        database_url: str,
+        *,
+        migration_backup_dir: str = "",
+    ):
         self.original_url = database_url
         self.database_url = self._normalize_database_url(database_url)
         self._uri = self.database_url.startswith("file:")
+        self.migration_backup_dir = migration_backup_dir.strip()
+        self._database_path = self._resolve_database_file_path(self.database_url)
+        self._database_existed_at_startup = bool(
+            self._database_path is not None and self._database_path.exists()
+        )
+        self._last_migration_backup_path: str | None = None
+        self._last_migration_backup_created_at: str | None = None
+        self._last_migration_backup_versions: list[int] = []
         self._keeper = None
         if "mode=memory" in self.database_url:
             self._keeper = self._connect()
@@ -334,6 +347,14 @@ class Database:
         if database_url == ":memory:":
             return f"file:goal_ops_{uuid.uuid4().hex}?mode=memory&cache=shared"
         return str(Path(database_url)) if not database_url.startswith("file:") else database_url
+
+    def _resolve_database_file_path(self, database_url: str) -> Path | None:
+        if database_url.startswith("file:"):
+            return None
+        normalized = Path(database_url)
+        if normalized.name == ":memory:":
+            return None
+        return normalized
 
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(
@@ -382,14 +403,155 @@ class Database:
                 conn.close()
 
     def _apply_migrations(self, conn: sqlite3.Connection) -> None:
-        for version, script in MIGRATIONS:
-            row = conn.execute(
-                "SELECT 1 FROM schema_migrations WHERE version = ?",
-                (version,),
-            ).fetchone()
-            if row is not None:
-                continue
+        pending = self._pending_migrations(conn)
+        if not pending:
+            return
+        self._create_migration_backup(conn, [version for version, _ in pending])
+        for _, script in pending:
             conn.executescript(script)
+
+    def _pending_migrations(self, conn: sqlite3.Connection) -> list[tuple[int, str]]:
+        applied_rows = conn.execute("SELECT version FROM schema_migrations").fetchall()
+        applied_versions = {int(row[0]) for row in applied_rows}
+        return [(version, script) for version, script in MIGRATIONS if version not in applied_versions]
+
+    def _create_migration_backup(
+        self,
+        conn: sqlite3.Connection,
+        pending_versions: list[int],
+    ) -> None:
+        if not pending_versions:
+            return
+        if self._database_path is None or not self._database_existed_at_startup:
+            return
+
+        timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        versions = "-".join(str(version) for version in pending_versions)
+        backup_suffix = self._database_path.suffix or ".sqlite3"
+        backup_name_prefix = (
+            f"{self._database_path.stem}-pre-migration-v{versions}-"
+            f"{timestamp}"
+        )
+        candidate_roots: list[Path] = []
+        if self.migration_backup_dir:
+            candidate_roots.append(Path(self.migration_backup_dir).expanduser())
+        default_root = self._database_path.parent / "migration_backups"
+        if all(default_root != root for root in candidate_roots):
+            candidate_roots.append(default_root)
+
+        last_error: Exception | None = None
+        for backup_root in candidate_roots:
+            backup_path = backup_root / (
+                f"{backup_name_prefix}-{uuid.uuid4().hex[:8]}{backup_suffix}"
+            )
+            try:
+                backup_root.mkdir(parents=True, exist_ok=True)
+                backup_conn = sqlite3.connect(
+                    str(backup_path),
+                    check_same_thread=False,
+                    isolation_level=None,
+                )
+                try:
+                    conn.backup(backup_conn)
+                finally:
+                    backup_conn.close()
+            except Exception as exc:
+                last_error = exc
+                continue
+
+            self._last_migration_backup_path = str(backup_path)
+            self._last_migration_backup_created_at = datetime.now(UTC).isoformat()
+            self._last_migration_backup_versions = list(pending_versions)
+            return
+
+        if last_error is not None:
+            raise RuntimeError("Failed to create database migration backup") from last_error
+
+    def database_file_info(self) -> dict[str, object]:
+        if self._database_path is None:
+            return {
+                "kind": "memory",
+                "path": None,
+                "exists": False,
+                "size_bytes": 0,
+                "modified_at_utc": None,
+            }
+
+        exists = self._database_path.exists()
+        if not exists:
+            return {
+                "kind": "file",
+                "path": str(self._database_path),
+                "exists": False,
+                "size_bytes": 0,
+                "modified_at_utc": None,
+            }
+
+        stat_result = self._database_path.stat()
+        return {
+            "kind": "file",
+            "path": str(self._database_path),
+            "exists": True,
+            "size_bytes": int(stat_result.st_size),
+            "modified_at_utc": datetime.fromtimestamp(stat_result.st_mtime, tz=UTC).isoformat(),
+        }
+
+    def integrity_check(self, *, mode: str = "quick") -> dict[str, object]:
+        normalized_mode = str(mode).strip().lower()
+        if normalized_mode not in {"quick", "full"}:
+            raise ValueError("Integrity mode must be 'quick' or 'full'")
+
+        pragma = "quick_check" if normalized_mode == "quick" else "integrity_check"
+        started = time.perf_counter()
+        try:
+            rows = self.fetch_all(f"PRAGMA {pragma}")
+            messages = [str(row[0]) for row in rows if row and row[0] is not None]
+            if not messages:
+                messages = ["no result"]
+            ok = len(messages) == 1 and messages[0].lower() == "ok"
+            result = "ok" if ok else "; ".join(messages)
+            return {
+                "ok": ok,
+                "mode": normalized_mode,
+                "result": result,
+                "messages": messages,
+                "duration_ms": int((time.perf_counter() - started) * 1000),
+            }
+        except Exception as exc:
+            return {
+                "ok": False,
+                "mode": normalized_mode,
+                "result": str(exc),
+                "messages": [str(exc)],
+                "duration_ms": int((time.perf_counter() - started) * 1000),
+            }
+
+    def migration_status(self) -> dict[str, object]:
+        rows = self.fetch_all(
+            """SELECT version, name, applied_at
+               FROM schema_migrations
+               ORDER BY version ASC"""
+        )
+        applied = [
+            {
+                "version": int(row["version"]),
+                "name": str(row["name"]),
+                "applied_at": str(row["applied_at"]),
+            }
+            for row in rows
+        ]
+        applied_versions = {item["version"] for item in applied}
+        pending_versions = [version for version, _ in MIGRATIONS if version not in applied_versions]
+        latest_applied_version = max(applied_versions) if applied_versions else None
+        return {
+            "latest_applied_version": latest_applied_version,
+            "applied_count": len(applied),
+            "pending_versions": pending_versions,
+            "last_backup_path": self._last_migration_backup_path,
+            "last_backup_created_at": self._last_migration_backup_created_at,
+            "last_backup_versions": list(self._last_migration_backup_versions),
+            "applied": applied,
+        }
 
     def execute(self, sql: str, *params: object) -> int:
         def _op(conn: sqlite3.Connection) -> int:

--- a/goal_ops_console/routers/system.py
+++ b/goal_ops_console/routers/system.py
@@ -2,7 +2,7 @@ import json
 import platform
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
@@ -141,6 +141,20 @@ def system_readiness(services: AppServices = Depends(get_services)) -> dict:
     return _build_readiness_payload(services)
 
 
+@router.get("/system/database/integrity")
+def database_integrity(
+    mode: Literal["quick", "full"] = "quick",
+    services: AppServices = Depends(get_services),
+) -> dict:
+    check = services.db.integrity_check(mode=mode)
+    return {
+        "timestamp_utc": _utc_iso(),
+        "integrity": check,
+        "file": services.db.database_file_info(),
+        "migrations": services.db.migration_status(),
+    }
+
+
 @router.post("/system/diagnostics")
 def export_system_diagnostics(services: AppServices = Depends(get_services)) -> dict:
     diagnostics_dir = _resolve_diagnostics_dir(services.settings.diagnostics_dir)
@@ -157,6 +171,9 @@ def export_system_diagnostics(services: AppServices = Depends(get_services)) -> 
         "database": {
             "original_url": services.db.original_url,
             "normalized_url": services.db.database_url,
+            "file": services.db.database_file_info(),
+            "integrity": services.db.integrity_check(mode="quick"),
+            "migrations": services.db.migration_status(),
         },
         "readiness": _build_readiness_payload(services),
         "health": _build_health_payload(services),

--- a/goal_ops_console/services.py
+++ b/goal_ops_console/services.py
@@ -32,7 +32,10 @@ class AppServices:
 
 def build_services(settings: Settings | None = None) -> AppServices:
     app_settings = settings or Settings()
-    db = Database(app_settings.database_url)
+    db = Database(
+        app_settings.database_url,
+        migration_backup_dir=app_settings.db_migration_backup_dir,
+    )
     db.initialize()
     observability = ObservabilityService(db)
     event_bus = EventBus(

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -11,7 +11,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from goal_ops_console.config import Settings
-from goal_ops_console.database import new_id, now_utc
+from goal_ops_console.database import Database, new_id, now_utc
 from goal_ops_console.failure_intelligence import compute_error_hash
 from goal_ops_console.main import create_app
 from goal_ops_console.models import OptimisticLockError, RetryBudgetExceeded
@@ -1379,6 +1379,8 @@ def test_63_system_diagnostics_exports_snapshot():
             assert snapshot["readiness"]["ready"] is True
             assert "health" in snapshot
             assert "recent_workflow_runs" in snapshot
+            assert snapshot["database"]["integrity"]["ok"] is True
+            assert snapshot["database"]["migrations"]["pending_versions"] == []
     finally:
         shutil.rmtree(diagnostics_dir, ignore_errors=True)
 
@@ -1419,3 +1421,52 @@ def test_64_workflow_worker_survives_claim_lock_conflict(monkeypatch):
         assert final_run["status"] == "succeeded"
         assert fail_once["remaining"] == 0
         assert catalog.worker_status()["is_running"] is True
+
+
+def test_65_database_creates_backup_before_pending_migration():
+    temp_dir = _local_test_dir("pytest-db-migration-backup")
+    db_path = temp_dir / "goal_ops.db"
+    backup_dir = temp_dir / "migration-backups"
+    try:
+        baseline = Database(str(db_path))
+        try:
+            baseline.initialize()
+        except sqlite3.OperationalError as exc:
+            if "disk i/o error" in str(exc).lower():
+                pytest.skip("File-backed SQLite is unavailable in this sandbox")
+            raise
+        baseline.execute("DELETE FROM schema_migrations WHERE version = 1")
+
+        migrating = Database(str(db_path), migration_backup_dir=str(backup_dir))
+        migrating.initialize()
+
+        migration_state = migrating.migration_status()
+        assert migration_state["pending_versions"] == []
+        assert migration_state["last_backup_versions"] == [1]
+        assert migration_state["last_backup_path"] is not None
+        backup_path = Path(str(migration_state["last_backup_path"]))
+        assert backup_path.exists()
+        assert backup_path.parent == backup_dir
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_66_system_database_integrity_endpoint_reports_status(client):
+    response = client.get("/system/database/integrity")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["integrity"]["ok"] is True
+    assert payload["integrity"]["mode"] == "quick"
+    assert payload["integrity"]["result"] == "ok"
+    assert payload["migrations"]["pending_versions"] == []
+
+    full = client.get("/system/database/integrity?mode=full")
+    assert full.status_code == 200
+    full_payload = full.json()
+    assert full_payload["integrity"]["ok"] is True
+    assert full_payload["integrity"]["mode"] == "full"
+
+
+def test_67_system_database_integrity_rejects_invalid_mode(client):
+    response = client.get("/system/database/integrity?mode=invalid")
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- add migration backup guardrails for pending SQLite schema migrations on file-backed DBs
- add database integrity/file/migration metadata helpers and expose GET /system/database/integrity?mode=quick|full
- enrich diagnostics snapshots with DB integrity + migration context for incident triage
- document new endpoint and backup env var in README + production runbook
- add tests for integrity endpoint and migration backup flow (sandbox-safe skip for file-backed SQLite limitations)

## Validation
- pytest -q (87 passed, 1 skipped)
- python .\\scripts\\desktop-smoke.py