### PR TITLE
Add Windows release gate script and CI guardrail job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  release-gate-windows:
+    name: Release Gate (Windows)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test]"
+
+      - name: Run release gate
+        shell: pwsh
+        run: |
+          .\scripts\release-gate.ps1 -StrictFileDatabaseProbe
+
   test:
     name: Pytest (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -401,6 +401,15 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-tests.ps1
 ```
 
+## Run Release Gate
+
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + migration state):
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\release-gate.ps1 -StrictFileDatabaseProbe
+```
+
 Current result during implementation:
 
 ```text
@@ -430,6 +439,7 @@ Recommended branch protection on `master`:
 5. Enable `Require status checks to pass before merging`.
 6. Select required check: `Pytest (Python 3.11)` and `Pytest (Python 3.12)`.
 7. Select required check: `Desktop Smoke (Windows)`.
+8. Select required check: `Release Gate (Windows)`.
 
 Local desktop smoke command:
 
@@ -570,5 +580,7 @@ If a value is rejected:
 - [manage-desktop-rings.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/manage-desktop-rings.ps1)
 - [reset-db.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/reset-db.ps1)
 - [run-tests.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-tests.ps1)
+- [release-gate.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/release-gate.ps1)
+- [release-gate-probe.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/release-gate-probe.py)
 - [test_goal_ops.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_goal_ops.py)
 - [test_desktop_launcher.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_desktop_launcher.py)

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -9,12 +9,19 @@ This runbook is optimized for reliability-first releases of the desktop app and 
 Run in repo root:
 
 ```powershell
-python -m pytest -q
-python .\scripts\desktop-smoke.py
+.\scripts\release-gate.ps1 -StrictFileDatabaseProbe
 ```
+
+This gate covers:
+- full `pytest` suite
+- desktop smoke boot path
+- `GET /system/readiness`
+- `GET /system/database/integrity?mode=quick|full`
+- schema migration pending-version check (`pending_versions` must be empty)
 
 Verify before release:
 - CI checks green:
+  - `Release Gate (Windows)`
   - `Pytest (Python 3.11)`
   - `Pytest (Python 3.12)`
   - `Desktop Smoke (Windows)`

--- a/scripts/release-gate-probe.py
+++ b/scripts/release-gate-probe.py
@@ -4,8 +4,13 @@ import argparse
 import json
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 from goal_ops_console.config import Settings
 from goal_ops_console.main import create_app

--- a/scripts/release-gate-probe.py
+++ b/scripts/release-gate-probe.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+
+from fastapi.testclient import TestClient
+
+from goal_ops_console.config import Settings
+from goal_ops_console.main import create_app
+
+
+@dataclass(slots=True)
+class ProbeResult:
+    label: str
+    database_url: str
+    database_kind: str
+    readiness_ready: bool
+    integrity_quick_ok: bool
+    integrity_full_ok: bool
+    pending_migrations: list[int]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "label": self.label,
+            "database_url": self.database_url,
+            "database_kind": self.database_kind,
+            "readiness_ready": self.readiness_ready,
+            "integrity_quick_ok": self.integrity_quick_ok,
+            "integrity_full_ok": self.integrity_full_ok,
+            "pending_migrations": list(self.pending_migrations),
+        }
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def run_probe(
+    *,
+    database_url: str,
+    expected_database_kind: str | None,
+    label: str,
+) -> ProbeResult:
+    app = create_app(Settings(database_url=database_url))
+    with TestClient(app) as client:
+        readiness = client.get("/system/readiness")
+        _expect(readiness.status_code == 200, "Readiness endpoint returned non-200 status")
+        readiness_payload = readiness.json()
+        _expect(bool(readiness_payload.get("ready")), f"Readiness failed: {readiness_payload}")
+        _expect(
+            bool(readiness_payload["checks"]["database"]["ok"]),
+            f"Database readiness check failed: {readiness_payload}",
+        )
+        _expect(
+            bool(readiness_payload["checks"]["workflow_worker"]["ok"]),
+            f"Workflow worker readiness check failed: {readiness_payload}",
+        )
+
+        quick = client.get("/system/database/integrity?mode=quick")
+        _expect(quick.status_code == 200, "Quick integrity endpoint returned non-200 status")
+        quick_payload = quick.json()
+        _expect(
+            bool(quick_payload["integrity"]["ok"]),
+            f"Quick integrity check failed: {quick_payload}",
+        )
+
+        full = client.get("/system/database/integrity?mode=full")
+        _expect(full.status_code == 200, "Full integrity endpoint returned non-200 status")
+        full_payload = full.json()
+        _expect(
+            bool(full_payload["integrity"]["ok"]),
+            f"Full integrity check failed: {full_payload}",
+        )
+
+        migrations = full_payload.get("migrations") or {}
+        pending_versions = [int(value) for value in (migrations.get("pending_versions") or [])]
+        _expect(
+            not pending_versions,
+            f"Pending schema migrations detected: {pending_versions}",
+        )
+
+        database_kind = str((full_payload.get("file") or {}).get("kind") or "unknown")
+        if expected_database_kind:
+            _expect(
+                database_kind == expected_database_kind,
+                (
+                    f"Unexpected database kind '{database_kind}', "
+                    f"expected '{expected_database_kind}'"
+                ),
+            )
+
+        return ProbeResult(
+            label=label,
+            database_url=database_url,
+            database_kind=database_kind,
+            readiness_ready=bool(readiness_payload.get("ready")),
+            integrity_quick_ok=bool(quick_payload["integrity"]["ok"]),
+            integrity_full_ok=bool(full_payload["integrity"]["ok"]),
+            pending_migrations=pending_versions,
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Release-gate probe for readiness, integrity, and schema migration state."
+    )
+    parser.add_argument("--database-url", default=":memory:")
+    parser.add_argument("--label", default="probe")
+    parser.add_argument(
+        "--expected-db-kind",
+        choices=("memory", "file"),
+        default=None,
+    )
+    args = parser.parse_args()
+
+    try:
+        result = run_probe(
+            database_url=str(args.database_url),
+            expected_database_kind=args.expected_db_kind,
+            label=str(args.label),
+        )
+    except Exception as exc:
+        print(f"[release-gate-probe] ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result.to_dict(), ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -1,0 +1,95 @@
+param(
+    [string]$PythonExe = "python",
+    [switch]$SkipPytest,
+    [switch]$SkipDesktopSmoke,
+    [switch]$SkipApiProbe,
+    [switch]$SkipFileDatabaseProbe,
+    [switch]$StrictFileDatabaseProbe
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+function Invoke-NativeCommand {
+    param(
+        [string]$Executable,
+        [string[]]$Arguments
+    )
+
+    & $Executable @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw (
+            "Command failed with exit code {0}: {1} {2}" -f
+            $LASTEXITCODE, $Executable, ($Arguments -join ' ')
+        )
+    }
+}
+
+function Invoke-GateStep {
+    param(
+        [string]$Name,
+        [scriptblock]$Action
+    )
+
+    $startedAt = Get-Date
+    Write-Host "==> $Name" -ForegroundColor Cyan
+    & $Action
+    $duration = [int]((Get-Date) - $startedAt).TotalSeconds
+    Write-Host "<== $Name passed (${duration}s)" -ForegroundColor Green
+}
+
+if (-not $SkipPytest) {
+    Invoke-GateStep -Name "Pytest suite" -Action {
+        Invoke-NativeCommand -Executable $PythonExe -Arguments @("-m", "pytest", "-q")
+    }
+}
+
+if (-not $SkipDesktopSmoke) {
+    Invoke-GateStep -Name "Desktop smoke" -Action {
+        Invoke-NativeCommand -Executable $PythonExe -Arguments @(".\scripts\desktop-smoke.py")
+    }
+}
+
+if (-not $SkipApiProbe) {
+    Invoke-GateStep -Name "API probe (:memory:)" -Action {
+        Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+            ".\scripts\release-gate-probe.py",
+            "--label", "memory",
+            "--database-url", ":memory:",
+            "--expected-db-kind", "memory"
+        )
+    }
+}
+
+if (-not $SkipFileDatabaseProbe) {
+    Invoke-GateStep -Name "API probe (file-backed DB)" -Action {
+        $probeDir = Join-Path $ProjectRoot ".tmp\release-gate"
+        New-Item -ItemType Directory -Force -Path $probeDir | Out-Null
+
+        $dbName = "release-gate-{0}-{1}.db" -f (
+            (Get-Date).ToUniversalTime().ToString("yyyyMMddTHHmmssZ")
+        ), ([guid]::NewGuid().ToString("N").Substring(0, 8))
+        $dbPath = Join-Path $probeDir $dbName
+
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\release-gate-probe.py",
+                "--label", "file-backed",
+                "--database-url", $dbPath,
+                "--expected-db-kind", "file"
+            )
+        } catch {
+            if ($StrictFileDatabaseProbe) {
+                throw
+            }
+            Write-Warning (
+                "File-backed DB probe failed but StrictFileDatabaseProbe is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+Write-Host "Release gate passed." -ForegroundColor Green

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import subprocess
 import shutil
+import sys
 import threading
 import time
 from pathlib import Path
@@ -1470,3 +1472,31 @@ def test_66_system_database_integrity_endpoint_reports_status(client):
 def test_67_system_database_integrity_rejects_invalid_mode(client):
     response = client.get("/system/database/integrity?mode=invalid")
     assert response.status_code == 422
+
+
+def test_68_release_gate_probe_reports_memory_database():
+    project_root = Path(__file__).resolve().parents[1]
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "release-gate-probe.py"),
+        "--database-url",
+        ":memory:",
+        "--expected-db-kind",
+        "memory",
+        "--label",
+        "pytest-memory",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    assert payload["database_kind"] == "memory"
+    assert payload["readiness_ready"] is True
+    assert payload["integrity_quick_ok"] is True
+    assert payload["integrity_full_ok"] is True
+    assert payload["pending_migrations"] == []


### PR DESCRIPTION
﻿## Summary
- add `scripts/release-gate.ps1` to enforce a reliability-first pre-release gate (pytest + desktop smoke + readiness + DB integrity + migration pending check)
- add `scripts/release-gate-probe.py` for API-level readiness/integrity/migration assertions (memory + file-backed DB modes)
- add a new `Release Gate (Windows)` job in `.github/workflows/ci.yml` that runs the gate with strict file-backed DB probing
- update README and production runbook with the new release-gate command and check expectations
- add test coverage for release-gate probe script output in `tests/test_goal_ops.py`

## Validation
- `python -m pytest -q` -> 88 passed, 1 skipped
- `powershell -ExecutionPolicy Bypass -File .\\scripts\\release-gate.ps1` -> passed locally (file-backed probe warned in this sandboxed environment)
- `python .\\scripts\\release-gate-probe.py --database-url :memory: --expected-db-kind memory --label local-memory`
