### PR TITLE
Add SLO endpoint and automated alert check guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Observability endpoints:
 
 - `GET /system/metrics`
 - `GET /system/audit`
+- `GET /system/slo`
 - `GET /system/database/integrity?mode=quick|full`
 - `GET /system/faults`
 - `GET /system/faults/summary`
@@ -403,7 +404,7 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + migration state + backup/restore drill):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + migration state + backup/restore drill):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
@@ -415,6 +416,13 @@ Standalone backup/restore drill:
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-backup-restore-drill.ps1
+```
+
+Standalone SLO alert check:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-slo-alert-check.ps1 -AllowedStatus ok
 ```
 
 Current result during implementation:
@@ -589,6 +597,8 @@ If a value is rejected:
 - [run-tests.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-tests.ps1)
 - [release-gate.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/release-gate.ps1)
 - [release-gate-probe.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/release-gate-probe.py)
+- [slo-alert-check.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/slo-alert-check.py)
+- [run-slo-alert-check.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-slo-alert-check.ps1)
 - [backup-restore-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/backup-restore-drill.py)
 - [run-backup-restore-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-backup-restore-drill.ps1)
 - [test_goal_ops.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_goal_ops.py)

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -16,6 +16,7 @@ This gate covers:
 - full `pytest` suite
 - desktop smoke boot path
 - `GET /system/readiness`
+- `GET /system/slo` (`status` must be `ok`)
 - `GET /system/database/integrity?mode=quick|full`
 - schema migration pending-version check (`pending_versions` must be empty)
 - backup/restore drill with row-count and integrity verification on restored DB
@@ -70,6 +71,7 @@ GitHub Actions `Desktop Build` publishes release assets on tag pushes.
 After release is live:
 - Launch desktop binary on a clean Windows machine.
 - Confirm `GET /system/readiness` returns `{"ready": true, ...}`.
+- Confirm `GET /system/slo` returns `"status": "ok"`.
 - Confirm `GET /system/database/integrity?mode=quick` returns `"ok": true`.
 - Trigger `Export Diagnostics` once from Operator Controls and confirm snapshot file exists.
 - Verify one workflow run can be queued and completed from UI.
@@ -149,7 +151,25 @@ Actions:
 3. Temporarily reduce operator-initiated workflow starts.
 4. When stable, run retention cleanup once.
 
-### 3.4 Desktop startup conflicts (single-instance lock)
+### 3.4 SLO alert status degraded or critical
+
+Symptoms:
+- `GET /system/slo` returns `status=degraded` or `status=critical`.
+- alert list contains active SLO violations.
+
+Actions:
+1. Check current SLO payload:
+   ```powershell
+   Invoke-RestMethod http://127.0.0.1:8000/system/slo
+   ```
+2. Run operator gate check against live service:
+   ```powershell
+   .\scripts\run-slo-alert-check.ps1 -BaseUrl "http://127.0.0.1:8000" -AllowedStatus degraded
+   ```
+3. If status is `critical`, treat as release blocker or trigger rollback.
+4. Export diagnostics snapshot and attach to incident ticket.
+
+### 3.5 Desktop startup conflicts (single-instance lock)
 
 Symptoms:
 - error: another desktop instance is already running.
@@ -159,7 +179,7 @@ Actions:
 2. Retry launch once (stale lock auto-recovery is enabled).
 3. If still blocked, collect crash/diagnostics and escalate.
 
-### 3.5 Crash-loop protection triggered
+### 3.6 Crash-loop protection triggered
 
 Symptoms:
 - launcher exits with crash-loop protection message.
@@ -174,7 +194,7 @@ Actions:
    ```
 4. If crash reproduces, stop and roll back ring immediately.
 
-### 3.6 Crash reports
+### 3.7 Crash reports
 
 Location:
 - default: `%USERPROFILE%\.goal_ops_console\diagnostics`

--- a/goal_ops_console/config.py
+++ b/goal_ops_console/config.py
@@ -1,7 +1,27 @@
 import os
 from dataclasses import dataclass
 
-SPEC_VERSION = "1.4.5"
+SPEC_VERSION = "1.4.6"
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
 
 # Skill Selection
 MIN_RUNS = 5
@@ -56,6 +76,18 @@ WORKFLOW_WORKER_POLL_INTERVAL_SECONDS = 0.5
 DIAGNOSTICS_DIR = os.getenv("GOAL_OPS_DIAGNOSTICS_DIR", "")
 DB_MIGRATION_BACKUP_DIR = os.getenv("GOAL_OPS_DB_MIGRATION_BACKUP_DIR", "")
 
+# SLO / Alerting
+SLO_MIN_HTTP_REQUEST_SAMPLE = _env_int("GOAL_OPS_SLO_MIN_HTTP_REQUEST_SAMPLE", 20)
+SLO_MIN_EVENT_ATTEMPT_SAMPLE = _env_int("GOAL_OPS_SLO_MIN_EVENT_ATTEMPT_SAMPLE", 20)
+SLO_MIN_HTTP_SUCCESS_RATE_PERCENT = _env_float("GOAL_OPS_SLO_MIN_HTTP_SUCCESS_RATE_PERCENT", 99.0)
+SLO_MAX_HTTP_429_RATE_PERCENT = _env_float("GOAL_OPS_SLO_MAX_HTTP_429_RATE_PERCENT", 5.0)
+SLO_MAX_EVENT_FAILURE_RATE_PERCENT = _env_float("GOAL_OPS_SLO_MAX_EVENT_FAILURE_RATE_PERCENT", 5.0)
+SLO_MAX_BACKLOG_UTILIZATION_PERCENT = _env_float(
+    "GOAL_OPS_SLO_MAX_BACKLOG_UTILIZATION_PERCENT",
+    90.0,
+)
+SLO_MAX_STUCK_EVENTS = _env_int("GOAL_OPS_SLO_MAX_STUCK_EVENTS", 0)
+
 # The sandbox in this workspace rejects file-backed SQLite locks, so the
 # persistent `goal_ops.db` path should be supplied via GOAL_OPS_DATABASE_URL.
 DEFAULT_DATABASE_URL = os.getenv("GOAL_OPS_DATABASE_URL", ":memory:")
@@ -86,3 +118,10 @@ class Settings:
     workflow_worker_poll_interval_seconds: float = WORKFLOW_WORKER_POLL_INTERVAL_SECONDS
     diagnostics_dir: str = DIAGNOSTICS_DIR
     db_migration_backup_dir: str = DB_MIGRATION_BACKUP_DIR
+    slo_min_http_request_sample: int = SLO_MIN_HTTP_REQUEST_SAMPLE
+    slo_min_event_attempt_sample: int = SLO_MIN_EVENT_ATTEMPT_SAMPLE
+    slo_min_http_success_rate_percent: float = SLO_MIN_HTTP_SUCCESS_RATE_PERCENT
+    slo_max_http_429_rate_percent: float = SLO_MAX_HTTP_429_RATE_PERCENT
+    slo_max_event_failure_rate_percent: float = SLO_MAX_EVENT_FAILURE_RATE_PERCENT
+    slo_max_backlog_utilization_percent: float = SLO_MAX_BACKLOG_UTILIZATION_PERCENT
+    slo_max_stuck_events: int = SLO_MAX_STUCK_EVENTS

--- a/goal_ops_console/routers/system.py
+++ b/goal_ops_console/routers/system.py
@@ -93,6 +93,195 @@ def _build_readiness_payload(services: AppServices) -> dict[str, Any]:
     }
 
 
+def _metric_counter_value(services: AppServices, metric_name: str) -> int:
+    value = services.db.fetch_scalar(
+        "SELECT value FROM metrics_counters WHERE metric_name = ?",
+        metric_name,
+    )
+    return int(value or 0)
+
+
+def _status_from_alerts(alerts: list[dict[str, Any]]) -> str:
+    if any(alert["severity"] == "critical" for alert in alerts):
+        return "critical"
+    if any(alert["severity"] == "warning" for alert in alerts):
+        return "degraded"
+    return "ok"
+
+
+def _build_slo_payload(services: AppServices) -> dict[str, Any]:
+    readiness = _build_readiness_payload(services)
+    db_integrity = services.db.integrity_check(mode="quick")
+    backpressure = services.event_bus.backpressure_snapshot()
+    stuck_events_count = len(services.event_bus.stuck_events())
+
+    http_total = _metric_counter_value(services, "http.requests.total")
+    http_429 = _metric_counter_value(services, "http.requests.status.429")
+
+    status_rows = services.observability.list_metrics(prefix="http.requests.status.", limit=1000)
+    http_5xx = 0
+    for item in status_rows:
+        metric_name = str(item.get("metric_name") or "")
+        suffix = metric_name.rsplit(".", 1)[-1]
+        if not suffix.isdigit():
+            continue
+        status_code = int(suffix)
+        if 500 <= status_code <= 599:
+            http_5xx += int(item.get("value") or 0)
+
+    events_processed = _metric_counter_value(services, "events.processed")
+    events_failed = _metric_counter_value(services, "events.failed")
+    event_attempts = events_processed + events_failed
+
+    max_pending_events = max(1, int(backpressure.get("max_pending_events") or 1))
+    pending_events = int(backpressure.get("pending_events") or 0)
+    backlog_utilization_percent = (pending_events / max_pending_events) * 100.0
+
+    http_success_rate_percent: float | None = None
+    http_429_rate_percent: float | None = None
+    if http_total > 0:
+        http_success_rate_percent = ((http_total - http_5xx) / http_total) * 100.0
+        http_429_rate_percent = (http_429 / http_total) * 100.0
+
+    event_failure_rate_percent: float | None = None
+    if event_attempts > 0:
+        event_failure_rate_percent = (events_failed / event_attempts) * 100.0
+
+    thresholds = {
+        "min_http_request_sample": int(services.settings.slo_min_http_request_sample),
+        "min_http_success_rate_percent": float(services.settings.slo_min_http_success_rate_percent),
+        "max_http_429_rate_percent": float(services.settings.slo_max_http_429_rate_percent),
+        "min_event_attempt_sample": int(services.settings.slo_min_event_attempt_sample),
+        "max_event_failure_rate_percent": float(services.settings.slo_max_event_failure_rate_percent),
+        "max_backlog_utilization_percent": float(services.settings.slo_max_backlog_utilization_percent),
+        "max_stuck_events": int(services.settings.slo_max_stuck_events),
+    }
+
+    alerts: list[dict[str, Any]] = []
+
+    def add_alert(
+        code: str,
+        severity: Literal["warning", "critical"],
+        message: str,
+        *,
+        observed: Any = None,
+        threshold: Any = None,
+    ) -> None:
+        alerts.append(
+            {
+                "code": code,
+                "severity": severity,
+                "message": message,
+                "observed": observed,
+                "threshold": threshold,
+            }
+        )
+
+    if not readiness["ready"]:
+        add_alert(
+            "readiness.not_ready",
+            "critical",
+            "System readiness is false.",
+            observed=readiness,
+            threshold=True,
+        )
+
+    if not bool(db_integrity.get("ok")):
+        add_alert(
+            "database.integrity.failed",
+            "critical",
+            "Database quick integrity check failed.",
+            observed=db_integrity.get("result"),
+            threshold="ok",
+        )
+
+    if backlog_utilization_percent >= thresholds["max_backlog_utilization_percent"]:
+        severity: Literal["warning", "critical"] = (
+            "critical" if bool(backpressure.get("is_throttled")) else "warning"
+        )
+        add_alert(
+            "backpressure.utilization_high",
+            severity,
+            "Event backlog utilization exceeds configured threshold.",
+            observed=round(backlog_utilization_percent, 3),
+            threshold=thresholds["max_backlog_utilization_percent"],
+        )
+
+    if stuck_events_count > thresholds["max_stuck_events"]:
+        add_alert(
+            "events.stuck_processing",
+            "warning",
+            "Stuck processing events exceed configured threshold.",
+            observed=stuck_events_count,
+            threshold=thresholds["max_stuck_events"],
+        )
+
+    if http_total >= thresholds["min_http_request_sample"]:
+        if (
+            http_success_rate_percent is not None
+            and http_success_rate_percent < thresholds["min_http_success_rate_percent"]
+        ):
+            add_alert(
+                "http.success_rate_low",
+                "critical",
+                "HTTP success rate is below SLO.",
+                observed=round(http_success_rate_percent, 3),
+                threshold=thresholds["min_http_success_rate_percent"],
+            )
+        if (
+            http_429_rate_percent is not None
+            and http_429_rate_percent > thresholds["max_http_429_rate_percent"]
+        ):
+            add_alert(
+                "http.429_rate_high",
+                "warning",
+                "HTTP 429 rate exceeds configured threshold.",
+                observed=round(http_429_rate_percent, 3),
+                threshold=thresholds["max_http_429_rate_percent"],
+            )
+
+    if event_attempts >= thresholds["min_event_attempt_sample"]:
+        if (
+            event_failure_rate_percent is not None
+            and event_failure_rate_percent > thresholds["max_event_failure_rate_percent"]
+        ):
+            add_alert(
+                "events.failure_rate_high",
+                "warning",
+                "Event processing failure rate exceeds configured threshold.",
+                observed=round(event_failure_rate_percent, 3),
+                threshold=thresholds["max_event_failure_rate_percent"],
+            )
+
+    status = _status_from_alerts(alerts)
+    indicators = {
+        "http_total_requests": http_total,
+        "http_5xx_requests": http_5xx,
+        "http_429_requests": http_429,
+        "http_success_rate_percent": http_success_rate_percent,
+        "http_429_rate_percent": http_429_rate_percent,
+        "event_attempts": event_attempts,
+        "event_failed": events_failed,
+        "event_failure_rate_percent": event_failure_rate_percent,
+        "backlog_utilization_percent": backlog_utilization_percent,
+        "stuck_events_count": stuck_events_count,
+    }
+    return {
+        "timestamp_utc": _utc_iso(),
+        "spec_version": SPEC_VERSION,
+        "status": status,
+        "alert_count": len(alerts),
+        "alerts": alerts,
+        "thresholds": thresholds,
+        "indicators": indicators,
+        "checks": {
+            "readiness": readiness,
+            "database_integrity": db_integrity,
+            "backpressure": backpressure,
+        },
+    }
+
+
 def _resolve_diagnostics_dir(configured_path: str) -> Path:
     normalized = configured_path.strip()
     if normalized:
@@ -141,6 +330,11 @@ def system_readiness(services: AppServices = Depends(get_services)) -> dict:
     return _build_readiness_payload(services)
 
 
+@router.get("/system/slo")
+def system_slo(services: AppServices = Depends(get_services)) -> dict:
+    return _build_slo_payload(services)
+
+
 @router.get("/system/database/integrity")
 def database_integrity(
     mode: Literal["quick", "full"] = "quick",
@@ -176,6 +370,7 @@ def export_system_diagnostics(services: AppServices = Depends(get_services)) -> 
             "migrations": services.db.migration_status(),
         },
         "readiness": _build_readiness_payload(services),
+        "slo": _build_slo_payload(services),
         "health": _build_health_payload(services),
         "queue": _queue_snapshot(services, limit=200),
         "recent_workflow_runs": services.workflow_catalog.list_runs(limit=50),

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -3,6 +3,7 @@ param(
     [switch]$SkipPytest,
     [switch]$SkipDesktopSmoke,
     [switch]$SkipApiProbe,
+    [switch]$SkipSloAlertCheck,
     [switch]$SkipFileDatabaseProbe,
     [switch]$StrictFileDatabaseProbe,
     [switch]$SkipBackupRestoreDrill,
@@ -61,6 +62,16 @@ if (-not $SkipApiProbe) {
             "--label", "memory",
             "--database-url", ":memory:",
             "--expected-db-kind", "memory"
+        )
+    }
+}
+
+if (-not $SkipSloAlertCheck) {
+    Invoke-GateStep -Name "SLO alert check (:memory:)" -Action {
+        Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+            ".\scripts\slo-alert-check.py",
+            "--database-url", ":memory:",
+            "--allowed-status", "ok"
         )
     }
 }

--- a/scripts/run-slo-alert-check.ps1
+++ b/scripts/run-slo-alert-check.ps1
@@ -1,0 +1,29 @@
+param(
+    [string]$PythonExe = "python",
+    [string]$DatabaseUrl = ":memory:",
+    [ValidateSet("ok", "degraded", "critical")]
+    [string]$AllowedStatus = "ok",
+    [string]$BaseUrl = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$args = @(
+    ".\\scripts\\slo-alert-check.py",
+    "--allowed-status", $AllowedStatus
+)
+if (-not [string]::IsNullOrWhiteSpace($BaseUrl)) {
+    $args += @("--base-url", $BaseUrl)
+} else {
+    $args += @("--database-url", $DatabaseUrl)
+}
+
+& $PythonExe @args
+if ($LASTEXITCODE -ne 0) {
+    throw "SLO alert check failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "SLO alert check passed." -ForegroundColor Green

--- a/scripts/slo-alert-check.py
+++ b/scripts/slo-alert-check.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from goal_ops_console.config import Settings
+from goal_ops_console.main import create_app
+
+STATUS_RANK = {"ok": 0, "degraded": 1, "critical": 2}
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _fetch_slo_from_local_app(database_url: str) -> dict[str, Any]:
+    app = create_app(Settings(database_url=database_url))
+    with TestClient(app) as client:
+        response = client.get("/system/slo")
+        _expect(response.status_code == 200, "Local /system/slo returned non-200 status")
+        payload = response.json()
+    _expect(isinstance(payload, dict), "Local /system/slo payload is not a JSON object")
+    return payload
+
+
+def _fetch_slo_from_url(base_url: str) -> dict[str, Any]:
+    normalized = base_url.strip().rstrip("/")
+    parsed = urlparse(normalized)
+    _expect(bool(parsed.scheme and parsed.netloc), f"Invalid base URL: {base_url}")
+    target = f"{normalized}/system/slo"
+    with urllib.request.urlopen(target, timeout=10) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    _expect(isinstance(payload, dict), "Remote /system/slo payload is not a JSON object")
+    return payload
+
+
+def _validate_status(payload: dict[str, Any], allowed_status: str) -> dict[str, Any]:
+    observed_status = str(payload.get("status") or "").lower()
+    _expect(observed_status in STATUS_RANK, f"Unknown SLO status: {observed_status!r}")
+    _expect(allowed_status in STATUS_RANK, f"Unknown allowed status: {allowed_status!r}")
+    _expect(
+        STATUS_RANK[observed_status] <= STATUS_RANK[allowed_status],
+        (
+            f"SLO status '{observed_status}' exceeds allowed status '{allowed_status}'. "
+            f"alerts={payload.get('alerts')}"
+        ),
+    )
+    return {
+        "observed_status": observed_status,
+        "allowed_status": allowed_status,
+        "alert_count": int(payload.get("alert_count") or 0),
+        "alerts": payload.get("alerts") or [],
+        "timestamp_utc": payload.get("timestamp_utc"),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check /system/slo and fail when status exceeds allowed severity."
+    )
+    parser.add_argument("--database-url", default=":memory:")
+    parser.add_argument("--base-url", default="")
+    parser.add_argument(
+        "--allowed-status",
+        choices=("ok", "degraded", "critical"),
+        default="ok",
+    )
+    args = parser.parse_args()
+
+    database_url = str(args.database_url)
+    base_url = str(args.base_url).strip()
+    if base_url and database_url and database_url != ":memory:":
+        print(
+            "[slo-alert-check] ERROR: Use either --base-url or --database-url, not both custom values.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        if base_url:
+            payload = _fetch_slo_from_url(base_url)
+            source = {"mode": "http", "base_url": base_url}
+        else:
+            payload = _fetch_slo_from_local_app(database_url)
+            source = {"mode": "local", "database_url": database_url}
+        summary = _validate_status(payload, allowed_status=str(args.allowed_status))
+    except Exception as exc:
+        print(f"[slo-alert-check] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    output = {
+        **summary,
+        "source": source,
+        "slo": payload,
+    }
+    print(json.dumps(output, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1379,6 +1379,7 @@ def test_63_system_diagnostics_exports_snapshot():
 
             snapshot = json.loads(file_path.read_text(encoding="utf-8"))
             assert snapshot["readiness"]["ready"] is True
+            assert snapshot["slo"]["status"] == "ok"
             assert "health" in snapshot
             assert "recent_workflow_runs" in snapshot
             assert snapshot["database"]["integrity"]["ok"] is True
@@ -1532,3 +1533,59 @@ def test_69_backup_restore_drill_reports_success():
     assert payload["restored_integrity"]["full_ok"] is True
     assert payload["seed_validation"]["ok"] is True
     shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_70_system_slo_reports_ok_by_default(client):
+    response = client.get("/system/slo")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["alert_count"] == 0
+    assert payload["checks"]["readiness"]["ready"] is True
+    assert payload["checks"]["database_integrity"]["ok"] is True
+
+
+def test_71_system_slo_reports_degraded_when_429_rate_exceeds_threshold(client):
+    services = client.app.state.services
+    services.observability.increment_metric("http.requests.total", delta=200)
+    services.observability.increment_metric("http.requests.status.429", delta=20)
+
+    response = client.get("/system/slo")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "degraded"
+    assert any(alert["code"] == "http.429_rate_high" for alert in payload["alerts"])
+
+
+def test_72_system_slo_reports_critical_when_readiness_fails():
+    app = create_app(Settings(database_url=":memory:"))
+    with TestClient(app) as local_client:
+        local_client.app.state.services.workflow_catalog.stop_worker()
+        response = local_client.get("/system/slo")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["status"] == "critical"
+        assert any(alert["code"] == "readiness.not_ready" for alert in payload["alerts"])
+
+
+def test_73_slo_alert_check_reports_ok_memory():
+    project_root = Path(__file__).resolve().parents[1]
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "slo-alert-check.py"),
+        "--database-url",
+        ":memory:",
+        "--allowed-status",
+        "ok",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    assert payload["observed_status"] == "ok"
+    assert payload["allowed_status"] == "ok"


### PR DESCRIPTION
﻿## Summary
- add SLO status/alert endpoint `GET /system/slo` with rule-based severity (`ok`, `degraded`, `critical`)
- evaluate alerts from readiness, DB integrity, backlog utilization, stuck events, HTTP success/429 rates, and event failure rate
- include SLO payload in diagnostics snapshots to improve incident triage context
- add SLO configuration thresholds in `Settings` (env-overridable)
- add `scripts/slo-alert-check.py` + `scripts/run-slo-alert-check.ps1` for automated SLO guard checks
- extend `scripts/release-gate.ps1` with a strict SLO alert check step
- add tests for `/system/slo` default/degraded/critical behavior and SLO check script execution
- update README and production runbook with SLO endpoint/check usage

## Validation
- `python -m pytest -q` -> 92 passed, 2 skipped
- `python -m pytest -q tests/test_goal_ops.py::test_63_system_diagnostics_exports_snapshot tests/test_goal_ops.py::test_70_system_slo_reports_ok_by_default tests/test_goal_ops.py::test_71_system_slo_reports_degraded_when_429_rate_exceeds_threshold tests/test_goal_ops.py::test_72_system_slo_reports_critical_when_readiness_fails tests/test_goal_ops.py::test_73_slo_alert_check_reports_ok_memory` -> 5 passed
- `powershell -ExecutionPolicy Bypass -File .\\scripts\\run-slo-alert-check.ps1 -AllowedStatus ok` -> passed
- `powershell -ExecutionPolicy Bypass -File .\\scripts\\release-gate.ps1 -SkipPytest` -> passed locally (file-backed probes can warn in this sandbox)
