### PR TITLE
P1: Harden Desktop Update Safety (hash/signature + fallback)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run release gate
         shell: pwsh
         run: |
-          .\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+          .\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 
   test:
     name: Pytest (Python ${{ matrix.python-version }})

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Output paths:
 Distribution bundle outputs (via `package-desktop-release.ps1`):
 - `GoalOpsConsole-onedir-<version>.zip`
 - `GoalOpsConsole-onefile-<version>.exe`
+- `GoalOpsConsole-update-helper-<version>.ps1` (hash/signature/fallback installer helper)
 - `GoalOpsConsole-install-<version>.ps1` (portable installer script)
 - `desktop-update-manifest.json` (auto-update feed preparation)
 - `desktop-rings.json` (ring targets + rollback pointer metadata)
@@ -212,6 +213,7 @@ Triggers:
 Published artifacts:
 - `GoalOpsConsole-onedir-<version>.zip` (if `onedir` was built)
 - `GoalOpsConsole-onefile-<version>.exe` (if `onefile` was built)
+- `GoalOpsConsole-update-helper-<version>.ps1` (if `onefile` was built)
 - `GoalOpsConsole-install-<version>.ps1` (if `onefile` was built)
 - `desktop-update-manifest.json` (version/channel + artifact hashes)
 - `SHA256SUMS.txt` (checksums for uploaded files)
@@ -404,11 +406,11 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + auto-rollback-policy drill + migration state + migration rehearsal on S/M/L DB copies + backup/restore drill + incident/rollback drill under burst load):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + auto-rollback-policy drill + desktop-update-safety drill + migration state + migration rehearsal on S/M/L DB copies + backup/restore drill + incident/rollback drill under burst load):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+.\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 ```
 
 Standalone backup/restore drill:
@@ -430,6 +432,13 @@ Standalone auto-rollback policy check (live service):
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-auto-rollback-policy.ps1 -BaseUrl "http://127.0.0.1:8000" -ManifestPath ".\artifacts\desktop-rings.json" -CriticalWindowSeconds 300 -PollIntervalSeconds 30 -MaxObservationSeconds 900
+```
+
+Standalone desktop-update safety drill:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-desktop-update-safety-drill.ps1
 ```
 
 Standalone SLO alert check:
@@ -613,6 +622,7 @@ If a value is rejected:
 - [start-desktop.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/start-desktop.ps1)
 - [build-desktop.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/build-desktop.ps1)
 - [package-desktop-release.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/package-desktop-release.ps1)
+- [install-desktop-update.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/install-desktop-update.ps1)
 - [manage-desktop-rings.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/manage-desktop-rings.ps1)
 - [reset-db.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/reset-db.ps1)
 - [run-tests.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-tests.ps1)
@@ -622,6 +632,8 @@ If a value is rejected:
 - [run-slo-alert-check.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-slo-alert-check.ps1)
 - [auto-rollback-policy.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/auto-rollback-policy.py)
 - [run-auto-rollback-policy.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-auto-rollback-policy.ps1)
+- [desktop-update-safety-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/desktop-update-safety-drill.py)
+- [run-desktop-update-safety-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-desktop-update-safety-drill.ps1)
 - [migration-rehearsal.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/migration-rehearsal.py)
 - [run-migration-rehearsal.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-migration-rehearsal.ps1)
 - [backup-restore-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/backup-restore-drill.py)

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -9,7 +9,7 @@ This runbook is optimized for reliability-first releases of the desktop app and 
 Run in repo root:
 
 ```powershell
-.\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+.\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 ```
 
 This gate covers:
@@ -18,6 +18,7 @@ This gate covers:
 - `GET /system/readiness`
 - `GET /system/slo` (`status` must be `ok`)
 - auto-rollback-policy drill (`critical` sustained window triggers stable ring rollback path)
+- desktop-update-safety drill (hash validation + rollback-to-stable fallback path)
 - `GET /system/database/integrity?mode=quick|full`
 - schema migration pending-version check (`pending_versions` must be empty)
 - migration rehearsal across small/medium/large DB copies with explicit backup/restore/migration runtime thresholds
@@ -34,6 +35,12 @@ Manual auto-rollback policy invocation (live endpoint, stable ring):
 
 ```powershell
 .\scripts\run-auto-rollback-policy.ps1 -BaseUrl "http://127.0.0.1:8000" -ManifestPath ".\artifacts\desktop-rings.json" -CriticalWindowSeconds 300 -PollIntervalSeconds 30 -MaxObservationSeconds 900
+```
+
+Manual desktop-update safety drill invocation:
+
+```powershell
+.\scripts\run-desktop-update-safety-drill.ps1
 ```
 
 Verify before release:
@@ -56,6 +63,7 @@ Validate artifacts:
 - `artifacts\desktop-rings.json` exists and points `stable` to intended version.
 - `artifacts\SHA256SUMS.txt` exists.
 - `GoalOpsConsole-onefile-<version>.exe` starts and reaches dashboard.
+- `GoalOpsConsole-update-helper-<version>.ps1` exists next to installer script.
 
 ### 1.3 Ring promotion
 
@@ -230,6 +238,31 @@ Required triage fields:
 - `error`
 - `traceback`
 - `context`
+
+### 3.8 Desktop update validation or install failure
+
+Symptoms:
+- installer exits with hash/signature verification failure
+- update copy fails and app version appears unchanged after install attempt
+
+Actions:
+1. Confirm checksum line for onefile artifact:
+   ```powershell
+   Get-Content .\artifacts\SHA256SUMS.txt
+   ```
+2. Re-run installer (it enforces hash validation and restores previous stable executable on failure):
+   ```powershell
+   .\artifacts\GoalOpsConsole-install-<version>.ps1
+   ```
+3. If signature enforcement is required, verify signature explicitly:
+   ```powershell
+   Get-AuthenticodeSignature .\artifacts\GoalOpsConsole-onefile-<version>.exe
+   ```
+4. Run desktop-update safety drill before retrying rollout:
+   ```powershell
+   .\scripts\run-desktop-update-safety-drill.ps1
+   ```
+5. If fallback restore happened, keep stable version active and open an incident with checksum/signature evidence.
 
 ## 4. Operational Defaults
 

--- a/scripts/desktop-update-safety-drill.py
+++ b/scripts/desktop-update-safety-drill.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _powershell_executable() -> str | None:
+    for candidate in ("pwsh", "powershell"):
+        resolved = shutil.which(candidate)
+        if resolved:
+            return resolved
+    return None
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _run_installer(
+    *,
+    source_exe_path: Path,
+    install_dir: Path,
+    expected_sha256: str,
+    report_path: Path,
+    fail_after_copy: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    executable = _powershell_executable()
+    if executable is None:
+        raise RuntimeError(
+            "PowerShell executable not found; cannot run install-desktop-update.ps1 for desktop update safety drill."
+        )
+
+    command = [
+        executable,
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        str(PROJECT_ROOT / "scripts" / "install-desktop-update.ps1"),
+        "-SourceExePath",
+        str(source_exe_path),
+        "-InstallDir",
+        str(install_dir),
+        "-AppName",
+        "GoalOpsConsole",
+        "-ExpectedSha256",
+        expected_sha256,
+        "-SkipShortcuts",
+        "-ReportPath",
+        str(report_path),
+    ]
+    if fail_after_copy:
+        command.append("-FailAfterCopy")
+
+    return subprocess.run(
+        command,
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+
+@dataclass(slots=True)
+class DrillPaths:
+    run_dir: Path
+    install_dir: Path
+    source_good: Path
+    source_tampered: Path
+    source_copy_fail: Path
+    report_success: Path
+    report_hash_mismatch: Path
+    report_copy_fail: Path
+
+
+def _create_paths(workspace_root: Path) -> DrillPaths:
+    run_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+    run_dir = workspace_root / f"desktop-update-safety-{run_id}"
+    return DrillPaths(
+        run_dir=run_dir,
+        install_dir=run_dir / "install",
+        source_good=run_dir / "GoalOpsConsole-good.exe",
+        source_tampered=run_dir / "GoalOpsConsole-tampered.exe",
+        source_copy_fail=run_dir / "GoalOpsConsole-copy-fail.exe",
+        report_success=run_dir / "install-report-success.json",
+        report_hash_mismatch=run_dir / "install-report-hash-mismatch.json",
+        report_copy_fail=run_dir / "install-report-copy-fail.json",
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    _expect(isinstance(payload, dict), f"Expected JSON object at {path}")
+    return payload
+
+
+def run_drill(*, workspace_root: Path, label: str, keep_artifacts: bool) -> dict[str, Any]:
+    started = time.perf_counter()
+    paths = _create_paths(workspace_root)
+    paths.run_dir.mkdir(parents=True, exist_ok=False)
+    paths.install_dir.mkdir(parents=True, exist_ok=True)
+
+    target_exe = paths.install_dir / "GoalOpsConsole.exe"
+    backup_exe = paths.install_dir / "GoalOpsConsole-stable.exe"
+    helper_script = PROJECT_ROOT / "scripts" / "install-desktop-update.ps1"
+    _expect(helper_script.exists(), f"Installer helper script missing: {helper_script}")
+
+    try:
+        initial_stable = b"goal-ops-stable-v1"
+        target_exe.write_bytes(initial_stable)
+
+        paths.source_good.write_bytes(b"goal-ops-update-v2")
+        success_result = _run_installer(
+            source_exe_path=paths.source_good,
+            install_dir=paths.install_dir,
+            expected_sha256=_sha256(paths.source_good),
+            report_path=paths.report_success,
+        )
+        success_report = _read_json(paths.report_success)
+        case_success_ok = (
+            success_result.returncode == 0
+            and target_exe.read_bytes() == paths.source_good.read_bytes()
+            and backup_exe.exists()
+            and backup_exe.read_bytes() == initial_stable
+            and bool(success_report.get("success"))
+            and success_report.get("decision") == "update_installed"
+        )
+        _expect(
+            case_success_ok,
+            (
+                "Successful update case failed. "
+                f"rc={success_result.returncode} stdout={success_result.stdout!r} stderr={success_result.stderr!r} "
+                f"report={json.dumps(success_report, sort_keys=True)}"
+            ),
+        )
+
+        stable_before_hash_failure = b"goal-ops-stable-before-hash-failure"
+        target_exe.write_bytes(stable_before_hash_failure)
+        paths.source_tampered.write_bytes(b"goal-ops-tampered-v3")
+        hash_failure_result = _run_installer(
+            source_exe_path=paths.source_tampered,
+            install_dir=paths.install_dir,
+            expected_sha256=hashlib.sha256(b"expected-but-different").hexdigest(),
+            report_path=paths.report_hash_mismatch,
+        )
+        hash_failure_report = _read_json(paths.report_hash_mismatch)
+        case_hash_failure_ok = (
+            hash_failure_result.returncode != 0
+            and target_exe.read_bytes() == stable_before_hash_failure
+            and hash_failure_report.get("decision") == "update_failed"
+        )
+        _expect(
+            case_hash_failure_ok,
+            (
+                "Hash mismatch protection case failed. "
+                f"rc={hash_failure_result.returncode} stdout={hash_failure_result.stdout!r} "
+                f"stderr={hash_failure_result.stderr!r} report={json.dumps(hash_failure_report, sort_keys=True)}"
+            ),
+        )
+
+        stable_before_copy_failure = b"goal-ops-stable-before-copy-failure"
+        target_exe.write_bytes(stable_before_copy_failure)
+        paths.source_copy_fail.write_bytes(b"goal-ops-update-v4")
+        copy_failure_result = _run_installer(
+            source_exe_path=paths.source_copy_fail,
+            install_dir=paths.install_dir,
+            expected_sha256=_sha256(paths.source_copy_fail),
+            report_path=paths.report_copy_fail,
+            fail_after_copy=True,
+        )
+        copy_failure_report = _read_json(paths.report_copy_fail)
+        case_copy_failure_ok = (
+            copy_failure_result.returncode != 0
+            and target_exe.read_bytes() == stable_before_copy_failure
+            and bool(copy_failure_report.get("fallback", {}).get("restored"))
+            and copy_failure_report.get("decision") == "rollback_to_stable_restored"
+        )
+        _expect(
+            case_copy_failure_ok,
+            (
+                "Fallback after copy failure case failed. "
+                f"rc={copy_failure_result.returncode} stdout={copy_failure_result.stdout!r} "
+                f"stderr={copy_failure_result.stderr!r} report={json.dumps(copy_failure_report, sort_keys=True)}"
+            ),
+        )
+
+        return {
+            "label": label,
+            "success": True,
+            "cases": {
+                "successful_update": {
+                    "ok": True,
+                    "return_code": success_result.returncode,
+                },
+                "tampered_hash_blocked": {
+                    "ok": True,
+                    "return_code": hash_failure_result.returncode,
+                },
+                "fallback_after_copy_failure": {
+                    "ok": True,
+                    "return_code": copy_failure_result.returncode,
+                },
+            },
+            "paths": {
+                "run_dir": str(paths.run_dir),
+                "helper_script": str(helper_script),
+                "report_success": str(paths.report_success),
+                "report_hash_mismatch": str(paths.report_hash_mismatch),
+                "report_copy_fail": str(paths.report_copy_fail),
+            },
+            "duration_ms": int((time.perf_counter() - started) * 1000),
+        }
+    finally:
+        if not keep_artifacts:
+            shutil.rmtree(paths.run_dir, ignore_errors=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run Desktop update safety drill: validate SHA checks, tamper blocking, "
+            "and fallback restore to previous stable executable."
+        )
+    )
+    parser.add_argument("--workspace", default=str(PROJECT_ROOT / ".tmp" / "desktop-update-safety-drills"))
+    parser.add_argument("--label", default="desktop-update-safety-drill")
+    parser.add_argument("--keep-artifacts", action="store_true")
+    args = parser.parse_args(argv)
+
+    workspace_root = Path(str(args.workspace)).expanduser()
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    try:
+        report = run_drill(
+            workspace_root=workspace_root,
+            label=str(args.label),
+            keep_artifacts=bool(args.keep_artifacts),
+        )
+    except Exception as exc:
+        print(f"[desktop-update-safety-drill] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install-desktop-update.ps1
+++ b/scripts/install-desktop-update.ps1
@@ -1,0 +1,220 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$SourceExePath,
+    [string]$InstallDir = "$env:LOCALAPPDATA\GoalOpsConsole",
+    [string]$AppName = "GoalOpsConsole",
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedSha256,
+    [switch]$RequireValidSignature,
+    [switch]$DesktopShortcut,
+    [string]$StartMenuFolderName = "Goal Ops Console",
+    [string]$ShortcutName = "Goal Ops Console",
+    [string]$StableBackupName = "",
+    [switch]$SkipShortcuts,
+    [switch]$FailAfterCopy,
+    [string]$ReportPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+function Normalize-Sha256 {
+    param(
+        [string]$Value
+    )
+
+    $normalized = ([string]$Value).Trim().ToLowerInvariant()
+    if ($normalized -notmatch "^[a-f0-9]{64}$") {
+        throw "ExpectedSha256 must be a 64-character hexadecimal SHA256 hash."
+    }
+    return $normalized
+}
+
+function Get-Sha256 {
+    param(
+        [string]$FilePath
+    )
+
+    return (Get-FileHash -LiteralPath $FilePath -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function Assert-ValidSignature {
+    param(
+        [string]$FilePath
+    )
+
+    $signature = Get-AuthenticodeSignature -LiteralPath $FilePath
+    if ($signature.Status -ne "Valid") {
+        throw "Signature verification failed for '$FilePath'. Status=$($signature.Status). $($signature.StatusMessage)"
+    }
+    return [string]$signature.Status
+}
+
+function Write-InstallReport {
+    param(
+        [string]$PathValue,
+        [hashtable]$Report
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PathValue)) {
+        return
+    }
+    $parent = Split-Path -Parent $PathValue
+    if (-not [string]::IsNullOrWhiteSpace($parent)) {
+        New-Item -ItemType Directory -Force -Path $parent | Out-Null
+    }
+    $Report | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $PathValue -Encoding UTF8
+}
+
+function New-AppShortcut {
+    param(
+        [object]$Shell,
+        [string]$PathValue,
+        [string]$TargetPath,
+        [string]$WorkingDirectory
+    )
+
+    $shortcut = $Shell.CreateShortcut($PathValue)
+    $shortcut.TargetPath = $TargetPath
+    $shortcut.WorkingDirectory = $WorkingDirectory
+    $shortcut.IconLocation = "$TargetPath,0"
+    $shortcut.Save()
+}
+
+$fallbackPrepared = $false
+$resolvedSourcePath = ""
+$stableBackupPath = ""
+$targetExe = ""
+
+$report = [ordered]@{
+    success = $false
+    source_exe = $SourceExePath
+    install_dir = $InstallDir
+    app_name = $AppName
+    expected_sha256 = $null
+    source_sha256 = $null
+    target_sha256 = $null
+    signature_required = [bool]$RequireValidSignature
+    source_signature_status = $null
+    target_signature_status = $null
+    previous_target_found = $false
+    stable_backup_path = $null
+    fallback = [ordered]@{
+        attempted = $false
+        restored = $false
+        error = $null
+    }
+    fail_after_copy = [bool]$FailAfterCopy
+    skip_shortcuts = [bool]$SkipShortcuts
+    target_exe = $null
+    shortcut_startmenu = $null
+    shortcut_desktop = $null
+    decision = "pending"
+    error = $null
+}
+
+try {
+    $resolvedSourcePath = (Resolve-Path -LiteralPath $SourceExePath).Path
+    $report.source_exe = $resolvedSourcePath
+
+    $normalizedExpectedSha = Normalize-Sha256 -Value $ExpectedSha256
+    $report.expected_sha256 = $normalizedExpectedSha
+
+    $sourceSha = Get-Sha256 -FilePath $resolvedSourcePath
+    $report.source_sha256 = $sourceSha
+    if ($sourceSha -ne $normalizedExpectedSha) {
+        throw "Source executable hash mismatch. expected=$normalizedExpectedSha actual=$sourceSha"
+    }
+
+    if ($RequireValidSignature) {
+        $report.source_signature_status = Assert-ValidSignature -FilePath $resolvedSourcePath
+    }
+
+    if ([string]::IsNullOrWhiteSpace($StableBackupName)) {
+        $StableBackupName = "$AppName-stable.exe"
+    }
+
+    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+    $targetExe = Join-Path $InstallDir "$AppName.exe"
+    $stableBackupPath = Join-Path $InstallDir $StableBackupName
+    $report.target_exe = $targetExe
+    $report.stable_backup_path = $stableBackupPath
+
+    if (Test-Path -LiteralPath $targetExe) {
+        $report.previous_target_found = $true
+        Copy-Item -LiteralPath $targetExe -Destination $stableBackupPath -Force
+        $fallbackPrepared = Test-Path -LiteralPath $stableBackupPath
+    }
+
+    Copy-Item -LiteralPath $resolvedSourcePath -Destination $targetExe -Force
+
+    if ($FailAfterCopy) {
+        throw "Injected failure after copy (FailAfterCopy)."
+    }
+
+    $targetSha = Get-Sha256 -FilePath $targetExe
+    $report.target_sha256 = $targetSha
+    if ($targetSha -ne $normalizedExpectedSha) {
+        throw "Installed executable hash mismatch. expected=$normalizedExpectedSha actual=$targetSha"
+    }
+
+    if ($RequireValidSignature) {
+        $report.target_signature_status = Assert-ValidSignature -FilePath $targetExe
+    }
+
+    if (-not $SkipShortcuts) {
+        $programsPath = [Environment]::GetFolderPath("Programs")
+        $shortcutDir = Join-Path $programsPath $StartMenuFolderName
+        New-Item -ItemType Directory -Force -Path $shortcutDir | Out-Null
+        $startMenuShortcutPath = Join-Path $shortcutDir "$ShortcutName.lnk"
+
+        $shell = New-Object -ComObject WScript.Shell
+        New-AppShortcut -Shell $shell -PathValue $startMenuShortcutPath -TargetPath $targetExe -WorkingDirectory $InstallDir
+        $report.shortcut_startmenu = $startMenuShortcutPath
+
+        if ($DesktopShortcut) {
+            $desktopPath = [Environment]::GetFolderPath("Desktop")
+            $desktopShortcutPath = Join-Path $desktopPath "$ShortcutName.lnk"
+            New-AppShortcut -Shell $shell -PathValue $desktopShortcutPath -TargetPath $targetExe -WorkingDirectory $InstallDir
+            $report.shortcut_desktop = $desktopShortcutPath
+        }
+    }
+
+    $report.success = $true
+    $report.decision = "update_installed"
+    Write-InstallReport -PathValue $ReportPath -Report $report
+
+    Write-Host "Installed $AppName to: $targetExe" -ForegroundColor Green
+    if ($report.previous_target_found) {
+        Write-Host "Stable fallback backup: $stableBackupPath" -ForegroundColor Yellow
+    }
+    if (-not $SkipShortcuts) {
+        Write-Host "Start Menu shortcut: $startMenuShortcutPath" -ForegroundColor Green
+    } else {
+        Write-Host "Shortcut creation skipped (-SkipShortcuts)." -ForegroundColor Yellow
+    }
+}
+catch {
+    $report.error = $_.Exception.Message
+    $report.decision = "update_failed"
+
+    if ($fallbackPrepared -and (Test-Path -LiteralPath $stableBackupPath)) {
+        $report.fallback.attempted = $true
+        try {
+            Copy-Item -LiteralPath $stableBackupPath -Destination $targetExe -Force
+            $report.target_sha256 = Get-Sha256 -FilePath $targetExe
+            $report.fallback.restored = $true
+            $report.decision = "rollback_to_stable_restored"
+        }
+        catch {
+            $report.fallback.error = $_.Exception.Message
+            $report.fallback.restored = $false
+        }
+    }
+
+    Write-InstallReport -PathValue $ReportPath -Report $report
+
+    if ($report.fallback.restored) {
+        throw "Desktop update failed, previous stable version restored. Root cause: $($report.error)"
+    }
+    throw
+}

--- a/scripts/package-desktop-release.ps1
+++ b/scripts/package-desktop-release.ps1
@@ -100,7 +100,8 @@ $artifacts = @()
 function Add-ArtifactMetadata {
     param(
         [string]$Kind,
-        [string]$ArtifactPath
+        [string]$ArtifactPath,
+        [bool]$SignatureRequired = $false
     )
 
     $item = Get-Item -LiteralPath $ArtifactPath
@@ -116,6 +117,7 @@ function Add-ArtifactMetadata {
         sha256 = $hash
         size_bytes = [int64]$item.Length
         url = $url
+        signature_required = [bool]$SignatureRequired
     }
 }
 
@@ -130,57 +132,75 @@ if ($includeOneDir) {
 }
 
 $oneFileArtifactName = ""
+$updateHelperArtifactName = ""
 if ($includeOneFile) {
     $oneFileArtifactName = "$Name-onefile-$safeVersion.exe"
     $oneFileArtifactPath = Join-Path $resolvedOutputDir $oneFileArtifactName
     Copy-Item -LiteralPath $oneFileExe -Destination $oneFileArtifactPath -Force
-    Add-ArtifactMetadata -Kind "onefile" -ArtifactPath $oneFileArtifactPath
+    Add-ArtifactMetadata -Kind "onefile" -ArtifactPath $oneFileArtifactPath -SignatureRequired:$Sign
+
+    $updateHelperSource = Join-Path $ProjectRoot "scripts/install-desktop-update.ps1"
+    if (-not (Test-Path -LiteralPath $updateHelperSource)) {
+        throw "Update helper script not found at $updateHelperSource"
+    }
+    $updateHelperArtifactName = "$Name-update-helper-$safeVersion.ps1"
+    $updateHelperArtifactPath = Join-Path $resolvedOutputDir $updateHelperArtifactName
+    Copy-Item -LiteralPath $updateHelperSource -Destination $updateHelperArtifactPath -Force
+    Add-ArtifactMetadata -Kind "update_helper_script" -ArtifactPath $updateHelperArtifactPath
 }
 
 if ($includeOneFile) {
+    $oneFileArtifact = $artifacts | Where-Object { $_.kind -eq "onefile" } | Select-Object -First 1
+    if ($null -eq $oneFileArtifact) {
+        throw "Missing onefile artifact metadata for installer generation."
+    }
+    $oneFileExpectedSha = [string]$oneFileArtifact.sha256
+    $requireValidSignatureLiteral = if ($Sign) { "`$true" } else { "`$false" }
+
     $installerScriptName = "$Name-install-$safeVersion.ps1"
     $installerScriptPath = Join-Path $resolvedOutputDir $installerScriptName
     $installerContent = @"
 param(
     [string]`$InstallDir = "`$env:LOCALAPPDATA\$Name",
-    [switch]`$DesktopShortcut
+    [switch]`$DesktopShortcut,
+    [bool]`$RequireValidSignature = $requireValidSignatureLiteral,
+    [string]`$ExpectedSha256 = "$oneFileExpectedSha",
+    [switch]`$FailAfterCopy
 )
 
 `$ErrorActionPreference = "Stop"
 
 `$SourceExe = Join-Path `$PSScriptRoot "$oneFileArtifactName"
+`$HelperScript = Join-Path `$PSScriptRoot "$updateHelperArtifactName"
 if (-not (Test-Path -LiteralPath `$SourceExe)) {
     throw "Desktop executable not found next to installer script: `$SourceExe"
 }
-
-New-Item -ItemType Directory -Force -Path `$InstallDir | Out-Null
-`$TargetExe = Join-Path `$InstallDir "$Name.exe"
-Copy-Item -LiteralPath `$SourceExe -Destination `$TargetExe -Force
-
-`$ProgramsPath = [Environment]::GetFolderPath("Programs")
-`$ShortcutDir = Join-Path `$ProgramsPath "Goal Ops Console"
-New-Item -ItemType Directory -Force -Path `$ShortcutDir | Out-Null
-`$ShortcutPath = Join-Path `$ShortcutDir "Goal Ops Console.lnk"
-
-`$shell = New-Object -ComObject WScript.Shell
-`$shortcut = `$shell.CreateShortcut(`$ShortcutPath)
-`$shortcut.TargetPath = `$TargetExe
-`$shortcut.WorkingDirectory = `$InstallDir
-`$shortcut.IconLocation = "`$TargetExe,0"
-`$shortcut.Save()
-
-if (`$DesktopShortcut) {
-    `$desktopPath = [Environment]::GetFolderPath("Desktop")
-    `$desktopLinkPath = Join-Path `$desktopPath "Goal Ops Console.lnk"
-    `$desktopLink = `$shell.CreateShortcut(`$desktopLinkPath)
-    `$desktopLink.TargetPath = `$TargetExe
-    `$desktopLink.WorkingDirectory = `$InstallDir
-    `$desktopLink.IconLocation = "`$TargetExe,0"
-    `$desktopLink.Save()
+if (-not (Test-Path -LiteralPath `$HelperScript)) {
+    throw "Update helper script not found next to installer script: `$HelperScript"
 }
 
-Write-Host "Installed Goal Ops Console to: `$TargetExe" -ForegroundColor Green
-Write-Host "Start Menu shortcut: `$ShortcutPath" -ForegroundColor Green
+`$invokeArgs = @(
+    "-SourceExePath", `$SourceExe,
+    "-InstallDir", `$InstallDir,
+    "-AppName", "$Name",
+    "-ExpectedSha256", `$ExpectedSha256
+)
+if (`$DesktopShortcut) {
+    `$invokeArgs += "-DesktopShortcut"
+}
+if (`$RequireValidSignature) {
+    `$invokeArgs += "-RequireValidSignature"
+}
+if (`$FailAfterCopy) {
+    `$invokeArgs += "-FailAfterCopy"
+}
+
+& `$HelperScript @invokeArgs
+if (`$LASTEXITCODE -ne 0) {
+    throw "Desktop update helper failed with exit code `$LASTEXITCODE."
+}
+
+Write-Host "Installer completed with hash/signature validation and fallback protection." -ForegroundColor Green
 "@
     Set-Content -LiteralPath $installerScriptPath -Value $installerContent -Encoding UTF8
     Add-ArtifactMetadata -Kind "installer_script" -ArtifactPath $installerScriptPath

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -8,6 +8,8 @@ param(
     [switch]$StrictFileDatabaseProbe,
     [switch]$SkipAutoRollbackPolicyDrill,
     [switch]$StrictAutoRollbackPolicyDrill,
+    [switch]$SkipDesktopUpdateSafetyDrill,
+    [switch]$StrictDesktopUpdateSafetyDrill,
     [switch]$SkipMigrationRehearsal,
     [switch]$StrictMigrationRehearsal,
     [switch]$SkipBackupRestoreDrill,
@@ -107,6 +109,27 @@ if (-not $SkipAutoRollbackPolicyDrill) {
             }
             Write-Warning (
                 "Auto rollback policy drill failed but StrictAutoRollbackPolicyDrill is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipDesktopUpdateSafetyDrill) {
+    Invoke-GateStep -Name "Desktop update safety drill (hash/signature validation + fallback)" -Action {
+        $workspace = Join-Path $ProjectRoot ".tmp\desktop-update-safety-drills"
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\desktop-update-safety-drill.py",
+                "--workspace", $workspace,
+                "--label", "release-gate"
+            )
+        } catch {
+            if ($StrictDesktopUpdateSafetyDrill) {
+                throw
+            }
+            Write-Warning (
+                "Desktop update safety drill failed but StrictDesktopUpdateSafetyDrill is off. " +
                 "Continuing. Error: $($_.Exception.Message)"
             )
         }

--- a/scripts/run-desktop-update-safety-drill.ps1
+++ b/scripts/run-desktop-update-safety-drill.ps1
@@ -1,0 +1,26 @@
+param(
+    [string]$PythonExe = "python",
+    [string]$WorkspaceDir = ".tmp\\desktop-update-safety-drills",
+    [switch]$KeepArtifacts
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$args = @(
+    ".\\scripts\\desktop-update-safety-drill.py",
+    "--workspace", $WorkspaceDir,
+    "--label", "manual"
+)
+if ($KeepArtifacts) {
+    $args += "--keep-artifacts"
+}
+
+& $PythonExe @args
+if ($LASTEXITCODE -ne 0) {
+    throw "Desktop update safety drill failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Desktop update safety drill passed." -ForegroundColor Green

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1724,3 +1724,34 @@ def test_76_auto_rollback_policy_triggers_and_executes_rollback():
     assert stable_post["version"] == "0.0.1"
     assert stable_post["rollback_version"] == "0.0.2"
     shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_77_desktop_update_safety_drill_reports_success():
+    workspace = _local_test_dir("pytest-desktop-update-safety-drill")
+    project_root = Path(__file__).resolve().parents[1]
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "desktop-update-safety-drill.py"),
+        "--workspace",
+        str(workspace),
+        "--label",
+        "pytest-drill",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0 and "powershell executable not found" in completed.stderr.lower():
+        shutil.rmtree(workspace, ignore_errors=True)
+        pytest.skip("PowerShell is unavailable in this environment")
+    assert completed.returncode == 0, completed.stderr
+
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    assert payload["success"] is True
+    assert payload["cases"]["successful_update"]["ok"] is True
+    assert payload["cases"]["tampered_hash_blocked"]["ok"] is True
+    assert payload["cases"]["fallback_after_copy_failure"]["ok"] is True
+    shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
﻿## Summary
- add hardened desktop update installer helper with SHA256 verification, optional Authenticode validation, and rollback-to-stable fallback
- package onefile releases with versioned update helper and wire installer script to enforce expected hash/signature requirements
- add desktop-update-safety drill (script + wrapper), integrate strict gate switch in release-gate/CI, add pytest coverage, and update runbook/README

## Verification
- python -m pytest -q
- python -m pytest -q tests/test_goal_ops.py -k "test_77_desktop_update_safety_drill_reports_success"
- .\scripts\release-gate.ps1 -SkipPytest -SkipDesktopSmoke -SkipApiProbe -SkipSloAlertCheck -SkipAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -SkipMigrationRehearsal -SkipBackupRestoreDrill -SkipIncidentRollbackDrill -SkipFileDatabaseProbe
- python .\scripts\desktop-update-safety-drill.py --workspace .tmp\desktop-update-safety-local --label local-check
