### PR TITLE
P0: Add hard-abort recovery drill and startup run recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run release gate
         shell: pwsh
         run: |
-          .\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+          .\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 
   test:
     name: Pytest (Python ${{ matrix.python-version }})

--- a/README.md
+++ b/README.md
@@ -406,11 +406,11 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + auto-rollback-policy drill + desktop-update-safety drill + migration state + migration rehearsal on S/M/L DB copies + backup/restore drill + incident/rollback drill under burst load):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + migration state + migration rehearsal on S/M/L DB copies + backup/restore drill + incident/rollback drill under burst load):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+.\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 ```
 
 Standalone backup/restore drill:
@@ -439,6 +439,13 @@ Standalone desktop-update safety drill:
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-desktop-update-safety-drill.ps1
+```
+
+Standalone recovery hard-abort drill:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-recovery-hard-abort-drill.ps1
 ```
 
 Standalone SLO alert check:
@@ -634,6 +641,9 @@ If a value is rejected:
 - [run-auto-rollback-policy.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-auto-rollback-policy.ps1)
 - [desktop-update-safety-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/desktop-update-safety-drill.py)
 - [run-desktop-update-safety-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-desktop-update-safety-drill.ps1)
+- [recovery-hard-abort-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/recovery-hard-abort-drill.py)
+- [recovery-hard-abort-target.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/recovery-hard-abort-target.py)
+- [run-recovery-hard-abort-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-recovery-hard-abort-drill.ps1)
 - [migration-rehearsal.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/migration-rehearsal.py)
 - [run-migration-rehearsal.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-migration-rehearsal.ps1)
 - [backup-restore-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/backup-restore-drill.py)

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -9,7 +9,7 @@ This runbook is optimized for reliability-first releases of the desktop app and 
 Run in repo root:
 
 ```powershell
-.\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+.\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 ```
 
 This gate covers:
@@ -19,6 +19,7 @@ This gate covers:
 - `GET /system/slo` (`status` must be `ok`)
 - auto-rollback-policy drill (`critical` sustained window triggers stable ring rollback path)
 - desktop-update-safety drill (hash validation + rollback-to-stable fallback path)
+- recovery hard-abort drill (kill running worker process, restart, and verify no hanging `running` runs)
 - `GET /system/database/integrity?mode=quick|full`
 - schema migration pending-version check (`pending_versions` must be empty)
 - migration rehearsal across small/medium/large DB copies with explicit backup/restore/migration runtime thresholds
@@ -41,6 +42,12 @@ Manual desktop-update safety drill invocation:
 
 ```powershell
 .\scripts\run-desktop-update-safety-drill.ps1
+```
+
+Manual recovery hard-abort drill invocation:
+
+```powershell
+.\scripts\run-recovery-hard-abort-drill.ps1
 ```
 
 Verify before release:
@@ -263,6 +270,27 @@ Actions:
    .\scripts\run-desktop-update-safety-drill.ps1
    ```
 5. If fallback restore happened, keep stable version active and open an incident with checksum/signature evidence.
+
+### 3.9 Hard process abort / unexpected termination
+
+Symptoms:
+- host process is killed while a workflow run is still `running`
+- after restart, historical runs appear stuck in `running`
+
+Actions:
+1. Verify worker recovery on restart:
+   ```powershell
+   Invoke-RestMethod http://127.0.0.1:8000/system/readiness
+   ```
+2. Confirm no hanging runs remain:
+   ```powershell
+   Invoke-RestMethod http://127.0.0.1:8000/workflows/runs
+   ```
+3. Run deterministic hard-abort recovery drill:
+   ```powershell
+   .\scripts\run-recovery-hard-abort-drill.ps1
+   ```
+4. If drill fails, block rollout and escalate with drill JSON output + diagnostics snapshot.
 
 ## 4. Operational Defaults
 

--- a/goal_ops_console/config.py
+++ b/goal_ops_console/config.py
@@ -73,6 +73,10 @@ FAILURE_LOG_RETENTION_DAYS = 90
 WORKFLOW_RUN_TIMEOUT_SECONDS = 300
 WORKFLOW_REAPER_BATCH_SIZE = 200
 WORKFLOW_WORKER_POLL_INTERVAL_SECONDS = 0.5
+WORKFLOW_STARTUP_RECOVERY_MAX_AGE_SECONDS = _env_int(
+    "GOAL_OPS_WORKFLOW_STARTUP_RECOVERY_MAX_AGE_SECONDS",
+    0,
+)
 DIAGNOSTICS_DIR = os.getenv("GOAL_OPS_DIAGNOSTICS_DIR", "")
 DB_MIGRATION_BACKUP_DIR = os.getenv("GOAL_OPS_DB_MIGRATION_BACKUP_DIR", "")
 
@@ -116,6 +120,7 @@ class Settings:
     workflow_run_timeout_seconds: int = WORKFLOW_RUN_TIMEOUT_SECONDS
     workflow_reaper_batch_size: int = WORKFLOW_REAPER_BATCH_SIZE
     workflow_worker_poll_interval_seconds: float = WORKFLOW_WORKER_POLL_INTERVAL_SECONDS
+    workflow_startup_recovery_max_age_seconds: int = WORKFLOW_STARTUP_RECOVERY_MAX_AGE_SECONDS
     diagnostics_dir: str = DIAGNOSTICS_DIR
     db_migration_backup_dir: str = DB_MIGRATION_BACKUP_DIR
     slo_min_http_request_sample: int = SLO_MIN_HTTP_REQUEST_SAMPLE

--- a/goal_ops_console/services.py
+++ b/goal_ops_console/services.py
@@ -71,6 +71,7 @@ def build_services(settings: Settings | None = None) -> AppServices:
         run_timeout_seconds=app_settings.workflow_run_timeout_seconds,
         reaper_batch_size=app_settings.workflow_reaper_batch_size,
         worker_poll_interval_seconds=app_settings.workflow_worker_poll_interval_seconds,
+        startup_recovery_max_age_seconds=app_settings.workflow_startup_recovery_max_age_seconds,
         observability=observability,
     )
     return AppServices(

--- a/goal_ops_console/workflow_catalog.py
+++ b/goal_ops_console/workflow_catalog.py
@@ -50,6 +50,7 @@ class WorkflowCatalog:
         run_timeout_seconds: int = 300,
         reaper_batch_size: int = 200,
         worker_poll_interval_seconds: float = 0.5,
+        startup_recovery_max_age_seconds: int = 0,
         observability: "ObservabilityService | None" = None,
     ):
         self.db = db
@@ -58,6 +59,7 @@ class WorkflowCatalog:
         self.run_timeout_seconds = max(0, int(run_timeout_seconds))
         self.reaper_batch_size = max(1, int(reaper_batch_size))
         self.worker_poll_interval_seconds = max(0.05, float(worker_poll_interval_seconds))
+        self.startup_recovery_max_age_seconds = max(0, int(startup_recovery_max_age_seconds))
         self.observability = observability
         self.handlers: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
             "scheduler.age_queue": self._run_scheduler_age_queue,
@@ -69,6 +71,14 @@ class WorkflowCatalog:
         self._worker_wakeup = threading.Event()
         self._worker_lock = threading.Lock()
         self._worker_thread: threading.Thread | None = None
+        self._startup_recovery_state: dict[str, Any] = {
+            "executed": False,
+            "recovered_count": 0,
+            "run_ids": [],
+            "error": None,
+            "at_utc": None,
+            "max_age_seconds": self.startup_recovery_max_age_seconds,
+        }
 
         self._seed_default_workflows()
 
@@ -76,6 +86,26 @@ class WorkflowCatalog:
         with self._worker_lock:
             if self._worker_thread is not None and self._worker_thread.is_alive():
                 return
+            startup_state: dict[str, Any] = {
+                "executed": True,
+                "recovered_count": 0,
+                "run_ids": [],
+                "error": None,
+                "at_utc": now_utc(),
+                "max_age_seconds": self.startup_recovery_max_age_seconds,
+            }
+            try:
+                recovered = self.recover_interrupted_runs(
+                    max_age_seconds=self.startup_recovery_max_age_seconds,
+                    limit=self.reaper_batch_size,
+                )
+                startup_state["recovered_count"] = int(recovered["recovered_count"])
+                startup_state["run_ids"] = list(recovered["run_ids"])
+            except Exception as exc:
+                startup_state["error"] = str(exc)
+                self._metric("workflows.startup_recovery.errors")
+            self._startup_recovery_state = startup_state
+
             self._worker_stop.clear()
             self._worker_wakeup.set()
             self._worker_thread = threading.Thread(
@@ -158,6 +188,7 @@ class WorkflowCatalog:
             "stop_requested": self._worker_stop.is_set(),
             "queued_runs": queued_runs,
             "running_runs": running_runs,
+            "startup_recovery": dict(self._startup_recovery_state),
         }
 
     def list_runs(self, *, limit: int = 100, workflow_id: str | None = None) -> list[dict[str, Any]]:
@@ -415,6 +446,84 @@ class WorkflowCatalog:
             if run_ids:
                 self._metric("workflows.runs.timed_out", delta=len(run_ids), tx=tx)
         return {"reaped_count": len(run_ids), "run_ids": run_ids}
+
+    def recover_interrupted_runs(self, *, max_age_seconds: int, limit: int) -> dict[str, Any]:
+        safe_limit = max(1, min(500, int(limit)))
+        safe_max_age = max(0, int(max_age_seconds))
+        rows = self.db.fetch_all(
+            """SELECT run_id, workflow_id, requested_by, correlation_id, started_at
+               FROM workflow_runs
+               WHERE status = 'running'
+               AND (
+                   started_at IS NULL
+                   OR started_at <= datetime('now', ? || ' seconds')
+               )
+               ORDER BY COALESCE(started_at, created_at) ASC
+               LIMIT ?""",
+            f"-{safe_max_age}",
+            safe_limit,
+        )
+        if not rows:
+            return {"recovered_count": 0, "run_ids": []}
+
+        run_ids: list[str] = []
+        with self.db.transaction() as tx:
+            for row in rows:
+                run_id = str(row["run_id"])
+                finished_at = now_utc()
+                updated = tx.execute(
+                    """UPDATE workflow_runs
+                       SET status = 'failed',
+                           result_payload = ?,
+                           finished_at = ?,
+                           updated_at = ?
+                       WHERE run_id = ? AND status = 'running'""",
+                    self._json_dump(
+                        {
+                            "error_type": "ProcessAbortRecovery",
+                            "error": (
+                                "Recovered interrupted workflow run during startup "
+                                "after previous process termination."
+                            ),
+                            "max_age_seconds": safe_max_age,
+                        }
+                    ),
+                    finished_at,
+                    finished_at,
+                    run_id,
+                )
+                if updated == 0:
+                    continue
+                run_ids.append(run_id)
+                self._safe_record_event(
+                    "workflow.run.recovered_after_abort",
+                    run_id,
+                    str(row["correlation_id"]),
+                    {
+                        "workflow_id": row["workflow_id"],
+                        "requested_by": row["requested_by"],
+                        "started_at": row["started_at"],
+                        "max_age_seconds": safe_max_age,
+                    },
+                    tx=tx,
+                )
+                self._record_audit(
+                    tx,
+                    action="workflow.startup_recovery",
+                    actor="system",
+                    status="error",
+                    workflow_id=str(row["workflow_id"]),
+                    correlation_id=str(row["correlation_id"]),
+                    details={
+                        "run_id": run_id,
+                        "max_age_seconds": safe_max_age,
+                        "started_at": row["started_at"],
+                    },
+                )
+
+            if run_ids:
+                self._metric("workflows.runs.recovered_after_abort", delta=len(run_ids), tx=tx)
+        return {"recovered_count": len(run_ids), "run_ids": run_ids}
 
     def _worker_loop(self) -> None:
         while not self._worker_stop.is_set():

--- a/scripts/recovery-hard-abort-drill.py
+++ b/scripts/recovery-hard-abort-drill.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sqlite3
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from goal_ops_console.config import Settings
+from goal_ops_console.main import create_app
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    _expect(isinstance(payload, dict), f"Expected JSON object in {path}")
+    return payload
+
+
+def _consume_process_output(process: subprocess.Popen[str]) -> tuple[str, str]:
+    stdout_text = ""
+    stderr_text = ""
+    if process.stdout is not None:
+        stdout_text = process.stdout.read()
+    if process.stderr is not None:
+        stderr_text = process.stderr.read()
+    return stdout_text, stderr_text
+
+
+def _read_run_status(db_path: Path, run_id: str) -> str | None:
+    last_error: Exception | None = None
+    for _ in range(20):
+        connection = sqlite3.connect(str(db_path))
+        try:
+            row = connection.execute(
+                "SELECT status FROM workflow_runs WHERE run_id = ?",
+                (run_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            return str(row[0])
+        except sqlite3.OperationalError as exc:
+            last_error = exc
+            if "locked" in str(exc).lower():
+                time.sleep(0.05)
+                continue
+            raise
+        finally:
+            connection.close()
+    if last_error is not None:
+        raise last_error
+    return None
+
+
+def _wait_for_target_state(
+    *,
+    process: subprocess.Popen[str],
+    state_file: Path,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    deadline = time.time() + max(1.0, float(timeout_seconds))
+    while time.time() < deadline:
+        if state_file.exists():
+            try:
+                payload = _read_json(state_file)
+            except Exception:
+                payload = {}
+            if payload.get("status") == "running" and payload.get("run_id"):
+                return payload
+        if process.poll() is not None:
+            stdout_text, stderr_text = _consume_process_output(process)
+            raise RuntimeError(
+                "Hard-abort target process exited before reporting running state. "
+                f"rc={process.returncode} stdout={stdout_text!r} stderr={stderr_text!r}"
+            )
+        time.sleep(0.05)
+    raise RuntimeError(
+        f"Hard-abort target did not report running state within {timeout_seconds}s."
+    )
+
+
+@dataclass(slots=True)
+class DrillPaths:
+    run_dir: Path
+    database_path: Path
+    target_state_file: Path
+
+
+def _create_paths(workspace_root: Path) -> DrillPaths:
+    run_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+    run_dir = workspace_root / f"recovery-hard-abort-{run_id}"
+    return DrillPaths(
+        run_dir=run_dir,
+        database_path=run_dir / "hard-abort-drill.db",
+        target_state_file=run_dir / "target-state.json",
+    )
+
+
+def run_drill(
+    *,
+    workspace_root: Path,
+    label: str,
+    keep_artifacts: bool,
+    startup_timeout_seconds: float,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    paths = _create_paths(workspace_root)
+    paths.run_dir.mkdir(parents=True, exist_ok=False)
+
+    target_script = PROJECT_ROOT / "scripts" / "recovery-hard-abort-target.py"
+    _expect(target_script.exists(), f"Target helper script missing: {target_script}")
+
+    target_process: subprocess.Popen[str] | None = None
+    target_stdout = ""
+    target_stderr = ""
+    run_id = ""
+
+    try:
+        target_process = subprocess.Popen(
+            [
+                sys.executable,
+                str(target_script),
+                "--database-url",
+                str(paths.database_path),
+                "--state-file",
+                str(paths.target_state_file),
+                "--startup-timeout-seconds",
+                str(float(startup_timeout_seconds)),
+            ],
+            cwd=PROJECT_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        target_state = _wait_for_target_state(
+            process=target_process,
+            state_file=paths.target_state_file,
+            timeout_seconds=max(5.0, float(startup_timeout_seconds)),
+        )
+        run_id = str(target_state["run_id"])
+
+        status_before_abort = _read_run_status(paths.database_path, run_id)
+        _expect(
+            status_before_abort == "running",
+            f"Expected run status 'running' before abort, got {status_before_abort!r}.",
+        )
+
+        target_process.kill()
+        target_process.wait(timeout=10)
+        target_stdout, target_stderr = _consume_process_output(target_process)
+
+        app = create_app(
+            Settings(
+                database_url=str(paths.database_path),
+                workflow_run_timeout_seconds=1800,
+                workflow_worker_poll_interval_seconds=0.05,
+                workflow_startup_recovery_max_age_seconds=0,
+            )
+        )
+        with TestClient(app) as client:
+            readiness_response = client.get("/system/readiness")
+            _expect(readiness_response.status_code == 200, "Readiness probe failed after restart.")
+            readiness = readiness_response.json()
+
+            run_response = client.get(f"/workflows/runs/{run_id}")
+            _expect(run_response.status_code == 200, f"Failed to read run {run_id} after restart.")
+            run_payload = run_response.json()["run"]
+
+            listed_runs = client.get("/workflows/runs?limit=200").json()["runs"]
+            running_run_ids = [str(item["run_id"]) for item in listed_runs if item["status"] == "running"]
+
+            events = client.get(f"/events?entity_id={run_id}").json()
+
+        startup_recovery = (
+            readiness.get("checks", {})
+            .get("workflow_worker", {})
+            .get("startup_recovery", {})
+        )
+        recovered_event_present = any(
+            str(item.get("event_type")) == "workflow.run.recovered_after_abort"
+            for item in events
+            if isinstance(item, dict)
+        )
+
+        status_after_restart = str(run_payload["status"])
+        result_payload = run_payload.get("result_payload") or {}
+        success = (
+            bool(readiness.get("ready"))
+            and status_after_restart == "failed"
+            and str(result_payload.get("error_type")) == "ProcessAbortRecovery"
+            and run_id not in running_run_ids
+            and int(startup_recovery.get("recovered_count") or 0) >= 1
+            and recovered_event_present
+        )
+        _expect(
+            success,
+            (
+                "Hard-abort recovery validation failed. "
+                f"readiness={json.dumps(readiness, sort_keys=True)} "
+                f"run={json.dumps(run_payload, sort_keys=True)} "
+                f"running_run_ids={running_run_ids} "
+                f"startup_recovery={json.dumps(startup_recovery, sort_keys=True)} "
+                f"events={json.dumps(events, sort_keys=True)}"
+            ),
+        )
+
+        return {
+            "label": label,
+            "success": True,
+            "recovery": {
+                "run_id": run_id,
+                "status_before_abort": status_before_abort,
+                "status_after_restart": status_after_restart,
+                "error_type_after_restart": result_payload.get("error_type"),
+                "startup_recovery": startup_recovery,
+                "recovered_event_present": recovered_event_present,
+                "running_run_ids_after_restart": running_run_ids,
+                "readiness_ready": bool(readiness.get("ready")),
+            },
+            "paths": {
+                "run_dir": str(paths.run_dir),
+                "database_path": str(paths.database_path),
+                "target_state_file": str(paths.target_state_file),
+                "target_script": str(target_script),
+            },
+            "target_process": {
+                "stdout": target_stdout.strip(),
+                "stderr": target_stderr.strip(),
+            },
+            "duration_ms": int((time.perf_counter() - started) * 1000),
+        }
+    finally:
+        if target_process is not None and target_process.poll() is None:
+            target_process.kill()
+            try:
+                target_process.wait(timeout=5)
+            except Exception:
+                pass
+        if not keep_artifacts:
+            shutil.rmtree(paths.run_dir, ignore_errors=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Recovery drill for hard process abort: kill worker process during running workflow, "
+            "restart service, and verify startup recovery marks interrupted run as non-running."
+        )
+    )
+    parser.add_argument("--workspace", default=str(PROJECT_ROOT / ".tmp" / "recovery-hard-abort-drills"))
+    parser.add_argument("--label", default="recovery-hard-abort-drill")
+    parser.add_argument("--startup-timeout-seconds", type=float, default=15.0)
+    parser.add_argument("--keep-artifacts", action="store_true")
+    args = parser.parse_args(argv)
+
+    workspace_root = Path(str(args.workspace)).expanduser()
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    try:
+        report = run_drill(
+            workspace_root=workspace_root,
+            label=str(args.label),
+            keep_artifacts=bool(args.keep_artifacts),
+            startup_timeout_seconds=float(args.startup_timeout_seconds),
+        )
+    except Exception as exc:
+        print(f"[recovery-hard-abort-drill] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/recovery-hard-abort-target.py
+++ b/scripts/recovery-hard-abort-target.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import threading
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from goal_ops_console.config import Settings
+from goal_ops_console.main import create_app
+
+
+def _utc_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _wait_for_running(client: TestClient, run_id: str, timeout_seconds: float) -> None:
+    deadline = time.time() + max(1.0, float(timeout_seconds))
+    while time.time() < deadline:
+        response = client.get(f"/workflows/runs/{run_id}")
+        if response.status_code == 200:
+            status = str(response.json()["run"]["status"])
+            if status == "running":
+                return
+            if status in {"succeeded", "failed", "timed_out", "cancelled"}:
+                raise RuntimeError(
+                    f"Run {run_id} reached terminal status {status!r} before hard-abort preparation."
+                )
+        time.sleep(0.05)
+    raise RuntimeError(f"Run {run_id} did not reach running state within {timeout_seconds}s.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Internal helper for recovery hard-abort drill: start a long-running workflow and "
+            "wait to be killed by parent process."
+        )
+    )
+    parser.add_argument("--database-url", required=True)
+    parser.add_argument("--state-file", required=True)
+    parser.add_argument("--startup-timeout-seconds", type=float, default=15.0)
+    args = parser.parse_args(argv)
+
+    state_file = Path(args.state_file).expanduser()
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+
+    app = create_app(
+        Settings(
+            database_url=str(args.database_url),
+            workflow_run_timeout_seconds=1800,
+            workflow_worker_poll_interval_seconds=0.05,
+            workflow_startup_recovery_max_age_seconds=0,
+        )
+    )
+
+    started = threading.Event()
+
+    def _blocking_handler(_: dict) -> dict:
+        started.set()
+        while True:
+            time.sleep(0.5)
+
+    with TestClient(app) as client:
+        services = client.app.state.services
+        services.workflow_catalog.handlers["maintenance.retention_cleanup"] = _blocking_handler
+
+        response = client.post(
+            "/workflows/maintenance.retention_cleanup/start",
+            json={"requested_by": "hard-abort-drill", "payload": {"source": "hard-abort-target"}},
+        )
+        if response.status_code != 201:
+            raise RuntimeError(
+                f"Failed to queue workflow run. status={response.status_code} body={response.text}"
+            )
+        run_id = str(response.json()["run"]["run_id"])
+
+        if not started.wait(timeout=max(1.0, float(args.startup_timeout_seconds))):
+            raise RuntimeError("Worker handler did not start before timeout.")
+        _wait_for_running(client, run_id, timeout_seconds=float(args.startup_timeout_seconds))
+
+        state_file.write_text(
+            json.dumps(
+                {
+                    "status": "running",
+                    "run_id": run_id,
+                    "pid": os.getpid(),
+                    "timestamp_utc": _utc_iso(),
+                },
+                ensure_ascii=True,
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+
+        while True:
+            time.sleep(1.0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -10,6 +10,8 @@ param(
     [switch]$StrictAutoRollbackPolicyDrill,
     [switch]$SkipDesktopUpdateSafetyDrill,
     [switch]$StrictDesktopUpdateSafetyDrill,
+    [switch]$SkipRecoveryHardAbortDrill,
+    [switch]$StrictRecoveryHardAbortDrill,
     [switch]$SkipMigrationRehearsal,
     [switch]$StrictMigrationRehearsal,
     [switch]$SkipBackupRestoreDrill,
@@ -130,6 +132,27 @@ if (-not $SkipDesktopUpdateSafetyDrill) {
             }
             Write-Warning (
                 "Desktop update safety drill failed but StrictDesktopUpdateSafetyDrill is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipRecoveryHardAbortDrill) {
+    Invoke-GateStep -Name "Recovery hard-abort drill (kill process + startup recovery)" -Action {
+        $workspace = Join-Path $ProjectRoot ".tmp\recovery-hard-abort-drills"
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\recovery-hard-abort-drill.py",
+                "--workspace", $workspace,
+                "--label", "release-gate"
+            )
+        } catch {
+            if ($StrictRecoveryHardAbortDrill) {
+                throw
+            }
+            Write-Warning (
+                "Recovery hard-abort drill failed but StrictRecoveryHardAbortDrill is off. " +
                 "Continuing. Error: $($_.Exception.Message)"
             )
         }

--- a/scripts/run-recovery-hard-abort-drill.ps1
+++ b/scripts/run-recovery-hard-abort-drill.ps1
@@ -1,0 +1,28 @@
+param(
+    [string]$PythonExe = "python",
+    [string]$WorkspaceDir = ".tmp\\recovery-hard-abort-drills",
+    [double]$StartupTimeoutSeconds = 15,
+    [switch]$KeepArtifacts
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$args = @(
+    ".\\scripts\\recovery-hard-abort-drill.py",
+    "--workspace", $WorkspaceDir,
+    "--label", "manual",
+    "--startup-timeout-seconds", [string]$StartupTimeoutSeconds
+)
+if ($KeepArtifacts) {
+    $args += "--keep-artifacts"
+}
+
+& $PythonExe @args
+if ($LASTEXITCODE -ne 0) {
+    throw "Recovery hard-abort drill failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Recovery hard-abort drill passed." -ForegroundColor Green

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1755,3 +1755,66 @@ def test_77_desktop_update_safety_drill_reports_success():
     assert payload["cases"]["tampered_hash_blocked"]["ok"] is True
     assert payload["cases"]["fallback_after_copy_failure"]["ok"] is True
     shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_78_recover_interrupted_runs_marks_running_status_failed(client):
+    services = client.app.state.services
+    services.workflow_catalog.stop_worker()
+
+    run_id = new_id()
+    created_at = now_utc()
+    services.db.execute(
+        """INSERT INTO workflow_runs
+           (run_id, workflow_id, status, requested_by, correlation_id, idempotency_key,
+            input_payload, result_payload, started_at, finished_at, created_at, updated_at)
+           VALUES (?, ?, 'running', ?, ?, NULL, '{}', NULL, ?, NULL, ?, ?)""",
+        run_id,
+        "maintenance.retention_cleanup",
+        "startup-recovery-test",
+        f"workflow:maintenance.retention_cleanup:{run_id[:8]}",
+        created_at,
+        created_at,
+        created_at,
+    )
+
+    recovered = services.workflow_catalog.recover_interrupted_runs(max_age_seconds=0, limit=10)
+    run = client.get(f"/workflows/runs/{run_id}").json()["run"]
+
+    assert recovered["recovered_count"] == 1
+    assert recovered["run_ids"] == [run_id]
+    assert run["status"] == "failed"
+    assert run["result_payload"]["error_type"] == "ProcessAbortRecovery"
+
+    services.workflow_catalog.start_worker()
+
+
+def test_79_recovery_hard_abort_drill_reports_success():
+    workspace = _local_test_dir("pytest-recovery-hard-abort-drill")
+    project_root = Path(__file__).resolve().parents[1]
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "recovery-hard-abort-drill.py"),
+        "--workspace",
+        str(workspace),
+        "--label",
+        "pytest-drill",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0 and "disk i/o error" in completed.stderr.lower():
+        shutil.rmtree(workspace, ignore_errors=True)
+        pytest.skip("File-backed SQLite is unavailable in this sandbox")
+    assert completed.returncode == 0, completed.stderr
+
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    assert payload["success"] is True
+    assert payload["recovery"]["status_before_abort"] == "running"
+    assert payload["recovery"]["status_after_restart"] == "failed"
+    assert payload["recovery"]["error_type_after_restart"] == "ProcessAbortRecovery"
+    assert payload["recovery"]["readiness_ready"] is True
+    shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
﻿## Summary
- add startup recovery for interrupted `running` workflow runs (`ProcessAbortRecovery`) when worker starts
- add deterministic hard-abort recovery drill (target process + kill + restart verification) and PowerShell wrapper
- integrate strict recovery drill gate in release-gate/CI and extend tests + docs

## Verification
- python -m pytest -q
- python -m pytest -q tests/test_goal_ops.py -k "test_78_recover_interrupted_runs_marks_running_status_failed or test_79_recovery_hard_abort_drill_reports_success"
- .\scripts\release-gate.ps1 -SkipPytest -SkipDesktopSmoke -SkipApiProbe -SkipSloAlertCheck -SkipAutoRollbackPolicyDrill -SkipDesktopUpdateSafetyDrill -SkipMigrationRehearsal -SkipBackupRestoreDrill -SkipIncidentRollbackDrill -SkipFileDatabaseProbe
  - note: in this sandbox the hard-abort drill reports `disk I/O error` for file-backed SQLite, so strict mode is expected only in real Windows CI
