### PR TITLE
P0: Extend migration rehearsal to S/M/L/XL DB copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + migration state + migration rehearsal on S/M/L DB copies + backup/restore drill + incident/rollback drill under burst load):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + migration state + migration rehearsal on S/M/L/XL DB copies + backup/restore drill + incident/rollback drill under burst load):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
@@ -424,7 +424,7 @@ Standalone migration rehearsal drill:
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\run-migration-rehearsal.ps1 -SmallRuns 500 -MediumRuns 2500 -LargeRuns 6000
+.\scripts\run-migration-rehearsal.ps1 -SmallRuns 500 -MediumRuns 2500 -LargeRuns 6000 -XLargeRuns 9000
 ```
 
 Standalone auto-rollback policy check (live service):

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -22,14 +22,14 @@ This gate covers:
 - recovery hard-abort drill (kill running worker process, restart, and verify no hanging `running` runs)
 - `GET /system/database/integrity?mode=quick|full`
 - schema migration pending-version check (`pending_versions` must be empty)
-- migration rehearsal across small/medium/large DB copies with explicit backup/restore/migration runtime thresholds
+- migration rehearsal across small/medium/large/xlarge DB copies with explicit backup/restore/migration runtime thresholds
 - backup/restore drill with row-count and integrity verification on restored DB
 - incident/rollback drill with controlled burst load, SLO incident detection, and stable-ring rollback validation
 
 Manual migration rehearsal invocation (same thresholds as gate defaults):
 
 ```powershell
-.\scripts\run-migration-rehearsal.ps1 -SmallRuns 500 -MediumRuns 2500 -LargeRuns 6000
+.\scripts\run-migration-rehearsal.ps1 -SmallRuns 500 -MediumRuns 2500 -LargeRuns 6000 -XLargeRuns 9000
 ```
 
 Manual auto-rollback policy invocation (live endpoint, stable ring):

--- a/scripts/migration-rehearsal.py
+++ b/scripts/migration-rehearsal.py
@@ -371,7 +371,7 @@ def run_drill(
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Run migration rehearsal across small/medium/large DB copies, measure backup+restore+migration "
+            "Run migration rehearsal across small/medium/large/(optional xlarge) DB copies, measure backup+restore+migration "
             "durations, and enforce release abort thresholds."
         )
     )
@@ -380,6 +380,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--small-runs", type=int, default=500)
     parser.add_argument("--medium-runs", type=int, default=2500)
     parser.add_argument("--large-runs", type=int, default=6000)
+    parser.add_argument("--xlarge-runs", type=int, default=0)
     parser.add_argument("--payload-bytes", type=int, default=1024)
     parser.add_argument("--max-backup-ms", type=int, default=15_000)
     parser.add_argument("--max-restore-ms", type=int, default=15_000)
@@ -397,6 +398,9 @@ def main(argv: list[str] | None = None) -> int:
     if any(value <= 0 for value in scenario_values):
         print("[migration-rehearsal] ERROR: scenario run counts must be positive integers.", file=sys.stderr)
         return 2
+    if int(args.xlarge_runs) < 0:
+        print("[migration-rehearsal] ERROR: --xlarge-runs must be >= 0.", file=sys.stderr)
+        return 2
     if int(args.payload_bytes) <= 0:
         print("[migration-rehearsal] ERROR: --payload-bytes must be positive.", file=sys.stderr)
         return 2
@@ -411,6 +415,10 @@ def main(argv: list[str] | None = None) -> int:
         ScenarioSpec(name="medium", run_rows=int(args.medium_runs), payload_bytes=int(args.payload_bytes)),
         ScenarioSpec(name="large", run_rows=int(args.large_runs), payload_bytes=int(args.payload_bytes)),
     ]
+    if int(args.xlarge_runs) > 0:
+        scenarios.append(
+            ScenarioSpec(name="xlarge", run_rows=int(args.xlarge_runs), payload_bytes=int(args.payload_bytes))
+        )
 
     try:
         report = run_drill(

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -189,13 +189,14 @@ if (-not $SkipFileDatabaseProbe) {
 }
 
 if (-not $SkipMigrationRehearsal) {
-    Invoke-GateStep -Name "Migration rehearsal (S/M/L DB copies)" -Action {
+    Invoke-GateStep -Name "Migration rehearsal (S/M/L/XL DB copies)" -Action {
         $workspace = Join-Path $ProjectRoot ".tmp\migration-rehearsals"
         try {
             Invoke-NativeCommand -Executable $PythonExe -Arguments @(
                 ".\scripts\migration-rehearsal.py",
                 "--workspace", $workspace,
-                "--label", "release-gate"
+                "--label", "release-gate",
+                "--xlarge-runs", "9000"
             )
         } catch {
             if ($StrictMigrationRehearsal) {

--- a/scripts/run-migration-rehearsal.ps1
+++ b/scripts/run-migration-rehearsal.ps1
@@ -4,6 +4,7 @@ param(
     [int]$SmallRuns = 500,
     [int]$MediumRuns = 2500,
     [int]$LargeRuns = 6000,
+    [int]$XLargeRuns = 0,
     [int]$PayloadBytes = 1024,
     [int]$MaxBackupMs = 15000,
     [int]$MaxRestoreMs = 15000,
@@ -28,6 +29,9 @@ $args = @(
     "--max-restore-ms", [string]$MaxRestoreMs,
     "--max-migration-ms", [string]$MaxMigrationMs
 )
+if ($XLargeRuns -gt 0) {
+    $args += @("--xlarge-runs", [string]$XLargeRuns)
+}
 if ($KeepArtifacts) {
     $args += "--keep-artifacts"
 }

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1818,3 +1818,43 @@ def test_79_recovery_hard_abort_drill_reports_success():
     assert payload["recovery"]["error_type_after_restart"] == "ProcessAbortRecovery"
     assert payload["recovery"]["readiness_ready"] is True
     shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_80_migration_rehearsal_supports_optional_xlarge_scenario():
+    workspace = _local_test_dir("pytest-migration-rehearsal-xlarge")
+    project_root = Path(__file__).resolve().parents[1]
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "migration-rehearsal.py"),
+        "--workspace",
+        str(workspace),
+        "--label",
+        "pytest-xlarge",
+        "--small-runs",
+        "80",
+        "--medium-runs",
+        "160",
+        "--large-runs",
+        "240",
+        "--xlarge-runs",
+        "320",
+        "--payload-bytes",
+        "128",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0 and "disk i/o error" in completed.stderr.lower():
+        shutil.rmtree(workspace, ignore_errors=True)
+        pytest.skip("File-backed SQLite is unavailable in this sandbox")
+    assert completed.returncode == 0, completed.stderr
+
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    scenario_names = [scenario["scenario"] for scenario in payload["scenarios"]]
+    assert payload["success"] is True
+    assert scenario_names == ["small", "medium", "large", "xlarge"]
+    shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
﻿## Summary
- extend `migration-rehearsal.py` with optional `--xlarge-runs` scenario support
- run migration rehearsal gate with S/M/L/XL coverage (`--xlarge-runs 9000`) and update wrapper/docs accordingly
- add pytest coverage for xlarge scenario wiring

## Verification
- python -m pytest -q
- python -m pytest -q tests/test_goal_ops.py -k "test_75_migration_rehearsal_reports_success or test_80_migration_rehearsal_supports_optional_xlarge_scenario"
- .\scripts\release-gate.ps1 -SkipPytest -SkipDesktopSmoke -SkipApiProbe -SkipSloAlertCheck -SkipAutoRollbackPolicyDrill -SkipDesktopUpdateSafetyDrill -SkipRecoveryHardAbortDrill -SkipBackupRestoreDrill -SkipIncidentRollbackDrill -SkipFileDatabaseProbe
  - note: this sandbox can emit file-backed SQLite `disk I/O error`; strict verification is enforced in Windows CI
