### PR TITLE
Stability: add workflow lock-resilience and soak drills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run release gate
         shell: pwsh
         run: |
-          .\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+          .\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 
   test:
     name: Pytest (Python ${{ matrix.python-version }})

--- a/README.md
+++ b/README.md
@@ -406,11 +406,11 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + migration state + migration rehearsal on S/M/L/XL DB copies + backup/restore drill + incident/rollback drill under burst load):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + workflow lock-resilience drill + workflow soak drill + migration state + migration rehearsal on S/M/L/XL DB copies + backup/restore drill + incident/rollback drill under burst load):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+.\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 ```
 
 Standalone backup/restore drill:
@@ -446,6 +446,20 @@ Standalone recovery hard-abort drill:
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-recovery-hard-abort-drill.ps1
+```
+
+Standalone workflow lock-resilience drill:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-workflow-lock-resilience-drill.ps1
+```
+
+Standalone workflow soak drill:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-workflow-soak-drill.ps1 -RunCount 40
 ```
 
 Standalone SLO alert check:
@@ -644,6 +658,10 @@ If a value is rejected:
 - [recovery-hard-abort-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/recovery-hard-abort-drill.py)
 - [recovery-hard-abort-target.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/recovery-hard-abort-target.py)
 - [run-recovery-hard-abort-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-recovery-hard-abort-drill.ps1)
+- [workflow-lock-resilience-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/workflow-lock-resilience-drill.py)
+- [run-workflow-lock-resilience-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-workflow-lock-resilience-drill.ps1)
+- [workflow-soak-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/workflow-soak-drill.py)
+- [run-workflow-soak-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-workflow-soak-drill.ps1)
 - [migration-rehearsal.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/migration-rehearsal.py)
 - [run-migration-rehearsal.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-migration-rehearsal.ps1)
 - [backup-restore-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/backup-restore-drill.py)

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -9,7 +9,7 @@ This runbook is optimized for reliability-first releases of the desktop app and 
 Run in repo root:
 
 ```powershell
-.\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+.\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 ```
 
 This gate covers:
@@ -20,6 +20,8 @@ This gate covers:
 - auto-rollback-policy drill (`critical` sustained window triggers stable ring rollback path)
 - desktop-update-safety drill (hash validation + rollback-to-stable fallback path)
 - recovery hard-abort drill (kill running worker process, restart, and verify no hanging `running` runs)
+- workflow lock-resilience drill (transient SQLite lock conflicts while worker remains healthy)
+- workflow soak drill (burst enqueue with zero lingering `running` or `queued` runs)
 - `GET /system/database/integrity?mode=quick|full`
 - schema migration pending-version check (`pending_versions` must be empty)
 - migration rehearsal across small/medium/large/xlarge DB copies with explicit backup/restore/migration runtime thresholds
@@ -48,6 +50,18 @@ Manual recovery hard-abort drill invocation:
 
 ```powershell
 .\scripts\run-recovery-hard-abort-drill.ps1
+```
+
+Manual workflow lock-resilience drill invocation:
+
+```powershell
+.\scripts\run-workflow-lock-resilience-drill.ps1
+```
+
+Manual workflow soak drill invocation:
+
+```powershell
+.\scripts\run-workflow-soak-drill.ps1 -RunCount 40
 ```
 
 Verify before release:
@@ -291,6 +305,39 @@ Actions:
    .\scripts\run-recovery-hard-abort-drill.ps1
    ```
 4. If drill fails, block rollout and escalate with drill JSON output + diagnostics snapshot.
+
+### 3.10 Workflow lock contention spikes
+
+Symptoms:
+- intermittent SQLite lock-conflict errors under concurrent workflow activity
+- worker appears healthy but throughput jitters
+
+Actions:
+1. Run lock-resilience drill:
+   ```powershell
+   .\scripts\run-workflow-lock-resilience-drill.ps1
+   ```
+2. Confirm worker remains healthy in readiness payload:
+   ```powershell
+   Invoke-RestMethod http://127.0.0.1:8000/system/readiness
+   ```
+3. If drill fails, block rollout and investigate DB contention before retrying release.
+
+### 3.11 Post-burst hanging run check
+
+Symptoms:
+- large queue bursts are processed, but some runs remain `queued`/`running`
+
+Actions:
+1. Run soak drill:
+   ```powershell
+   .\scripts\run-workflow-soak-drill.ps1 -RunCount 40
+   ```
+2. Verify workflow run list contains only terminal states:
+   ```powershell
+   Invoke-RestMethod http://127.0.0.1:8000/workflows/runs
+   ```
+3. If hanging runs remain, trigger incident and hold release promotion.
 
 ## 4. Operational Defaults
 

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -12,6 +12,10 @@ param(
     [switch]$StrictDesktopUpdateSafetyDrill,
     [switch]$SkipRecoveryHardAbortDrill,
     [switch]$StrictRecoveryHardAbortDrill,
+    [switch]$SkipWorkflowLockResilienceDrill,
+    [switch]$StrictWorkflowLockResilienceDrill,
+    [switch]$SkipWorkflowSoakDrill,
+    [switch]$StrictWorkflowSoakDrill,
     [switch]$SkipMigrationRehearsal,
     [switch]$StrictMigrationRehearsal,
     [switch]$SkipBackupRestoreDrill,
@@ -153,6 +157,46 @@ if (-not $SkipRecoveryHardAbortDrill) {
             }
             Write-Warning (
                 "Recovery hard-abort drill failed but StrictRecoveryHardAbortDrill is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipWorkflowLockResilienceDrill) {
+    Invoke-GateStep -Name "Workflow lock resilience drill (transient SQLite lock conflicts)" -Action {
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\workflow-lock-resilience-drill.py",
+                "--lock-failures", "8",
+                "--timeout-seconds", "12"
+            )
+        } catch {
+            if ($StrictWorkflowLockResilienceDrill) {
+                throw
+            }
+            Write-Warning (
+                "Workflow lock resilience drill failed but StrictWorkflowLockResilienceDrill is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipWorkflowSoakDrill) {
+    Invoke-GateStep -Name "Workflow soak drill (no hanging runs after burst enqueue)" -Action {
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\workflow-soak-drill.py",
+                "--run-count", "40",
+                "--timeout-seconds", "25"
+            )
+        } catch {
+            if ($StrictWorkflowSoakDrill) {
+                throw
+            }
+            Write-Warning (
+                "Workflow soak drill failed but StrictWorkflowSoakDrill is off. " +
                 "Continuing. Error: $($_.Exception.Message)"
             )
         }

--- a/scripts/run-workflow-lock-resilience-drill.ps1
+++ b/scripts/run-workflow-lock-resilience-drill.ps1
@@ -1,0 +1,23 @@
+param(
+    [string]$PythonExe = "python",
+    [int]$LockFailures = 5,
+    [double]$TimeoutSeconds = 10
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$args = @(
+    ".\\scripts\\workflow-lock-resilience-drill.py",
+    "--lock-failures", [string]$LockFailures,
+    "--timeout-seconds", [string]$TimeoutSeconds
+)
+
+& $PythonExe @args
+if ($LASTEXITCODE -ne 0) {
+    throw "Workflow lock resilience drill failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Workflow lock resilience drill passed." -ForegroundColor Green

--- a/scripts/run-workflow-soak-drill.ps1
+++ b/scripts/run-workflow-soak-drill.ps1
@@ -1,0 +1,23 @@
+param(
+    [string]$PythonExe = "python",
+    [int]$RunCount = 40,
+    [double]$TimeoutSeconds = 20
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$args = @(
+    ".\\scripts\\workflow-soak-drill.py",
+    "--run-count", [string]$RunCount,
+    "--timeout-seconds", [string]$TimeoutSeconds
+)
+
+& $PythonExe @args
+if ($LASTEXITCODE -ne 0) {
+    throw "Workflow soak drill failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Workflow soak drill passed." -ForegroundColor Green

--- a/scripts/workflow-lock-resilience-drill.py
+++ b/scripts/workflow-lock-resilience-drill.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from goal_ops_console.config import Settings
+from goal_ops_console.main import create_app
+
+TERMINAL_STATUSES = {"succeeded", "failed", "timed_out", "cancelled"}
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _wait_for_terminal_run(client: TestClient, run_id: str, timeout_seconds: float) -> dict:
+    deadline = time.time() + max(1.0, float(timeout_seconds))
+    while time.time() < deadline:
+        response = client.get(f"/workflows/runs/{run_id}")
+        if response.status_code == 200:
+            run = response.json()["run"]
+            status = str(run["status"])
+            if status in TERMINAL_STATUSES:
+                return run
+        time.sleep(0.05)
+    raise RuntimeError(f"Run {run_id} did not reach terminal status within {timeout_seconds}s.")
+
+
+def run_drill(*, lock_failures: int, timeout_seconds: float) -> dict:
+    app = create_app(
+        Settings(
+            database_url=":memory:",
+            workflow_worker_poll_interval_seconds=0.05,
+            workflow_run_timeout_seconds=60,
+        )
+    )
+
+    with TestClient(app) as client:
+        services = client.app.state.services
+        catalog = services.workflow_catalog
+        original_claim = catalog._claim_next_queued_run
+        remaining_failures = {"value": max(0, int(lock_failures))}
+
+        def _flaky_claim():
+            if remaining_failures["value"] > 0:
+                remaining_failures["value"] -= 1
+                raise sqlite3.OperationalError("database table is locked: workflow_runs")
+            return original_claim()
+
+        catalog._claim_next_queued_run = _flaky_claim  # type: ignore[assignment]
+
+        started = client.post(
+            "/workflows/maintenance.retention_cleanup/start",
+            json={"requested_by": "lock-resilience-drill", "payload": {"source": "drill"}},
+        )
+        _expect(started.status_code == 201, f"Failed to queue workflow run: {started.text}")
+        run_id = str(started.json()["run"]["run_id"])
+
+        final_run = _wait_for_terminal_run(client, run_id, timeout_seconds=timeout_seconds)
+        worker_status = catalog.worker_status()
+        lock_conflict_metric = int(
+            services.db.fetch_scalar(
+                "SELECT value FROM metrics_counters WHERE metric_name = ?",
+                "workflows.worker.lock_conflicts",
+            )
+            or 0
+        )
+
+        success = (
+            final_run["status"] == "succeeded"
+            and bool(worker_status["is_running"])
+            and lock_conflict_metric >= int(lock_failures)
+        )
+        _expect(
+            success,
+            (
+                "Workflow lock resilience drill failed. "
+                f"run={json.dumps(final_run, sort_keys=True)} "
+                f"worker_status={json.dumps(worker_status, sort_keys=True)} "
+                f"lock_conflict_metric={lock_conflict_metric} requested_failures={lock_failures}"
+            ),
+        )
+
+        return {
+            "success": True,
+            "run": {
+                "run_id": run_id,
+                "status": final_run["status"],
+            },
+            "worker_status": worker_status,
+            "lock_conflict_metric": lock_conflict_metric,
+            "requested_lock_failures": int(lock_failures),
+        }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inject transient SQLite lock conflicts into workflow claim path and verify "
+            "worker resilience with successful completion."
+        )
+    )
+    parser.add_argument("--lock-failures", type=int, default=5)
+    parser.add_argument("--timeout-seconds", type=float, default=10.0)
+    args = parser.parse_args(argv)
+
+    if int(args.lock_failures) < 0:
+        print("[workflow-lock-resilience-drill] ERROR: --lock-failures must be >= 0.", file=sys.stderr)
+        return 2
+
+    try:
+        report = run_drill(
+            lock_failures=int(args.lock_failures),
+            timeout_seconds=float(args.timeout_seconds),
+        )
+    except Exception as exc:
+        print(f"[workflow-lock-resilience-drill] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/workflow-soak-drill.py
+++ b/scripts/workflow-soak-drill.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from goal_ops_console.config import Settings
+from goal_ops_console.main import create_app
+
+TERMINAL_STATUSES = {"succeeded", "failed", "timed_out", "cancelled"}
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _wait_for_runs_terminal(client: TestClient, run_ids: list[str], timeout_seconds: float) -> list[dict]:
+    deadline = time.time() + max(1.0, float(timeout_seconds))
+    terminal_by_id: dict[str, dict] = {}
+
+    while time.time() < deadline:
+        pending = [run_id for run_id in run_ids if run_id not in terminal_by_id]
+        if not pending:
+            return [terminal_by_id[run_id] for run_id in run_ids]
+
+        for run_id in pending:
+            response = client.get(f"/workflows/runs/{run_id}")
+            if response.status_code != 200:
+                continue
+            run = response.json()["run"]
+            if str(run["status"]) in TERMINAL_STATUSES:
+                terminal_by_id[run_id] = run
+        time.sleep(0.05)
+
+    still_pending = [run_id for run_id in run_ids if run_id not in terminal_by_id]
+    raise RuntimeError(
+        f"Workflow soak drill timed out; pending runs={still_pending} after {timeout_seconds}s."
+    )
+
+
+def run_drill(*, run_count: int, timeout_seconds: float) -> dict:
+    app = create_app(
+        Settings(
+            database_url=":memory:",
+            workflow_worker_poll_interval_seconds=0.02,
+            workflow_run_timeout_seconds=120,
+        )
+    )
+
+    with TestClient(app) as client:
+        run_ids: list[str] = []
+        for index in range(int(run_count)):
+            response = client.post(
+                "/workflows/maintenance.retention_cleanup/start",
+                json={
+                    "requested_by": "workflow-soak-drill",
+                    "payload": {"index": index, "source": "soak"},
+                },
+            )
+            _expect(response.status_code == 201, f"Failed to enqueue run #{index}: {response.text}")
+            run_ids.append(str(response.json()["run"]["run_id"]))
+
+        terminal_runs = _wait_for_runs_terminal(client, run_ids, timeout_seconds=timeout_seconds)
+        status_counts = Counter(str(item["status"]) for item in terminal_runs)
+
+        readiness = client.get("/system/readiness").json()
+        slo = client.get("/system/slo").json()
+        worker_status = readiness["checks"]["workflow_worker"]
+
+        success = (
+            status_counts.get("succeeded", 0) == int(run_count)
+            and status_counts.get("failed", 0) == 0
+            and status_counts.get("timed_out", 0) == 0
+            and status_counts.get("cancelled", 0) == 0
+            and bool(readiness["ready"])
+            and bool(worker_status["is_running"])
+            and int(worker_status["running_runs"]) == 0
+            and int(worker_status["queued_runs"]) == 0
+            and str(slo["status"]) == "ok"
+        )
+        _expect(
+            success,
+            (
+                "Workflow soak drill failed. "
+                f"status_counts={json.dumps(dict(status_counts), sort_keys=True)} "
+                f"readiness={json.dumps(readiness, sort_keys=True)} "
+                f"slo={json.dumps(slo, sort_keys=True)}"
+            ),
+        )
+
+        return {
+            "success": True,
+            "run_count": int(run_count),
+            "status_counts": dict(status_counts),
+            "readiness": {
+                "ready": bool(readiness["ready"]),
+                "worker_status": worker_status,
+            },
+            "slo_status": str(slo["status"]),
+        }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run workflow soak drill: enqueue a burst of workflow runs and verify terminal completion, "
+            "readiness true, and zero hanging runs."
+        )
+    )
+    parser.add_argument("--run-count", type=int, default=40)
+    parser.add_argument("--timeout-seconds", type=float, default=20.0)
+    args = parser.parse_args(argv)
+
+    if int(args.run_count) <= 0:
+        print("[workflow-soak-drill] ERROR: --run-count must be > 0.", file=sys.stderr)
+        return 2
+
+    try:
+        report = run_drill(
+            run_count=int(args.run_count),
+            timeout_seconds=float(args.timeout_seconds),
+        )
+    except Exception as exc:
+        print(f"[workflow-soak-drill] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1858,3 +1858,56 @@ def test_80_migration_rehearsal_supports_optional_xlarge_scenario():
     assert payload["success"] is True
     assert scenario_names == ["small", "medium", "large", "xlarge"]
     shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_81_workflow_lock_resilience_drill_reports_success():
+    project_root = Path(__file__).resolve().parents[1]
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "workflow-lock-resilience-drill.py"),
+        "--lock-failures",
+        "5",
+        "--timeout-seconds",
+        "12",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    assert payload["success"] is True
+    assert payload["run"]["status"] == "succeeded"
+    assert payload["lock_conflict_metric"] >= payload["requested_lock_failures"]
+    assert payload["worker_status"]["is_running"] is True
+
+
+def test_82_workflow_soak_drill_reports_success():
+    project_root = Path(__file__).resolve().parents[1]
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "workflow-soak-drill.py"),
+        "--run-count",
+        "30",
+        "--timeout-seconds",
+        "25",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    assert payload["success"] is True
+    assert payload["run_count"] == 30
+    assert payload["status_counts"]["succeeded"] == 30
+    assert payload["readiness"]["ready"] is True
+    assert payload["slo_status"] == "ok"


### PR DESCRIPTION
﻿## Summary
- add workflow lock-resilience drill (inject transient SQLite lock conflicts, verify worker stays healthy and run succeeds)
- add workflow soak drill (burst enqueue, verify readiness/SLO stay healthy and no hanging runs)
- wire both drills into release-gate + CI strict flags, add wrappers, tests, and runbook/README updates

## Verification
- python -m pytest -q
- python -m pytest -q tests/test_goal_ops.py -k "test_81_workflow_lock_resilience_drill_reports_success or test_82_workflow_soak_drill_reports_success"
- python .\scripts\workflow-lock-resilience-drill.py --lock-failures 5 --timeout-seconds 12
- python .\scripts\workflow-soak-drill.py --run-count 30 --timeout-seconds 25
- .\scripts\release-gate.ps1 -SkipPytest -SkipDesktopSmoke -SkipApiProbe -SkipSloAlertCheck -SkipAutoRollbackPolicyDrill -SkipDesktopUpdateSafetyDrill -SkipRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -SkipMigrationRehearsal -SkipBackupRestoreDrill -SkipIncidentRollbackDrill -SkipFileDatabaseProbe
