### PR TITLE
Add workflow worker restart self-heal drill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run release gate
         shell: pwsh
         run: |
-          .\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+          .\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 
   test:
     name: Pytest (Python ${{ matrix.python-version }})

--- a/README.md
+++ b/README.md
@@ -406,11 +406,11 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + workflow lock-resilience drill + workflow soak drill + migration state + migration rehearsal on S/M/L/XL DB copies + backup/restore drill + incident/rollback drill under burst load):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + migration state + migration rehearsal on S/M/L/XL DB copies + backup/restore drill + incident/rollback drill under burst load):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+.\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 ```
 
 Standalone backup/restore drill:
@@ -460,6 +460,13 @@ Standalone workflow soak drill:
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-workflow-soak-drill.ps1 -RunCount 40
+```
+
+Standalone workflow worker restart drill:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-workflow-worker-restart-drill.ps1
 ```
 
 Standalone SLO alert check:
@@ -662,6 +669,8 @@ If a value is rejected:
 - [run-workflow-lock-resilience-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-workflow-lock-resilience-drill.ps1)
 - [workflow-soak-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/workflow-soak-drill.py)
 - [run-workflow-soak-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-workflow-soak-drill.ps1)
+- [workflow-worker-restart-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/workflow-worker-restart-drill.py)
+- [run-workflow-worker-restart-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-workflow-worker-restart-drill.ps1)
 - [migration-rehearsal.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/migration-rehearsal.py)
 - [run-migration-rehearsal.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-migration-rehearsal.ps1)
 - [backup-restore-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/backup-restore-drill.py)

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -9,7 +9,7 @@ This runbook is optimized for reliability-first releases of the desktop app and 
 Run in repo root:
 
 ```powershell
-.\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+.\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 ```
 
 This gate covers:
@@ -22,6 +22,7 @@ This gate covers:
 - recovery hard-abort drill (kill running worker process, restart, and verify no hanging `running` runs)
 - workflow lock-resilience drill (transient SQLite lock conflicts while worker remains healthy)
 - workflow soak drill (burst enqueue with zero lingering `running` or `queued` runs)
+- workflow worker restart drill (stop worker, enqueue run, and verify self-healing restart path)
 - `GET /system/database/integrity?mode=quick|full`
 - schema migration pending-version check (`pending_versions` must be empty)
 - migration rehearsal across small/medium/large/xlarge DB copies with explicit backup/restore/migration runtime thresholds
@@ -62,6 +63,12 @@ Manual workflow soak drill invocation:
 
 ```powershell
 .\scripts\run-workflow-soak-drill.ps1 -RunCount 40
+```
+
+Manual workflow worker restart drill invocation:
+
+```powershell
+.\scripts\run-workflow-worker-restart-drill.ps1
 ```
 
 Verify before release:
@@ -338,6 +345,23 @@ Actions:
    Invoke-RestMethod http://127.0.0.1:8000/workflows/runs
    ```
 3. If hanging runs remain, trigger incident and hold release promotion.
+
+### 3.12 Workflow worker does not recover after stop/crash
+
+Symptoms:
+- readiness check shows `workflow_worker.ok = false`
+- workflow starts remain queued because worker thread is not running
+
+Actions:
+1. Run worker restart drill:
+   ```powershell
+   .\scripts\run-workflow-worker-restart-drill.ps1
+   ```
+2. Verify readiness recovers to `ready=true`:
+   ```powershell
+   Invoke-RestMethod http://127.0.0.1:8000/system/readiness
+   ```
+3. If drill fails or `startup_recovery_error` is set, block release and escalate with diagnostics snapshot.
 
 ## 4. Operational Defaults
 

--- a/goal_ops_console/routers/system.py
+++ b/goal_ops_console/routers/system.py
@@ -68,13 +68,33 @@ def _build_readiness_payload(services: AppServices) -> dict[str, Any]:
         "stop_requested": False,
         "queued_runs": 0,
         "running_runs": 0,
+        "startup_recovery": {
+            "executed": False,
+            "recovered_count": 0,
+            "run_ids": [],
+            "error": None,
+            "at_utc": None,
+            "max_age_seconds": 0,
+        },
     }
     try:
         worker_status = services.workflow_catalog.worker_status()
     except Exception as exc:
         worker_error = str(exc)
 
-    worker_ok = bool(worker_status.get("is_running")) and worker_error is None
+    startup_recovery = worker_status.get("startup_recovery")
+    startup_recovery_error: str | None = None
+    if isinstance(startup_recovery, dict):
+        raw_error = startup_recovery.get("error")
+        if raw_error is not None:
+            startup_recovery_error = str(raw_error)
+    startup_recovery_ok = startup_recovery_error is None
+
+    worker_ok = (
+        bool(worker_status.get("is_running"))
+        and worker_error is None
+        and startup_recovery_ok
+    )
     return {
         "ready": bool(db_ok and worker_ok),
         "spec_version": SPEC_VERSION,
@@ -88,6 +108,8 @@ def _build_readiness_payload(services: AppServices) -> dict[str, Any]:
                 **worker_status,
                 "ok": worker_ok,
                 "error": worker_error,
+                "startup_recovery_ok": startup_recovery_ok,
+                "startup_recovery_error": startup_recovery_error,
             },
         },
     }

--- a/goal_ops_console/workflow_catalog.py
+++ b/goal_ops_console/workflow_catalog.py
@@ -191,6 +191,19 @@ class WorkflowCatalog:
             "startup_recovery": dict(self._startup_recovery_state),
         }
 
+    def ensure_worker_running(self) -> dict[str, Any]:
+        status = self.worker_status()
+        if bool(status.get("is_running")):
+            return status
+
+        self.start_worker()
+        status = self.worker_status()
+        if not bool(status.get("is_running")):
+            raise ConflictError("Workflow worker failed to start")
+
+        self._metric("workflows.worker.restarted")
+        return status
+
     def list_runs(self, *, limit: int = 100, workflow_id: str | None = None) -> list[dict[str, Any]]:
         params: list[Any] = []
         where = ""
@@ -263,6 +276,7 @@ class WorkflowCatalog:
                 f"Workflow {workflow_id} has unknown entrypoint '{definition['entrypoint']}'"
             )
 
+        self.ensure_worker_running()
         stale = self.reap_stuck_runs(
             timeout_seconds=self.run_timeout_seconds,
             limit=self.reaper_batch_size,

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -16,6 +16,8 @@ param(
     [switch]$StrictWorkflowLockResilienceDrill,
     [switch]$SkipWorkflowSoakDrill,
     [switch]$StrictWorkflowSoakDrill,
+    [switch]$SkipWorkflowWorkerRestartDrill,
+    [switch]$StrictWorkflowWorkerRestartDrill,
     [switch]$SkipMigrationRehearsal,
     [switch]$StrictMigrationRehearsal,
     [switch]$SkipBackupRestoreDrill,
@@ -197,6 +199,25 @@ if (-not $SkipWorkflowSoakDrill) {
             }
             Write-Warning (
                 "Workflow soak drill failed but StrictWorkflowSoakDrill is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipWorkflowWorkerRestartDrill) {
+    Invoke-GateStep -Name "Workflow worker restart drill (self-heal after worker stop)" -Action {
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\workflow-worker-restart-drill.py",
+                "--timeout-seconds", "12"
+            )
+        } catch {
+            if ($StrictWorkflowWorkerRestartDrill) {
+                throw
+            }
+            Write-Warning (
+                "Workflow worker restart drill failed but StrictWorkflowWorkerRestartDrill is off. " +
                 "Continuing. Error: $($_.Exception.Message)"
             )
         }

--- a/scripts/run-workflow-worker-restart-drill.ps1
+++ b/scripts/run-workflow-worker-restart-drill.ps1
@@ -1,0 +1,21 @@
+param(
+    [string]$PythonExe = "python",
+    [double]$TimeoutSeconds = 12
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$args = @(
+    ".\\scripts\\workflow-worker-restart-drill.py",
+    "--timeout-seconds", [string]$TimeoutSeconds
+)
+
+& $PythonExe @args
+if ($LASTEXITCODE -ne 0) {
+    throw "Workflow worker restart drill failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Workflow worker restart drill passed." -ForegroundColor Green

--- a/scripts/workflow-worker-restart-drill.py
+++ b/scripts/workflow-worker-restart-drill.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from goal_ops_console.config import Settings
+from goal_ops_console.main import create_app
+
+TERMINAL_STATUSES = {"succeeded", "failed", "timed_out", "cancelled"}
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _wait_for_terminal_run(client: TestClient, run_id: str, timeout_seconds: float) -> dict:
+    deadline = time.time() + max(1.0, float(timeout_seconds))
+    while time.time() < deadline:
+        response = client.get(f"/workflows/runs/{run_id}")
+        if response.status_code == 200:
+            run = response.json()["run"]
+            if str(run["status"]) in TERMINAL_STATUSES:
+                return run
+        time.sleep(0.05)
+    raise RuntimeError(f"Run {run_id} did not reach terminal state in {timeout_seconds}s.")
+
+
+def run_drill(*, timeout_seconds: float) -> dict:
+    app = create_app(
+        Settings(
+            database_url=":memory:",
+            workflow_worker_poll_interval_seconds=0.02,
+            workflow_run_timeout_seconds=60,
+        )
+    )
+
+    with TestClient(app) as client:
+        catalog = client.app.state.services.workflow_catalog
+        catalog.stop_worker()
+
+        readiness_before = client.get("/system/readiness").json()
+        _expect(
+            bool(readiness_before["ready"]) is False,
+            f"Expected readiness false after worker stop, got: {json.dumps(readiness_before, sort_keys=True)}",
+        )
+        _expect(
+            bool(readiness_before["checks"]["workflow_worker"]["is_running"]) is False,
+            "Expected worker to be stopped before restart drill.",
+        )
+
+        started = client.post(
+            "/workflows/maintenance.retention_cleanup/start",
+            json={"requested_by": "worker-restart-drill", "payload": {"source": "drill"}},
+        )
+        _expect(started.status_code == 201, f"Failed to start workflow: {started.text}")
+        run_id = str(started.json()["run"]["run_id"])
+
+        final_run = _wait_for_terminal_run(client, run_id, timeout_seconds=timeout_seconds)
+        readiness_after = client.get("/system/readiness").json()
+        worker_after = readiness_after["checks"]["workflow_worker"]
+
+        success = (
+            final_run["status"] == "succeeded"
+            and bool(readiness_after["ready"])
+            and bool(worker_after["is_running"])
+            and bool(worker_after.get("startup_recovery_ok", True))
+        )
+        _expect(
+            success,
+            (
+                "Workflow worker restart drill failed. "
+                f"final_run={json.dumps(final_run, sort_keys=True)} "
+                f"readiness_before={json.dumps(readiness_before, sort_keys=True)} "
+                f"readiness_after={json.dumps(readiness_after, sort_keys=True)}"
+            ),
+        )
+
+        return {
+            "success": True,
+            "run": {"run_id": run_id, "status": final_run["status"]},
+            "before": {
+                "ready": bool(readiness_before["ready"]),
+                "worker_running": bool(readiness_before["checks"]["workflow_worker"]["is_running"]),
+            },
+            "after": {
+                "ready": bool(readiness_after["ready"]),
+                "worker_running": bool(worker_after["is_running"]),
+                "startup_recovery_ok": bool(worker_after.get("startup_recovery_ok", True)),
+            },
+        }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Stop the workflow worker, then start a workflow run and verify automatic worker restart "
+            "plus successful run completion."
+        )
+    )
+    parser.add_argument("--timeout-seconds", type=float, default=12.0)
+    args = parser.parse_args(argv)
+
+    if float(args.timeout_seconds) <= 0:
+        print("[workflow-worker-restart-drill] ERROR: --timeout-seconds must be > 0.", file=sys.stderr)
+        return 2
+
+    try:
+        report = run_drill(timeout_seconds=float(args.timeout_seconds))
+    except Exception as exc:
+        print(f"[workflow-worker-restart-drill] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1911,3 +1911,75 @@ def test_82_workflow_soak_drill_reports_success():
     assert payload["status_counts"]["succeeded"] == 30
     assert payload["readiness"]["ready"] is True
     assert payload["slo_status"] == "ok"
+
+
+def test_83_start_workflow_restarts_worker_if_stopped(client):
+    catalog = client.app.state.services.workflow_catalog
+    catalog.stop_worker()
+    assert catalog.worker_status()["is_running"] is False
+
+    started = client.post(
+        "/workflows/maintenance.retention_cleanup/start",
+        json={"requested_by": "workflow-test", "payload": {"source": "worker-restart"}},
+    )
+    assert started.status_code == 201
+    run_id = started.json()["run"]["run_id"]
+
+    final_run = _wait_for_run_in_states(
+        client,
+        run_id,
+        {"succeeded", "failed", "timed_out", "cancelled"},
+        timeout_seconds=3.0,
+    )
+    assert final_run["status"] == "succeeded"
+    assert catalog.worker_status()["is_running"] is True
+
+
+def test_84_system_readiness_reports_not_ready_on_startup_recovery_error(client):
+    catalog = client.app.state.services.workflow_catalog
+    catalog.ensure_worker_running()
+    catalog._startup_recovery_state = {
+        "executed": True,
+        "recovered_count": 0,
+        "run_ids": [],
+        "error": "startup recovery failed in test",
+        "at_utc": now_utc(),
+        "max_age_seconds": 0,
+    }
+
+    response = client.get("/system/readiness")
+    assert response.status_code == 200
+    payload = response.json()
+    worker = payload["checks"]["workflow_worker"]
+
+    assert payload["ready"] is False
+    assert worker["is_running"] is True
+    assert worker["ok"] is False
+    assert worker["startup_recovery_ok"] is False
+    assert worker["startup_recovery_error"] == "startup recovery failed in test"
+
+
+def test_85_workflow_worker_restart_drill_reports_success():
+    project_root = Path(__file__).resolve().parents[1]
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "workflow-worker-restart-drill.py"),
+        "--timeout-seconds",
+        "12",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    assert payload["success"] is True
+    assert payload["before"]["ready"] is False
+    assert payload["before"]["worker_running"] is False
+    assert payload["after"]["ready"] is True
+    assert payload["after"]["worker_running"] is True
+    assert payload["run"]["status"] == "succeeded"


### PR DESCRIPTION
﻿## Summary
- add workflow worker self-heal in `WorkflowCatalog.start_workflow()` via `ensure_worker_running()` so enqueued runs recover if the worker thread is down
- add a new deterministic stability drill: `workflow-worker-restart-drill.py` (+ PowerShell wrapper) that stops the worker, starts a workflow, and verifies readiness/run recovery
- make readiness stricter: `workflow_worker.ok` now also requires `startup_recovery_ok=true`; surface `startup_recovery_ok` and `startup_recovery_error`
- integrate the new drill into release gate + CI (`-StrictWorkflowWorkerRestartDrill`)
- extend tests and docs/runbook for the new restart/self-heal path

## Validation
- `python -m pytest -q tests/test_goal_ops.py -k "test_83_start_workflow_restarts_worker_if_stopped or test_84_system_readiness_reports_not_ready_on_startup_recovery_error or test_85_workflow_worker_restart_drill_reports_success"`
- `powershell -ExecutionPolicy Bypass -File .\scripts\release-gate.ps1 -SkipPytest -SkipDesktopSmoke -SkipApiProbe -SkipSloAlertCheck -SkipFileDatabaseProbe -SkipAutoRollbackPolicyDrill -SkipDesktopUpdateSafetyDrill -SkipRecoveryHardAbortDrill -SkipWorkflowLockResilienceDrill -SkipWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -SkipMigrationRehearsal -SkipBackupRestoreDrill -SkipIncidentRollbackDrill`
- `python -m pytest -q`
