### PR TITLE
Stability-first: safe-mode guardrails, recovery drills, and canary gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run release gate
         shell: pwsh
         run: |
-          .\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+          .\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 
   test:
     name: Pytest (Python ${{ matrix.python-version }})

--- a/.github/workflows/stability-canary.yml
+++ b/.github/workflows/stability-canary.yml
@@ -1,0 +1,39 @@
+name: Stability Canary
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  canary:
+    name: Nightly Stability Canary (Windows)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test]"
+
+      - name: Run stability canary
+        shell: pwsh
+        run: |
+          python .\scripts\stability-canary.py --output-file .\artifacts\stability-canary-report.json --long-soak-duration-seconds 120
+
+      - name: Upload canary report
+        uses: actions/upload-artifact@v4
+        with:
+          name: stability-canary-report
+          path: artifacts/stability-canary-report.json
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -388,6 +388,10 @@ Observability endpoints:
 - `GET /system/metrics`
 - `GET /system/audit`
 - `GET /system/slo`
+- `GET /system/safe-mode`
+- `POST /system/safe-mode/enable`
+- `POST /system/safe-mode/disable`
+- `GET /system/invariants`
 - `GET /system/database/integrity?mode=quick|full`
 - `GET /system/faults`
 - `GET /system/faults/summary`
@@ -406,11 +410,11 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + migration state + migration rehearsal on S/M/L/XL DB copies + backup/restore drill + incident/rollback drill under burst load):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + backup/restore drill + incident/rollback drill under burst load):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 ```
 
 Standalone backup/restore drill:
@@ -432,6 +436,13 @@ Standalone auto-rollback policy check (live service):
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-auto-rollback-policy.ps1 -BaseUrl "http://127.0.0.1:8000" -ManifestPath ".\artifacts\desktop-rings.json" -CriticalWindowSeconds 300 -PollIntervalSeconds 30 -MaxObservationSeconds 900
+```
+
+Standalone release-freeze policy check (live service):
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-release-freeze-policy.ps1 -BaseUrl "http://127.0.0.1:8000" -ManifestPath ".\artifacts\desktop-rings.json" -NonOkWindowSeconds 300 -PollIntervalSeconds 30 -MaxObservationSeconds 900
 ```
 
 Standalone desktop-update safety drill:
@@ -469,6 +480,41 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-workflow-worker-restart-drill.ps1
 ```
 
+Standalone event-consumer recovery chaos drill:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-event-consumer-recovery-chaos-drill.ps1
+```
+
+Standalone invariant burst drill:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-invariant-burst-drill.ps1
+```
+
+Standalone long soak budget drill (15-minute default):
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-long-soak-budget-drill.ps1 -DurationSeconds 900
+```
+
+Standalone DB safe-mode watchdog drill:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-db-safe-mode-watchdog-drill.ps1 -LockErrorInjections 4
+```
+
+Standalone invariant monitor watchdog drill:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-invariant-monitor-watchdog-drill.ps1 -TimeoutSeconds 8
+```
+
 Standalone SLO alert check:
 
 ```powershell
@@ -503,6 +549,9 @@ Workflow file:
 Desktop workflow file:
 [desktop-build.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/desktop-build.yml)
 
+Nightly stability canary workflow:
+[stability-canary.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/stability-canary.yml)
+
 Recommended branch protection on `master`:
 
 1. Open repository settings on GitHub.
@@ -519,6 +568,15 @@ Local desktop smoke command:
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 python .\scripts\desktop-smoke.py
+```
+
+## Nightly Stability Canary
+
+Run the full canary profile locally (includes release-freeze policy, watchdog drills, recovery chaos, invariant burst, and long soak budgets):
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+python .\scripts\stability-canary.py --baseline-file .\docs\stability-canary-baseline.json --long-soak-duration-seconds 120 --output-file .\.tmp\stability-canary-report.json
 ```
 
 ## Production Runbook
@@ -660,6 +718,8 @@ If a value is rejected:
 - [run-slo-alert-check.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-slo-alert-check.ps1)
 - [auto-rollback-policy.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/auto-rollback-policy.py)
 - [run-auto-rollback-policy.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-auto-rollback-policy.ps1)
+- [release-freeze-policy.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/release-freeze-policy.py)
+- [run-release-freeze-policy.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-release-freeze-policy.ps1)
 - [desktop-update-safety-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/desktop-update-safety-drill.py)
 - [run-desktop-update-safety-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-desktop-update-safety-drill.ps1)
 - [recovery-hard-abort-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/recovery-hard-abort-drill.py)
@@ -671,6 +731,18 @@ If a value is rejected:
 - [run-workflow-soak-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-workflow-soak-drill.ps1)
 - [workflow-worker-restart-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/workflow-worker-restart-drill.py)
 - [run-workflow-worker-restart-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-workflow-worker-restart-drill.ps1)
+- [event-consumer-recovery-chaos-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/event-consumer-recovery-chaos-drill.py)
+- [run-event-consumer-recovery-chaos-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-event-consumer-recovery-chaos-drill.ps1)
+- [invariant-burst-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/invariant-burst-drill.py)
+- [run-invariant-burst-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-invariant-burst-drill.ps1)
+- [long-soak-budget-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/long-soak-budget-drill.py)
+- [run-long-soak-budget-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-long-soak-budget-drill.ps1)
+- [db-safe-mode-watchdog-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/db-safe-mode-watchdog-drill.py)
+- [run-db-safe-mode-watchdog-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-db-safe-mode-watchdog-drill.ps1)
+- [invariant-monitor-watchdog-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/invariant-monitor-watchdog-drill.py)
+- [run-invariant-monitor-watchdog-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-invariant-monitor-watchdog-drill.ps1)
+- [stability-canary.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/stability-canary.py)
+- [stability-canary-baseline.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/stability-canary-baseline.json)
 - [migration-rehearsal.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/migration-rehearsal.py)
 - [run-migration-rehearsal.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-migration-rehearsal.ps1)
 - [backup-restore-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/backup-restore-drill.py)

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -9,7 +9,7 @@ This runbook is optimized for reliability-first releases of the desktop app and 
 Run in repo root:
 
 ```powershell
-.\scripts\release-gate.ps1 -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 ```
 
 This gate covers:
@@ -17,12 +17,18 @@ This gate covers:
 - desktop smoke boot path
 - `GET /system/readiness`
 - `GET /system/slo` (`status` must be `ok`)
+- release-freeze policy drill (sustained non-ok window or burn-rate spike freezes ring promotion path)
 - auto-rollback-policy drill (`critical` sustained window triggers stable ring rollback path)
 - desktop-update-safety drill (hash validation + rollback-to-stable fallback path)
 - recovery hard-abort drill (kill running worker process, restart, and verify no hanging `running` runs)
 - workflow lock-resilience drill (transient SQLite lock conflicts while worker remains healthy)
 - workflow soak drill (burst enqueue with zero lingering `running` or `queued` runs)
 - workflow worker restart drill (stop worker, enqueue run, and verify self-healing restart path)
+- DB safe-mode watchdog drill (database lock bursts trigger guarded mutating API mode)
+- invariant monitor watchdog drill (periodic invariant scanner detects drift and can force safe mode)
+- event-consumer recovery chaos drill (stale `processing` rows reclaimed and drained to clean `processed` state)
+- invariant burst drill (mixed goal/task state transitions under burst load with zero invariant violations)
+- long soak budget drill (sustained mixed load with latency/429/error budgets enforced)
 - `GET /system/database/integrity?mode=quick|full`
 - schema migration pending-version check (`pending_versions` must be empty)
 - migration rehearsal across small/medium/large/xlarge DB copies with explicit backup/restore/migration runtime thresholds
@@ -39,6 +45,12 @@ Manual auto-rollback policy invocation (live endpoint, stable ring):
 
 ```powershell
 .\scripts\run-auto-rollback-policy.ps1 -BaseUrl "http://127.0.0.1:8000" -ManifestPath ".\artifacts\desktop-rings.json" -CriticalWindowSeconds 300 -PollIntervalSeconds 30 -MaxObservationSeconds 900
+```
+
+Manual release-freeze policy invocation (live endpoint, stable ring):
+
+```powershell
+.\scripts\run-release-freeze-policy.ps1 -BaseUrl "http://127.0.0.1:8000" -ManifestPath ".\artifacts\desktop-rings.json" -NonOkWindowSeconds 300 -PollIntervalSeconds 30 -MaxObservationSeconds 900
 ```
 
 Manual desktop-update safety drill invocation:
@@ -69,6 +81,36 @@ Manual workflow worker restart drill invocation:
 
 ```powershell
 .\scripts\run-workflow-worker-restart-drill.ps1
+```
+
+Manual event-consumer recovery chaos drill invocation:
+
+```powershell
+.\scripts\run-event-consumer-recovery-chaos-drill.ps1
+```
+
+Manual invariant burst drill invocation:
+
+```powershell
+.\scripts\run-invariant-burst-drill.ps1
+```
+
+Manual long soak budget drill invocation (15-minute pre-release profile):
+
+```powershell
+.\scripts\run-long-soak-budget-drill.ps1 -DurationSeconds 900
+```
+
+Manual DB safe-mode watchdog drill invocation:
+
+```powershell
+.\scripts\run-db-safe-mode-watchdog-drill.ps1 -LockErrorInjections 4
+```
+
+Manual invariant monitor watchdog drill invocation:
+
+```powershell
+.\scripts\run-invariant-monitor-watchdog-drill.ps1 -TimeoutSeconds 8
 ```
 
 Verify before release:
@@ -126,6 +168,16 @@ After release is live:
 - Confirm `GET /system/database/integrity?mode=quick` returns `"ok": true`.
 - Trigger `Export Diagnostics` once from Operator Controls and confirm snapshot file exists.
 - Verify one workflow run can be queued and completed from UI.
+
+### 1.6 Nightly stability canary
+
+The scheduled workflow [stability-canary.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/stability-canary.yml) runs a nightly trend check against [stability-canary-baseline.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/stability-canary-baseline.json).
+
+Manual canary invocation:
+
+```powershell
+python .\scripts\stability-canary.py --baseline-file .\docs\stability-canary-baseline.json --long-soak-duration-seconds 120 --output-file .\.tmp\stability-canary-report.json
+```
 
 ## 2. Rollback
 
@@ -223,9 +275,13 @@ Actions:
    ```
 3. If status is `critical`, enforce sustained-window policy check:
    ```powershell
+   .\scripts\run-release-freeze-policy.ps1 -BaseUrl "http://127.0.0.1:8000" -ManifestPath ".\artifacts\desktop-rings.json" -NonOkWindowSeconds 300 -PollIntervalSeconds 30 -MaxObservationSeconds 900
+   ```
+4. If status remains `critical`, enforce sustained-window rollback policy check:
+   ```powershell
    .\scripts\run-auto-rollback-policy.ps1 -BaseUrl "http://127.0.0.1:8000" -ManifestPath ".\artifacts\desktop-rings.json" -CriticalWindowSeconds 300 -PollIntervalSeconds 30 -MaxObservationSeconds 900
    ```
-4. Export diagnostics snapshot and attach to incident ticket.
+5. Export diagnostics snapshot and attach to incident ticket.
 
 ### 3.5 Desktop startup conflicts (single-instance lock)
 
@@ -362,6 +418,112 @@ Actions:
    Invoke-RestMethod http://127.0.0.1:8000/system/readiness
    ```
 3. If drill fails or `startup_recovery_error` is set, block release and escalate with diagnostics snapshot.
+
+### 3.13 Event consumer backlog stuck in `processing`
+
+Symptoms:
+- consumer stats show persistent `processing` rows
+- pending backlog does not shrink despite repeated drain attempts
+
+Actions:
+1. Run event-consumer recovery chaos drill:
+   ```powershell
+   .\scripts\run-event-consumer-recovery-chaos-drill.ps1
+   ```
+2. Verify consumer status no longer includes stale `processing` rows:
+   ```powershell
+   Invoke-RestMethod http://127.0.0.1:8000/system/health
+   ```
+3. If reclaim/drain cannot clear backlog, block rollout and escalate with diagnostics + backlog snapshot.
+
+### 3.14 Queue/goal/task consistency drift after burst activity
+
+Symptoms:
+- dashboard/system health reports invariant violations
+- archived/cancelled goals appear unexpectedly in queue-related views
+
+Actions:
+1. Run invariant burst drill:
+   ```powershell
+   .\scripts\run-invariant-burst-drill.ps1
+   ```
+2. Re-check invariants:
+   ```powershell
+   Invoke-RestMethod http://127.0.0.1:8000/system/health
+   ```
+3. If violations persist, stop promotion and investigate state transition paths before release.
+
+### 3.15 Sustained-load budget regression
+
+Symptoms:
+- throughput appears fine in short tests but degrades in longer sustained runs
+- release candidate shows rising latency, throttling, or server errors under prolonged activity
+
+Actions:
+1. Run long soak budget drill with release profile:
+   ```powershell
+   .\scripts\run-long-soak-budget-drill.ps1 -DurationSeconds 900
+   ```
+2. Confirm budget thresholds stay within limits (`p95 latency`, `HTTP 429 rate`, `error rate`).
+3. If budgets fail, hold release, attach soak JSON output + diagnostics to incident ticket, and require remediation before retry.
+
+### 3.16 Release freeze prevents ring promotion
+
+Symptoms:
+- stable ring promotion command fails with active freeze message
+- `/system/slo` stays non-ok beyond allowed window
+
+Actions:
+1. Inspect freeze state:
+   ```powershell
+   Get-Content .\artifacts\desktop-rings.json
+   ```
+2. Validate current runtime state:
+   ```powershell
+   Invoke-RestMethod http://127.0.0.1:8000/system/slo
+   ```
+3. If freeze should remain active, do not override and keep rollout paused.
+4. If issue is mitigated and override is approved, clear freeze with documented reason:
+   ```powershell
+   .\scripts\manage-desktop-rings.ps1 -ManifestPath ".\artifacts\desktop-rings.json" -Action unfreeze -Reason "Mitigated incident INC-<ID>"
+   ```
+
+### 3.17 Runtime safe mode active (mutations blocked)
+
+Symptoms:
+- mutating API calls return `503` with safe-mode details
+- readiness reports `checks.safe_mode.ok = false`
+
+Actions:
+1. Inspect guard state:
+   ```powershell
+   Invoke-RestMethod http://127.0.0.1:8000/system/safe-mode
+   ```
+2. Run DB safe-mode watchdog drill to verify lock/io handling:
+   ```powershell
+   .\scripts\run-db-safe-mode-watchdog-drill.ps1 -LockErrorInjections 4
+   ```
+3. If cause is mitigated, disable safe mode with operator reason:
+   ```powershell
+   Invoke-RestMethod -Method Post -Uri http://127.0.0.1:8000/system/safe-mode/disable -ContentType "application/json" -Body '{"reason":"Mitigated lock burst"}'
+   ```
+
+### 3.18 Invariant monitor reports violations
+
+Symptoms:
+- readiness reports `checks.invariant_monitor.ok = false`
+- `/system/invariants` returns non-empty violation list
+
+Actions:
+1. Fetch monitor and violation details:
+   ```powershell
+   Invoke-RestMethod http://127.0.0.1:8000/system/invariants
+   ```
+2. Run invariant monitor watchdog drill:
+   ```powershell
+   .\scripts\run-invariant-monitor-watchdog-drill.ps1 -TimeoutSeconds 8
+   ```
+3. If violations persist, keep safe mode enabled and hold promotion until root cause is fixed.
 
 ## 4. Operational Defaults
 

--- a/docs/stability-canary-baseline.json
+++ b/docs/stability-canary-baseline.json
@@ -1,0 +1,25 @@
+{
+  "max_duration_regression_percent": 25.0,
+  "drills": {
+    "release_freeze_policy": {
+      "baseline_duration_seconds": 6.0
+    },
+    "db_safe_mode_watchdog": {
+      "baseline_duration_seconds": 3.0
+    },
+    "invariant_monitor_watchdog": {
+      "baseline_duration_seconds": 6.0
+    },
+    "event_consumer_recovery_chaos": {
+      "baseline_duration_seconds": 8.0
+    },
+    "invariant_burst": {
+      "baseline_duration_seconds": 8.0
+    },
+    "long_soak_budget": {
+      "baseline_duration_seconds": 140.0,
+      "max_http_429_rate_percent": 1.0,
+      "max_error_rate_percent": 1.0
+    }
+  }
+}

--- a/goal_ops_console/config.py
+++ b/goal_ops_console/config.py
@@ -23,6 +23,18 @@ def _env_float(name: str, default: float) -> float:
     except ValueError:
         return default
 
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    value = raw.strip().lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off"}:
+        return False
+    return default
+
 # Skill Selection
 MIN_RUNS = 5
 DEFAULT_BASELINE_SCORE = 0.60
@@ -92,6 +104,40 @@ SLO_MAX_BACKLOG_UTILIZATION_PERCENT = _env_float(
 )
 SLO_MAX_STUCK_EVENTS = _env_int("GOAL_OPS_SLO_MAX_STUCK_EVENTS", 0)
 
+# Runtime Stability Guards
+INVARIANT_MONITOR_INTERVAL_SECONDS = _env_int(
+    "GOAL_OPS_INVARIANT_MONITOR_INTERVAL_SECONDS",
+    30,
+)
+INVARIANT_MONITOR_AUTO_SAFE_MODE = _env_bool(
+    "GOAL_OPS_INVARIANT_MONITOR_AUTO_SAFE_MODE",
+    False,
+)
+SAFE_MODE_LOCK_ERROR_THRESHOLD = _env_int(
+    "GOAL_OPS_SAFE_MODE_LOCK_ERROR_THRESHOLD",
+    6,
+)
+SAFE_MODE_LOCK_ERROR_WINDOW_SECONDS = _env_int(
+    "GOAL_OPS_SAFE_MODE_LOCK_ERROR_WINDOW_SECONDS",
+    60,
+)
+SAFE_MODE_IO_ERROR_THRESHOLD = _env_int(
+    "GOAL_OPS_SAFE_MODE_IO_ERROR_THRESHOLD",
+    2,
+)
+SAFE_MODE_IO_ERROR_WINDOW_SECONDS = _env_int(
+    "GOAL_OPS_SAFE_MODE_IO_ERROR_WINDOW_SECONDS",
+    120,
+)
+SAFE_MODE_AUTO_DISABLE_AFTER_SECONDS = _env_int(
+    "GOAL_OPS_SAFE_MODE_AUTO_DISABLE_AFTER_SECONDS",
+    0,
+)
+IDEMPOTENCY_RETENTION_DAYS = _env_int(
+    "GOAL_OPS_IDEMPOTENCY_RETENTION_DAYS",
+    14,
+)
+
 # The sandbox in this workspace rejects file-backed SQLite locks, so the
 # persistent `goal_ops.db` path should be supplied via GOAL_OPS_DATABASE_URL.
 DEFAULT_DATABASE_URL = os.getenv("GOAL_OPS_DATABASE_URL", ":memory:")
@@ -130,3 +176,11 @@ class Settings:
     slo_max_event_failure_rate_percent: float = SLO_MAX_EVENT_FAILURE_RATE_PERCENT
     slo_max_backlog_utilization_percent: float = SLO_MAX_BACKLOG_UTILIZATION_PERCENT
     slo_max_stuck_events: int = SLO_MAX_STUCK_EVENTS
+    invariant_monitor_interval_seconds: int = INVARIANT_MONITOR_INTERVAL_SECONDS
+    invariant_monitor_auto_safe_mode: bool = INVARIANT_MONITOR_AUTO_SAFE_MODE
+    safe_mode_lock_error_threshold: int = SAFE_MODE_LOCK_ERROR_THRESHOLD
+    safe_mode_lock_error_window_seconds: int = SAFE_MODE_LOCK_ERROR_WINDOW_SECONDS
+    safe_mode_io_error_threshold: int = SAFE_MODE_IO_ERROR_THRESHOLD
+    safe_mode_io_error_window_seconds: int = SAFE_MODE_IO_ERROR_WINDOW_SECONDS
+    safe_mode_auto_disable_after_seconds: int = SAFE_MODE_AUTO_DISABLE_AFTER_SECONDS
+    idempotency_retention_days: int = IDEMPOTENCY_RETENTION_DAYS

--- a/goal_ops_console/database.py
+++ b/goal_ops_console/database.py
@@ -125,6 +125,20 @@ CREATE TABLE IF NOT EXISTS event_processing (
   PRIMARY KEY (event_id, consumer_id)
 );
 
+CREATE TABLE IF NOT EXISTS idempotency_keys (
+  idempotency_key TEXT NOT NULL,
+  method          TEXT NOT NULL,
+  path            TEXT NOT NULL,
+  request_hash    TEXT NOT NULL,
+  response_status INTEGER NOT NULL,
+  response_body   TEXT NOT NULL,
+  created_at      TEXT NOT NULL,
+  updated_at      TEXT NOT NULL,
+  PRIMARY KEY (idempotency_key, method, path)
+);
+CREATE INDEX IF NOT EXISTS idx_idempotency_updated_at
+ON idempotency_keys(updated_at DESC);
+
 CREATE TABLE IF NOT EXISTS ephemeral_state (
   key        TEXT PRIMARY KEY,
   value      TEXT NOT NULL,

--- a/goal_ops_console/event_bus.py
+++ b/goal_ops_console/event_bus.py
@@ -27,6 +27,7 @@ class EventBus:
         events_retention_days: int,
         event_processing_retention_days: int,
         failure_log_retention_days: int,
+        idempotency_retention_days: int,
         observability: "ObservabilityService | None" = None,
     ):
         self.db = db
@@ -37,6 +38,7 @@ class EventBus:
         self.events_retention_days = events_retention_days
         self.event_processing_retention_days = event_processing_retention_days
         self.failure_log_retention_days = failure_log_retention_days
+        self.idempotency_retention_days = idempotency_retention_days
         self.observability = observability
 
     def record_event(
@@ -139,6 +141,11 @@ class EventBus:
                    WHERE created_at < datetime('now', ? || ' days')""",
                 f"-{self.failure_log_retention_days}",
             )
+            idempotency_deleted = tx.execute(
+                """DELETE FROM idempotency_keys
+                   WHERE updated_at < datetime('now', ? || ' days')""",
+                f"-{self.idempotency_retention_days}",
+            )
             if events_deleted:
                 self._metric("maintenance.retention.events_deleted", events_deleted, tx=tx)
             if event_processing_deleted:
@@ -149,10 +156,13 @@ class EventBus:
                 )
             if failures_deleted:
                 self._metric("maintenance.retention.failure_log_deleted", failures_deleted, tx=tx)
+            if idempotency_deleted:
+                self._metric("maintenance.retention.idempotency_deleted", idempotency_deleted, tx=tx)
         return {
             "events_deleted": events_deleted,
             "event_processing_deleted": event_processing_deleted,
             "failure_log_deleted": failures_deleted,
+            "idempotency_deleted": idempotency_deleted,
         }
 
     def list_events(

--- a/goal_ops_console/invariant_monitor.py
+++ b/goal_ops_console/invariant_monitor.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+from typing import Any
+
+from goal_ops_console.database import now_utc
+
+if TYPE_CHECKING:
+    from goal_ops_console.observability import ObservabilityService
+    from goal_ops_console.runtime_guard import RuntimeGuard
+    from goal_ops_console.state_manager import StateManager
+
+
+class InvariantMonitor:
+    def __init__(
+        self,
+        state_manager: "StateManager",
+        *,
+        scan_interval_seconds: int,
+        auto_safe_mode: bool,
+        runtime_guard: "RuntimeGuard | None" = None,
+        observability: "ObservabilityService | None" = None,
+    ):
+        self.state_manager = state_manager
+        self.scan_interval_seconds = max(1, int(scan_interval_seconds))
+        self.auto_safe_mode = bool(auto_safe_mode)
+        self.runtime_guard = runtime_guard
+        self.observability = observability
+
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._state: dict[str, Any] = {
+            "is_running": False,
+            "scan_interval_seconds": self.scan_interval_seconds,
+            "auto_safe_mode": self.auto_safe_mode,
+            "last_scan_at_utc": None,
+            "last_error": None,
+            "violation_count": 0,
+            "violations": [],
+        }
+
+    def start(self) -> None:
+        with self._lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._stop.clear()
+            self._thread = threading.Thread(
+                target=self._loop,
+                daemon=True,
+                name="goal-ops-invariant-monitor",
+            )
+            self._thread.start()
+
+    def stop(self, timeout_seconds: float = 5.0) -> None:
+        with self._lock:
+            thread = self._thread
+            if thread is None:
+                return
+            self._stop.set()
+        thread.join(timeout=timeout_seconds)
+        with self._lock:
+            if self._thread is thread:
+                self._thread = None
+                self._state["is_running"] = False
+
+    def status(self) -> dict[str, Any]:
+        with self._lock:
+            thread = self._thread
+            self._state["is_running"] = bool(thread is not None and thread.is_alive())
+            self._state["scan_interval_seconds"] = self.scan_interval_seconds
+            self._state["auto_safe_mode"] = self.auto_safe_mode
+            return dict(self._state)
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                violations = self.state_manager.find_invariant_violations()
+                with self._lock:
+                    self._state["last_scan_at_utc"] = now_utc()
+                    self._state["last_error"] = None
+                    self._state["violation_count"] = len(violations)
+                    self._state["violations"] = list(violations)
+                    self._state["is_running"] = True
+
+                if violations:
+                    self._metric("invariants.violations.detected", delta=len(violations))
+                    self._audit(
+                        action="system.invariants.detected",
+                        status="error",
+                        details={
+                            "violation_count": len(violations),
+                            "violations": list(violations),
+                        },
+                    )
+                    if self.auto_safe_mode and self.runtime_guard is not None:
+                        self.runtime_guard.activate_safe_mode(
+                            reason=(
+                                "Invariant monitor detected queue/state inconsistencies; "
+                                "safe mode activated."
+                            ),
+                            source="invariant_monitor",
+                            auto=True,
+                        )
+                else:
+                    self._metric("invariants.scan.ok")
+            except Exception as exc:
+                with self._lock:
+                    self._state["last_scan_at_utc"] = now_utc()
+                    self._state["last_error"] = str(exc)
+                    self._state["is_running"] = True
+                self._metric("invariants.scan.errors")
+            self._stop.wait(self.scan_interval_seconds)
+
+    def _metric(self, metric_name: str, delta: int = 1) -> None:
+        if self.observability is None:
+            return
+        self.observability.increment_metric(metric_name, delta=delta)
+
+    def _audit(self, *, action: str, status: str, details: dict[str, Any]) -> None:
+        if self.observability is None:
+            return
+        self.observability.record_audit(
+            action=action,
+            actor="system",
+            status=status,
+            entity_type="invariant_monitor",
+            entity_id="goal_ops_console",
+            correlation_id=None,
+            details=details,
+        )

--- a/goal_ops_console/main.py
+++ b/goal_ops_console/main.py
@@ -1,13 +1,17 @@
+import hashlib
+import json
+import sqlite3
 from contextlib import asynccontextmanager
 from pathlib import Path
 from time import perf_counter
 
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from goal_ops_console.config import Settings
+from goal_ops_console.database import now_utc
 from goal_ops_console.models import DomainError
 from goal_ops_console.routers import events, goals, system, tasks, workflows
 from goal_ops_console.services import build_services
@@ -17,9 +21,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         app.state.services.workflow_catalog.start_worker()
+        app.state.services.invariant_monitor.start()
         try:
             yield
         finally:
+            app.state.services.invariant_monitor.stop()
             app.state.services.workflow_catalog.stop_worker()
 
     app = FastAPI(title="Goal Ops Console", version="0.1.0", lifespan=lifespan)
@@ -41,6 +47,132 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         if route is not None and hasattr(route, "path"):
             return str(route.path)
         return request.url.path
+
+    def allow_idempotency_storage(status_code: int) -> bool:
+        return 200 <= int(status_code) < 500
+
+    @app.middleware("http")
+    async def stability_idempotency_middleware(request: Request, call_next):
+        services = request.app.state.services
+        method = request.method.upper()
+        path = request.url.path
+
+        if services.runtime_guard.should_block_mutation(method=method, path=path):
+            safe_mode = services.runtime_guard.safe_mode_snapshot()
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "detail": "Runtime safe mode active: mutating operations are temporarily blocked.",
+                    "safe_mode": safe_mode,
+                },
+            )
+
+        if method not in {"POST", "PUT", "PATCH", "DELETE"} or path.startswith("/static"):
+            return await call_next(request)
+        if path.startswith("/workflows/") and path.endswith("/start"):
+            # Workflow start has richer domain-level idempotency metadata that we keep intact.
+            return await call_next(request)
+
+        idempotency_key_raw = request.headers.get("Idempotency-Key")
+        if idempotency_key_raw is None:
+            return await call_next(request)
+
+        idempotency_key = idempotency_key_raw.strip()
+        if not idempotency_key:
+            return await call_next(request)
+        if len(idempotency_key) > 120:
+            return JSONResponse(
+                status_code=400,
+                content={"detail": "Idempotency-Key must be 120 characters or fewer."},
+            )
+
+        request_body = await request.body()
+        request_hash = hashlib.sha256(request_body).hexdigest()
+
+        existing = services.db.fetch_one(
+            """SELECT request_hash, response_status, response_body
+               FROM idempotency_keys
+               WHERE idempotency_key = ? AND method = ? AND path = ?""",
+            idempotency_key,
+            method,
+            path,
+        )
+        if existing is not None:
+            if str(existing["request_hash"]) != request_hash:
+                return JSONResponse(
+                    status_code=409,
+                    content={
+                        "detail": (
+                            "Idempotency-Key was already used for a different payload on this endpoint."
+                        )
+                    },
+                )
+            try:
+                replay_payload = json.loads(str(existing["response_body"]))
+            except json.JSONDecodeError:
+                return JSONResponse(
+                    status_code=500,
+                    content={"detail": "Stored idempotency response payload is invalid."},
+                )
+            replay = JSONResponse(
+                status_code=int(existing["response_status"]),
+                content=replay_payload,
+            )
+            replay.headers["X-Idempotency-Replay"] = "true"
+            return replay
+
+        consumed = False
+
+        async def receive() -> dict[str, object]:
+            nonlocal consumed
+            if consumed:
+                return {"type": "http.request", "body": b"", "more_body": False}
+            consumed = True
+            return {"type": "http.request", "body": request_body, "more_body": False}
+
+        replay_request = Request(request.scope, receive)
+        response = await call_next(replay_request)
+
+        content_type = str(response.headers.get("content-type") or "").lower()
+        if "application/json" not in content_type or not allow_idempotency_storage(response.status_code):
+            return response
+
+        body_bytes = getattr(response, "body", None)
+        if body_bytes is None:
+            chunks = [chunk async for chunk in response.body_iterator]
+            body_bytes = b"".join(chunks)
+            response = Response(
+                content=body_bytes,
+                status_code=response.status_code,
+                headers=dict(response.headers),
+                media_type=response.media_type,
+            )
+
+        try:
+            payload = json.loads(body_bytes.decode("utf-8"))
+        except json.JSONDecodeError:
+            return response
+
+        timestamp = now_utc()
+        try:
+            services.db.execute(
+                """INSERT INTO idempotency_keys
+                   (idempotency_key, method, path, request_hash, response_status,
+                    response_body, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                idempotency_key,
+                method,
+                path,
+                request_hash,
+                int(response.status_code),
+                json.dumps(payload, ensure_ascii=True, sort_keys=True),
+                timestamp,
+                timestamp,
+            )
+        except sqlite3.IntegrityError:
+            # Race-safe behavior: another request stored the same key in parallel.
+            pass
+        return response
 
     @app.middleware("http")
     async def observability_middleware(request: Request, call_next):
@@ -96,8 +228,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         return JSONResponse(status_code=exc.status_code, content=content, headers=headers)
 
     @app.exception_handler(Exception)
-    async def handle_unexpected_error(request: Request, _: Exception) -> JSONResponse:
-        request.app.state.services.observability.increment_metric("errors.unhandled")
+    async def handle_unexpected_error(request: Request, exc: Exception) -> JSONResponse:
+        services = request.app.state.services
+        services.observability.increment_metric("errors.unhandled")
+        if isinstance(exc, sqlite3.OperationalError):
+            services.runtime_guard.record_database_error(
+                message=str(exc),
+                source="unhandled_exception",
+            )
         return JSONResponse(status_code=500, content={"detail": "Internal server error"})
 
     return app

--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -115,3 +115,7 @@ class WorkflowStartRequest(BaseModel):
 class WorkflowCancelRequest(BaseModel):
     requested_by: str = Field(default="operator", min_length=1, max_length=120)
     reason: str | None = Field(default=None, max_length=500)
+
+
+class SafeModeToggleRequest(BaseModel):
+    reason: str = Field(default="Operator override", min_length=3, max_length=500)

--- a/goal_ops_console/observability.py
+++ b/goal_ops_console/observability.py
@@ -59,6 +59,10 @@ class ObservabilityService:
             "tasks.created",
             "transition.rejected",
             "backpressure.throttled",
+            "runtime.safe_mode.activated",
+            "runtime.db_errors.lock",
+            "runtime.db_errors.io",
+            "invariants.violations.detected",
         )
         summary: dict[str, int] = {}
         for metric in watched:

--- a/goal_ops_console/routers/system.py
+++ b/goal_ops_console/routers/system.py
@@ -8,7 +8,12 @@ from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
 
 from goal_ops_console.config import CONSUMER_BATCH_SIZE, MAX_TOTAL_RETRIES_PER_CYCLE, SPEC_VERSION
-from goal_ops_console.models import BackpressureError, FaultBulkResolveRequest, FaultRemediationRequest
+from goal_ops_console.models import (
+    BackpressureError,
+    FaultBulkResolveRequest,
+    FaultRemediationRequest,
+    SafeModeToggleRequest,
+)
 from goal_ops_console.services import AppServices, get_services
 
 router = APIRouter(tags=["system"])
@@ -40,6 +45,7 @@ def _build_health_payload(services: AppServices) -> dict[str, Any]:
             "events_days": services.settings.events_retention_days,
             "event_processing_days": services.settings.event_processing_retention_days,
             "failure_log_days": services.settings.failure_log_retention_days,
+            "idempotency_keys_days": services.settings.idempotency_retention_days,
         },
         "metrics": services.observability.metrics_summary(),
         "audit": {
@@ -50,6 +56,8 @@ def _build_health_payload(services: AppServices) -> dict[str, Any]:
         "consumer_stats": services.event_bus.consumer_stats(),
         "stuck_events": services.event_bus.stuck_events(),
         "invariant_violations": services.state_manager.find_invariant_violations(),
+        "invariant_monitor": services.invariant_monitor.status(),
+        "safe_mode": services.runtime_guard.safe_mode_snapshot(),
     }
 
 
@@ -95,8 +103,55 @@ def _build_readiness_payload(services: AppServices) -> dict[str, Any]:
         and worker_error is None
         and startup_recovery_ok
     )
+
+    safe_mode_error: str | None = None
+    safe_mode: dict[str, Any] = {
+        "active": False,
+        "reason": None,
+        "source": None,
+        "auto": False,
+        "activated_at_utc": None,
+        "error_counters": {
+            "lock_errors_in_window": 0,
+            "lock_error_window_seconds": 0,
+            "io_errors_in_window": 0,
+            "io_error_window_seconds": 0,
+        },
+        "thresholds": {
+            "lock_error_threshold": 0,
+            "io_error_threshold": 0,
+            "auto_disable_after_seconds": 0,
+        },
+    }
+    try:
+        safe_mode = services.runtime_guard.safe_mode_snapshot()
+    except Exception as exc:
+        safe_mode_error = str(exc)
+    safe_mode_ok = safe_mode_error is None and not bool(safe_mode.get("active"))
+
+    invariant_monitor_error: str | None = None
+    invariant_monitor: dict[str, Any] = {
+        "is_running": False,
+        "scan_interval_seconds": int(services.settings.invariant_monitor_interval_seconds),
+        "auto_safe_mode": bool(services.settings.invariant_monitor_auto_safe_mode),
+        "last_scan_at_utc": None,
+        "last_error": None,
+        "violation_count": 0,
+        "violations": [],
+    }
+    try:
+        invariant_monitor = services.invariant_monitor.status()
+    except Exception as exc:
+        invariant_monitor_error = str(exc)
+    invariant_monitor_ok = (
+        invariant_monitor_error is None
+        and bool(invariant_monitor.get("is_running"))
+        and int(invariant_monitor.get("violation_count") or 0) == 0
+        and not invariant_monitor.get("last_error")
+    )
+
     return {
-        "ready": bool(db_ok and worker_ok),
+        "ready": bool(db_ok and worker_ok and safe_mode_ok and invariant_monitor_ok),
         "spec_version": SPEC_VERSION,
         "timestamp_utc": _utc_iso(),
         "checks": {
@@ -110,6 +165,16 @@ def _build_readiness_payload(services: AppServices) -> dict[str, Any]:
                 "error": worker_error,
                 "startup_recovery_ok": startup_recovery_ok,
                 "startup_recovery_error": startup_recovery_error,
+            },
+            "safe_mode": {
+                **safe_mode,
+                "ok": safe_mode_ok,
+                "error": safe_mode_error,
+            },
+            "invariant_monitor": {
+                **invariant_monitor,
+                "ok": invariant_monitor_ok,
+                "error": invariant_monitor_error,
             },
         },
     }
@@ -133,6 +198,8 @@ def _status_from_alerts(alerts: list[dict[str, Any]]) -> str:
 
 def _build_slo_payload(services: AppServices) -> dict[str, Any]:
     readiness = _build_readiness_payload(services)
+    safe_mode = readiness["checks"].get("safe_mode", {})
+    invariant_monitor = readiness["checks"].get("invariant_monitor", {})
     db_integrity = services.db.integrity_check(mode="quick")
     backpressure = services.event_bus.backpressure_snapshot()
     stuck_events_count = len(services.event_bus.stuck_events())
@@ -217,6 +284,25 @@ def _build_slo_payload(services: AppServices) -> dict[str, Any]:
             threshold="ok",
         )
 
+    if bool(safe_mode.get("active")):
+        add_alert(
+            "runtime.safe_mode_active",
+            "critical",
+            "Runtime safe mode is active and mutating API operations are restricted.",
+            observed=safe_mode,
+            threshold=False,
+        )
+
+    invariant_violation_count = int(invariant_monitor.get("violation_count") or 0)
+    if invariant_violation_count > 0:
+        add_alert(
+            "invariants.violations_detected",
+            "critical",
+            "Invariant monitor detected queue/state consistency violations.",
+            observed=invariant_violation_count,
+            threshold=0,
+        )
+
     if backlog_utilization_percent >= thresholds["max_backlog_utilization_percent"]:
         severity: Literal["warning", "critical"] = (
             "critical" if bool(backpressure.get("is_throttled")) else "warning"
@@ -287,6 +373,8 @@ def _build_slo_payload(services: AppServices) -> dict[str, Any]:
         "event_failure_rate_percent": event_failure_rate_percent,
         "backlog_utilization_percent": backlog_utilization_percent,
         "stuck_events_count": stuck_events_count,
+        "safe_mode_active": bool(safe_mode.get("active")),
+        "invariant_violation_count": invariant_violation_count,
     }
     return {
         "timestamp_utc": _utc_iso(),
@@ -300,6 +388,8 @@ def _build_slo_payload(services: AppServices) -> dict[str, Any]:
             "readiness": readiness,
             "database_integrity": db_integrity,
             "backpressure": backpressure,
+            "safe_mode": safe_mode,
+            "invariant_monitor": invariant_monitor,
         },
     }
 
@@ -473,6 +563,44 @@ def backpressure_status(services: AppServices = Depends(get_services)) -> dict:
     return services.event_bus.backpressure_snapshot()
 
 
+@router.get("/system/safe-mode")
+def safe_mode_status(services: AppServices = Depends(get_services)) -> dict:
+    return services.runtime_guard.safe_mode_snapshot()
+
+
+@router.post("/system/safe-mode/enable")
+def enable_safe_mode(
+    request: SafeModeToggleRequest,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return services.runtime_guard.activate_safe_mode(
+        reason=request.reason,
+        source="operator",
+        auto=False,
+    )
+
+
+@router.post("/system/safe-mode/disable")
+def disable_safe_mode(
+    request: SafeModeToggleRequest,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return services.runtime_guard.deactivate_safe_mode(
+        reason=request.reason,
+        source="operator",
+    )
+
+
+@router.get("/system/invariants")
+def invariants_status(services: AppServices = Depends(get_services)) -> dict:
+    monitor = services.invariant_monitor.status()
+    return {
+        "timestamp_utc": _utc_iso(),
+        "monitor": monitor,
+        "violations": services.state_manager.find_invariant_violations(),
+    }
+
+
 @router.get("/system/metrics")
 def metrics_status(
     prefix: str | None = None,
@@ -617,5 +745,6 @@ def run_retention_cleanup(services: AppServices = Depends(get_services)) -> dict
             "events": services.settings.events_retention_days,
             "event_processing": services.settings.event_processing_retention_days,
             "failure_log": services.settings.failure_log_retention_days,
+            "idempotency_keys": services.settings.idempotency_retention_days,
         },
     }

--- a/goal_ops_console/runtime_guard.py
+++ b/goal_ops_console/runtime_guard.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import time
+from collections import deque
+from threading import Lock
+from typing import TYPE_CHECKING
+from typing import Any
+
+from goal_ops_console.database import now_utc
+
+if TYPE_CHECKING:
+    from goal_ops_console.observability import ObservabilityService
+
+MUTATING_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+
+
+class RuntimeGuard:
+    def __init__(
+        self,
+        *,
+        lock_error_threshold: int,
+        lock_error_window_seconds: int,
+        io_error_threshold: int,
+        io_error_window_seconds: int,
+        auto_disable_after_seconds: int,
+        observability: "ObservabilityService | None" = None,
+    ):
+        self.lock_error_threshold = max(1, int(lock_error_threshold))
+        self.lock_error_window_seconds = max(1, int(lock_error_window_seconds))
+        self.io_error_threshold = max(1, int(io_error_threshold))
+        self.io_error_window_seconds = max(1, int(io_error_window_seconds))
+        self.auto_disable_after_seconds = max(0, int(auto_disable_after_seconds))
+        self.observability = observability
+
+        self._lock = Lock()
+        self._lock_errors = deque()
+        self._io_errors = deque()
+        self._safe_mode_active = False
+        self._safe_mode_reason: str | None = None
+        self._safe_mode_source: str | None = None
+        self._safe_mode_activated_at_utc: str | None = None
+        self._safe_mode_activated_monotonic: float | None = None
+        self._safe_mode_auto = False
+
+    def _prune_locked(self, now_monotonic: float) -> None:
+        lock_cutoff = now_monotonic - float(self.lock_error_window_seconds)
+        io_cutoff = now_monotonic - float(self.io_error_window_seconds)
+        while self._lock_errors and self._lock_errors[0] < lock_cutoff:
+            self._lock_errors.popleft()
+        while self._io_errors and self._io_errors[0] < io_cutoff:
+            self._io_errors.popleft()
+
+    def _auto_disable_if_due_locked(self) -> None:
+        if (
+            not self._safe_mode_active
+            or self.auto_disable_after_seconds <= 0
+            or self._safe_mode_activated_monotonic is None
+        ):
+            return
+        elapsed = time.monotonic() - self._safe_mode_activated_monotonic
+        if elapsed < float(self.auto_disable_after_seconds):
+            return
+        self._safe_mode_active = False
+        self._safe_mode_reason = "Auto-disabled after safety cooldown window."
+        self._safe_mode_source = "runtime_guard"
+        self._safe_mode_auto = True
+        self._safe_mode_activated_at_utc = None
+        self._safe_mode_activated_monotonic = None
+        self._metric("runtime.safe_mode.auto_disabled")
+        self._audit(
+            action="runtime.safe_mode.auto_disable",
+            status="success",
+            details={"auto_disable_after_seconds": self.auto_disable_after_seconds},
+        )
+
+    def safe_mode_snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            self._auto_disable_if_due_locked()
+            now_monotonic = time.monotonic()
+            self._prune_locked(now_monotonic)
+            return {
+                "active": bool(self._safe_mode_active),
+                "reason": self._safe_mode_reason,
+                "source": self._safe_mode_source,
+                "auto": bool(self._safe_mode_auto),
+                "activated_at_utc": self._safe_mode_activated_at_utc,
+                "error_counters": {
+                    "lock_errors_in_window": len(self._lock_errors),
+                    "lock_error_window_seconds": self.lock_error_window_seconds,
+                    "io_errors_in_window": len(self._io_errors),
+                    "io_error_window_seconds": self.io_error_window_seconds,
+                },
+                "thresholds": {
+                    "lock_error_threshold": self.lock_error_threshold,
+                    "io_error_threshold": self.io_error_threshold,
+                    "auto_disable_after_seconds": self.auto_disable_after_seconds,
+                },
+            }
+
+    def is_safe_mode_active(self) -> bool:
+        return bool(self.safe_mode_snapshot()["active"])
+
+    def activate_safe_mode(
+        self,
+        *,
+        reason: str,
+        source: str,
+        auto: bool = True,
+    ) -> dict[str, Any]:
+        normalized_reason = reason.strip() or "Safe mode activated."
+        normalized_source = source.strip() or "system"
+        with self._lock:
+            self._safe_mode_active = True
+            self._safe_mode_reason = normalized_reason
+            self._safe_mode_source = normalized_source
+            self._safe_mode_auto = bool(auto)
+            self._safe_mode_activated_at_utc = now_utc()
+            self._safe_mode_activated_monotonic = time.monotonic()
+        self._metric("runtime.safe_mode.activated")
+        self._audit(
+            action="runtime.safe_mode.activate",
+            status="error",
+            details={
+                "reason": normalized_reason,
+                "source": normalized_source,
+                "auto": bool(auto),
+            },
+        )
+        return self.safe_mode_snapshot()
+
+    def deactivate_safe_mode(
+        self,
+        *,
+        reason: str,
+        source: str = "operator",
+    ) -> dict[str, Any]:
+        normalized_reason = reason.strip() or "Safe mode disabled."
+        normalized_source = source.strip() or "operator"
+        with self._lock:
+            self._safe_mode_active = False
+            self._safe_mode_reason = normalized_reason
+            self._safe_mode_source = normalized_source
+            self._safe_mode_auto = False
+            self._safe_mode_activated_at_utc = None
+            self._safe_mode_activated_monotonic = None
+        self._metric("runtime.safe_mode.deactivated")
+        self._audit(
+            action="runtime.safe_mode.deactivate",
+            status="success",
+            details={"reason": normalized_reason, "source": normalized_source},
+        )
+        return self.safe_mode_snapshot()
+
+    def should_block_mutation(self, *, method: str, path: str) -> bool:
+        if method.upper() not in MUTATING_METHODS:
+            return False
+        if not self.is_safe_mode_active():
+            return False
+        normalized = path.strip()
+        if normalized == "/system/diagnostics":
+            return False
+        if normalized.startswith("/system/safe-mode/"):
+            return False
+        if normalized.startswith("/system/consumers/") and (
+            normalized.endswith("/drain") or normalized.endswith("/reclaim")
+        ):
+            return False
+        return True
+
+    def record_database_error(self, *, message: str, source: str = "api") -> dict[str, Any]:
+        text = message.strip().lower()
+        now_monotonic = time.monotonic()
+        category = None
+        with self._lock:
+            self._auto_disable_if_due_locked()
+            if (
+                "database is locked" in text
+                or "database table is locked" in text
+                or "database schema is locked" in text
+            ):
+                self._lock_errors.append(now_monotonic)
+                category = "lock"
+            elif (
+                "disk i/o error" in text
+                or "database or disk is full" in text
+                or "i/o error" in text
+            ):
+                self._io_errors.append(now_monotonic)
+                category = "io"
+
+            self._prune_locked(now_monotonic)
+            lock_count = len(self._lock_errors)
+            io_count = len(self._io_errors)
+
+        if category == "lock":
+            self._metric("runtime.db_errors.lock")
+        elif category == "io":
+            self._metric("runtime.db_errors.io")
+        else:
+            self._metric("runtime.db_errors.other")
+            return self.safe_mode_snapshot()
+
+        should_activate = (
+            (category == "lock" and lock_count >= self.lock_error_threshold)
+            or (category == "io" and io_count >= self.io_error_threshold)
+        )
+        if should_activate and not self.is_safe_mode_active():
+            threshold = (
+                self.lock_error_threshold if category == "lock" else self.io_error_threshold
+            )
+            window_seconds = (
+                self.lock_error_window_seconds if category == "lock" else self.io_error_window_seconds
+            )
+            self.activate_safe_mode(
+                reason=(
+                    f"Detected {category} database error burst "
+                    f"({threshold}+ errors in {window_seconds}s window)."
+                ),
+                source=source,
+                auto=True,
+            )
+        return self.safe_mode_snapshot()
+
+    def _metric(self, metric_name: str, delta: int = 1) -> None:
+        if self.observability is None:
+            return
+        self.observability.increment_metric(metric_name, delta=delta)
+
+    def _audit(self, *, action: str, status: str, details: dict[str, Any]) -> None:
+        if self.observability is None:
+            return
+        self.observability.record_audit(
+            action=action,
+            actor="system",
+            status=status,
+            entity_type="runtime_guard",
+            entity_id="safe_mode",
+            correlation_id=None,
+            details=details,
+        )

--- a/goal_ops_console/services.py
+++ b/goal_ops_console/services.py
@@ -7,7 +7,9 @@ from goal_ops_console.database import Database
 from goal_ops_console.event_bus import EventBus
 from goal_ops_console.execution_layer import ExecutionLayer
 from goal_ops_console.failure_intelligence import FailureIntelligence
+from goal_ops_console.invariant_monitor import InvariantMonitor
 from goal_ops_console.observability import ObservabilityService
+from goal_ops_console.runtime_guard import RuntimeGuard
 from goal_ops_console.scheduler import SchedulerService
 from goal_ops_console.state_manager import StateManager
 from goal_ops_console.stubs import PermissionManager, Planner, QdrantClientStub
@@ -25,6 +27,8 @@ class AppServices:
     failure_intelligence: FailureIntelligence
     scheduler: SchedulerService
     workflow_catalog: WorkflowCatalog
+    runtime_guard: RuntimeGuard
+    invariant_monitor: InvariantMonitor
     qdrant: QdrantClientStub
     planner: Planner
     permission_manager: PermissionManager
@@ -38,6 +42,14 @@ def build_services(settings: Settings | None = None) -> AppServices:
     )
     db.initialize()
     observability = ObservabilityService(db)
+    runtime_guard = RuntimeGuard(
+        lock_error_threshold=app_settings.safe_mode_lock_error_threshold,
+        lock_error_window_seconds=app_settings.safe_mode_lock_error_window_seconds,
+        io_error_threshold=app_settings.safe_mode_io_error_threshold,
+        io_error_window_seconds=app_settings.safe_mode_io_error_window_seconds,
+        auto_disable_after_seconds=app_settings.safe_mode_auto_disable_after_seconds,
+        observability=observability,
+    )
     event_bus = EventBus(
         db,
         default_consumer_id=app_settings.consumer_id,
@@ -46,6 +58,7 @@ def build_services(settings: Settings | None = None) -> AppServices:
         events_retention_days=app_settings.events_retention_days,
         event_processing_retention_days=app_settings.event_processing_retention_days,
         failure_log_retention_days=app_settings.failure_log_retention_days,
+        idempotency_retention_days=app_settings.idempotency_retention_days,
         observability=observability,
     )
     state_manager = StateManager(
@@ -74,6 +87,13 @@ def build_services(settings: Settings | None = None) -> AppServices:
         startup_recovery_max_age_seconds=app_settings.workflow_startup_recovery_max_age_seconds,
         observability=observability,
     )
+    invariant_monitor = InvariantMonitor(
+        state_manager,
+        scan_interval_seconds=app_settings.invariant_monitor_interval_seconds,
+        auto_safe_mode=app_settings.invariant_monitor_auto_safe_mode,
+        runtime_guard=runtime_guard,
+        observability=observability,
+    )
     return AppServices(
         settings=app_settings,
         db=db,
@@ -84,6 +104,8 @@ def build_services(settings: Settings | None = None) -> AppServices:
         failure_intelligence=failure_intelligence,
         scheduler=scheduler,
         workflow_catalog=workflow_catalog,
+        runtime_guard=runtime_guard,
+        invariant_monitor=invariant_monitor,
         qdrant=QdrantClientStub(),
         planner=Planner(),
         permission_manager=PermissionManager(),

--- a/scripts/db-safe-mode-watchdog-drill.py
+++ b/scripts/db-safe-mode-watchdog-drill.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from goal_ops_console.config import Settings
+from goal_ops_console.main import create_app
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def run_drill(*, lock_error_injections: int) -> dict:
+    app = create_app(
+        Settings(
+            database_url=":memory:",
+            safe_mode_lock_error_threshold=3,
+            safe_mode_lock_error_window_seconds=60,
+        )
+    )
+
+    with TestClient(app) as client:
+        guard = client.app.state.services.runtime_guard
+        initial = client.get("/system/safe-mode").json()
+        _expect(initial["active"] is False, f"Safe mode unexpectedly active: {json.dumps(initial, sort_keys=True)}")
+
+        for _ in range(max(1, int(lock_error_injections))):
+            guard.record_database_error(
+                message="database table is locked: goals",
+                source="safe_mode_watchdog_drill",
+            )
+            time.sleep(0.01)
+
+        active = client.get("/system/safe-mode").json()
+        _expect(active["active"] is True, f"Safe mode was not activated: {json.dumps(active, sort_keys=True)}")
+
+        blocked = client.post(
+            "/goals",
+            json={
+                "title": "Should be blocked",
+                "description": "safe mode drill",
+                "urgency": 0.5,
+                "value": 0.5,
+                "deadline_score": 0.2,
+            },
+        )
+        _expect(
+            blocked.status_code == 503,
+            f"Mutating endpoint was not blocked in safe mode: status={blocked.status_code} body={blocked.text}",
+        )
+
+        reclaim = client.post("/system/consumers/drill/reclaim")
+        _expect(
+            reclaim.status_code == 200,
+            f"Allowed reclaim endpoint failed in safe mode: status={reclaim.status_code} body={reclaim.text}",
+        )
+
+        disable = client.post(
+            "/system/safe-mode/disable",
+            json={"reason": "Drill cleanup"},
+        )
+        _expect(
+            disable.status_code == 200,
+            f"Failed to disable safe mode after drill: status={disable.status_code} body={disable.text}",
+        )
+        after_disable = client.get("/system/safe-mode").json()
+        _expect(
+            after_disable["active"] is False,
+            f"Safe mode remained active after disable: {json.dumps(after_disable, sort_keys=True)}",
+        )
+
+        unblocked = client.post(
+            "/goals",
+            json={
+                "title": "Allowed after safe mode",
+                "description": "safe mode drill",
+                "urgency": 0.5,
+                "value": 0.5,
+                "deadline_score": 0.2,
+            },
+        )
+        _expect(
+            unblocked.status_code == 201,
+            f"Mutating endpoint stayed blocked after safe mode disable: status={unblocked.status_code} body={unblocked.text}",
+        )
+
+        return {
+            "success": True,
+            "lock_error_injections": int(lock_error_injections),
+            "safe_mode_active_after_injection": bool(active["active"]),
+            "blocked_status_code": int(blocked.status_code),
+            "allowed_reclaim_status_code": int(reclaim.status_code),
+            "safe_mode_active_after_disable": bool(after_disable["active"]),
+            "post_disable_goal_create_status_code": int(unblocked.status_code),
+        }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Watchdog drill for DB lock bursts: trigger runtime safe mode, verify mutating API block, "
+            "ensure diagnostics/reclaim path remains available, then recover."
+        )
+    )
+    parser.add_argument("--lock-error-injections", type=int, default=4)
+    args = parser.parse_args(argv)
+
+    if int(args.lock_error_injections) <= 0:
+        print("[db-safe-mode-watchdog-drill] ERROR: --lock-error-injections must be > 0.", file=sys.stderr)
+        return 2
+
+    try:
+        report = run_drill(lock_error_injections=int(args.lock_error_injections))
+    except Exception as exc:
+        print(f"[db-safe-mode-watchdog-drill] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/event-consumer-recovery-chaos-drill.py
+++ b/scripts/event-consumer-recovery-chaos-drill.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from goal_ops_console.config import Settings
+from goal_ops_console.main import create_app
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _pending_event_ids(client: TestClient, consumer_id: str) -> list[str]:
+    rows = client.app.state.services.db.fetch_all(
+        """SELECT e.event_id
+           FROM events e
+           LEFT JOIN event_processing ep
+             ON e.event_id = ep.event_id AND ep.consumer_id = ?
+           WHERE ep.event_id IS NULL OR ep.status IN ('pending', 'failed', 'processing')
+           ORDER BY e.seq ASC""",
+        consumer_id,
+    )
+    return [str(row["event_id"]) for row in rows]
+
+
+def _stale_processing_count(client: TestClient, consumer_id: str) -> int:
+    rows = client.app.state.services.event_bus.stuck_events()
+    return sum(1 for row in rows if str(row.get("consumer_id")) == consumer_id)
+
+
+def run_drill(
+    *,
+    goal_count: int,
+    stale_processing_count: int,
+    consumer_id: str,
+    drain_batch_size: int,
+    timeout_seconds: float,
+) -> dict:
+    app = create_app(Settings(database_url=":memory:"))
+
+    with TestClient(app) as client:
+        baseline_seq = int(
+            client.app.state.services.db.fetch_scalar("SELECT COALESCE(MAX(seq), 0) FROM events") or 0
+        )
+        goal_ids: list[str] = []
+        for index in range(int(goal_count)):
+            created = client.post(
+                "/goals",
+                json={
+                    "title": f"Consumer chaos goal {index}",
+                    "description": "event consumer recovery drill",
+                    "urgency": 0.4,
+                    "value": 0.7,
+                    "deadline_score": 0.2,
+                },
+            )
+            _expect(created.status_code == 201, f"Goal creation failed at index={index}: {created.text}")
+            goal_id = str(created.json()["goal_id"])
+            goal_ids.append(goal_id)
+
+            activated = client.post(f"/goals/{goal_id}/activate")
+            _expect(activated.status_code == 200, f"Goal activation failed for {goal_id}: {activated.text}")
+
+            task = client.post(
+                "/tasks",
+                json={"goal_id": goal_id, "title": f"Consumer chaos task {index}"},
+            )
+            _expect(task.status_code == 201, f"Task creation failed for {goal_id}: {task.text}")
+
+        generated_rows = client.app.state.services.db.fetch_all(
+            "SELECT event_id FROM events WHERE seq > ? ORDER BY seq ASC",
+            baseline_seq,
+        )
+        generated_event_ids = [str(row["event_id"]) for row in generated_rows]
+        _expect(generated_event_ids, "Drill generated no events.")
+
+        stale_target = min(max(1, int(stale_processing_count)), len(generated_event_ids))
+        stale_ids = generated_event_ids[:stale_target]
+        for event_id in stale_ids:
+            client.app.state.services.db.execute(
+                """INSERT INTO event_processing
+                   (event_id, consumer_id, status, processing_started_at, processed_at, version)
+                   VALUES (?, ?, 'processing', datetime('now', '-120 seconds'), NULL, 1)
+                   ON CONFLICT(event_id, consumer_id) DO UPDATE
+                     SET status = 'processing',
+                         processing_started_at = datetime('now', '-120 seconds'),
+                         processed_at = NULL,
+                         version = event_processing.version + 1""",
+                event_id,
+                consumer_id,
+            )
+
+        stale_before = _stale_processing_count(client, consumer_id)
+        _expect(
+            stale_before >= stale_target,
+            (
+                "Expected stale processing rows before recovery. "
+                f"stale_before={stale_before} stale_target={stale_target}"
+            ),
+        )
+
+        reclaim = client.post(f"/system/consumers/{consumer_id}/reclaim")
+        _expect(reclaim.status_code == 200, f"Consumer reclaim failed: {reclaim.text}")
+        reclaimed_count = int(reclaim.json()["reclaimed_count"])
+        _expect(
+            reclaimed_count >= stale_target,
+            (
+                "Reclaim did not recover expected stale rows. "
+                f"reclaimed_count={reclaimed_count} stale_target={stale_target}"
+            ),
+        )
+
+        processed_total = 0
+        deadline = time.time() + max(1.0, float(timeout_seconds))
+        while time.time() < deadline:
+            pending = _pending_event_ids(client, consumer_id)
+            if not pending:
+                break
+            drained = client.post(
+                f"/system/consumers/{consumer_id}/drain",
+                params={"batch_size": int(drain_batch_size)},
+            )
+            _expect(drained.status_code == 200, f"Consumer drain failed: {drained.text}")
+            processed_total += int(drained.json()["processed_count"])
+            time.sleep(0.02)
+
+        pending_after = _pending_event_ids(client, consumer_id)
+        _expect(
+            not pending_after,
+            (
+                "Pending events remain after recovery drill. "
+                f"pending_count={len(pending_after)} pending_sample={pending_after[:10]}"
+            ),
+        )
+
+        status_rows = client.app.state.services.db.fetch_all(
+            """SELECT status, COUNT(*) AS count
+               FROM event_processing
+               WHERE consumer_id = ?
+               GROUP BY status
+               ORDER BY status ASC""",
+            consumer_id,
+        )
+        status_counts = {str(row["status"]): int(row["count"]) for row in status_rows}
+        _expect(status_counts.get("processing", 0) == 0, f"Processing rows still stuck: {status_counts}")
+        _expect(status_counts.get("failed", 0) == 0, f"Failed rows remain after recovery: {status_counts}")
+        _expect(
+            status_counts.get("processed", 0) >= len(generated_event_ids),
+            (
+                "Not all generated events reached processed state. "
+                f"processed={status_counts.get('processed', 0)} generated={len(generated_event_ids)}"
+            ),
+        )
+
+        readiness = client.get("/system/readiness").json()
+        slo = client.get("/system/slo").json()
+        _expect(bool(readiness["ready"]), f"Readiness is false after drill: {json.dumps(readiness, sort_keys=True)}")
+        _expect(str(slo["status"]) == "ok", f"SLO is not ok after drill: {json.dumps(slo, sort_keys=True)}")
+
+        return {
+            "success": True,
+            "goal_count": int(goal_count),
+            "generated_events": len(generated_event_ids),
+            "consumer_id": consumer_id,
+            "stale_processing_target": stale_target,
+            "stale_processing_before_reclaim": stale_before,
+            "reclaimed_count": reclaimed_count,
+            "drain_batch_size": int(drain_batch_size),
+            "processed_total": processed_total,
+            "status_counts": status_counts,
+            "readiness_ready": bool(readiness["ready"]),
+            "slo_status": str(slo["status"]),
+        }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Chaos drill for event consumer recovery: seed stale processing rows, reclaim, drain backlog, "
+            "and verify clean processed state."
+        )
+    )
+    parser.add_argument("--goal-count", type=int, default=40)
+    parser.add_argument("--stale-processing-count", type=int, default=15)
+    parser.add_argument("--consumer-id", default="chaos-recovery")
+    parser.add_argument("--drain-batch-size", type=int, default=100)
+    parser.add_argument("--timeout-seconds", type=float, default=20.0)
+    args = parser.parse_args(argv)
+
+    if int(args.goal_count) <= 0:
+        print("[event-consumer-recovery-chaos-drill] ERROR: --goal-count must be > 0.", file=sys.stderr)
+        return 2
+    if int(args.stale_processing_count) <= 0:
+        print(
+            "[event-consumer-recovery-chaos-drill] ERROR: --stale-processing-count must be > 0.",
+            file=sys.stderr,
+        )
+        return 2
+    if int(args.drain_batch_size) <= 0:
+        print("[event-consumer-recovery-chaos-drill] ERROR: --drain-batch-size must be > 0.", file=sys.stderr)
+        return 2
+    if float(args.timeout_seconds) <= 0:
+        print("[event-consumer-recovery-chaos-drill] ERROR: --timeout-seconds must be > 0.", file=sys.stderr)
+        return 2
+
+    try:
+        report = run_drill(
+            goal_count=int(args.goal_count),
+            stale_processing_count=int(args.stale_processing_count),
+            consumer_id=str(args.consumer_id),
+            drain_batch_size=int(args.drain_batch_size),
+            timeout_seconds=float(args.timeout_seconds),
+        )
+    except Exception as exc:
+        print(f"[event-consumer-recovery-chaos-drill] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/invariant-burst-drill.py
+++ b/scripts/invariant-burst-drill.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from goal_ops_console.config import Settings
+from goal_ops_console.main import create_app
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def run_drill(*, goal_count: int) -> dict:
+    app = create_app(Settings(database_url=":memory:"))
+
+    with TestClient(app) as client:
+        counters = {
+            "goals_created": 0,
+            "tasks_created": 0,
+            "tasks_succeeded": 0,
+            "tasks_failed": 0,
+            "goals_archived": 0,
+        }
+
+        for index in range(int(goal_count)):
+            created = client.post(
+                "/goals",
+                json={
+                    "title": f"Invariant burst goal {index}",
+                    "description": "queue/goal/task invariant burst drill",
+                    "urgency": 0.5,
+                    "value": 0.6,
+                    "deadline_score": 0.3,
+                },
+            )
+            _expect(created.status_code == 201, f"Goal create failed at index={index}: {created.text}")
+            goal_id = str(created.json()["goal_id"])
+            counters["goals_created"] += 1
+
+            if index % 10 == 0:
+                age = client.post("/system/scheduler/age")
+                _expect(age.status_code == 200, f"Scheduler age failed at index={index}: {age.text}")
+                pick = client.post("/system/scheduler/pick")
+                _expect(pick.status_code == 200, f"Scheduler pick failed at index={index}: {pick.text}")
+
+            activate = client.post(f"/goals/{goal_id}/activate")
+            if activate.status_code == 409:
+                goal = client.get(f"/goals/{goal_id}")
+                _expect(goal.status_code == 200, f"Goal fetch failed for {goal_id}: {goal.text}")
+                _expect(
+                    str(goal.json().get("state")) == "active",
+                    f"Goal activate conflict did not end in active state for {goal_id}: {activate.text}",
+                )
+            else:
+                _expect(activate.status_code == 200, f"Goal activate failed for {goal_id}: {activate.text}")
+
+            task = client.post(
+                "/tasks",
+                json={"goal_id": goal_id, "title": f"Invariant burst task {index}"},
+            )
+            _expect(task.status_code == 201, f"Task create failed for goal {goal_id}: {task.text}")
+            task_id = str(task.json()["task_id"])
+            counters["tasks_created"] += 1
+
+            scenario = index % 3
+            if scenario == 0:
+                success = client.post(f"/tasks/{task_id}/success")
+                _expect(success.status_code == 200, f"Task success failed for {task_id}: {success.text}")
+                counters["tasks_succeeded"] += 1
+                block = client.post(f"/goals/{goal_id}/block")
+                _expect(block.status_code == 200, f"Goal block failed for {goal_id}: {block.text}")
+                archive = client.post(f"/goals/{goal_id}/archive")
+                _expect(archive.status_code == 200, f"Goal archive failed for {goal_id}: {archive.text}")
+                counters["goals_archived"] += 1
+                continue
+
+            if scenario == 1:
+                for attempt in range(2):
+                    failed = client.post(
+                        f"/tasks/{task_id}/fail",
+                        json={
+                            "failure_type": "SkillFailure",
+                            "error_message": f"invariant burst poison attempt {attempt}",
+                        },
+                    )
+                    _expect(
+                        failed.status_code == 200,
+                        f"Skill failure attempt {attempt} failed for {task_id}: {failed.text}",
+                    )
+                    counters["tasks_failed"] += 1
+
+                approve = client.post(f"/goals/{goal_id}/hitl_approve")
+                _expect(approve.status_code == 200, f"HITL approve failed for {goal_id}: {approve.text}")
+                block = client.post(f"/goals/{goal_id}/block")
+                _expect(block.status_code == 200, f"Goal block failed for {goal_id}: {block.text}")
+                archive = client.post(f"/goals/{goal_id}/archive")
+                _expect(archive.status_code == 200, f"Goal archive failed for {goal_id}: {archive.text}")
+                counters["goals_archived"] += 1
+                continue
+
+            for attempt in range(3):
+                failed = client.post(
+                    f"/tasks/{task_id}/fail",
+                    json={
+                        "failure_type": "ExecutionFailure",
+                        "error_message": f"invariant burst exhausted attempt {attempt}",
+                    },
+                )
+                _expect(
+                    failed.status_code == 200,
+                    f"Execution failure attempt {attempt} failed for {task_id}: {failed.text}",
+                )
+                counters["tasks_failed"] += 1
+            archive = client.post(f"/goals/{goal_id}/archive")
+            _expect(archive.status_code == 200, f"Goal archive failed for {goal_id}: {archive.text}")
+            counters["goals_archived"] += 1
+
+        health = client.get("/system/health")
+        _expect(health.status_code == 200, f"System health failed: {health.text}")
+        health_payload = health.json()
+        health_violations = list(health_payload.get("invariant_violations") or [])
+
+        direct_violations = client.app.state.services.state_manager.find_invariant_violations()
+        _expect(
+            not direct_violations and not health_violations,
+            (
+                "Invariant violations detected. "
+                f"direct={json.dumps(direct_violations, sort_keys=True)} "
+                f"health={json.dumps(health_violations, sort_keys=True)}"
+            ),
+        )
+
+        queue_size = int(client.app.state.services.db.fetch_scalar("SELECT COUNT(*) FROM goal_queue") or 0)
+        readiness = client.get("/system/readiness").json()
+        _expect(bool(readiness["ready"]), f"Readiness is false: {json.dumps(readiness, sort_keys=True)}")
+
+        return {
+            "success": True,
+            "goal_count": int(goal_count),
+            "counters": counters,
+            "queue_size": queue_size,
+            "invariant_violations": {
+                "direct": direct_violations,
+                "health": health_violations,
+            },
+            "readiness_ready": bool(readiness["ready"]),
+        }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Burst drill for queue/goal/task consistency: execute mixed transition paths and verify "
+            "no invariant violations."
+        )
+    )
+    parser.add_argument("--goal-count", type=int, default=45)
+    args = parser.parse_args(argv)
+
+    if int(args.goal_count) <= 0:
+        print("[invariant-burst-drill] ERROR: --goal-count must be > 0.", file=sys.stderr)
+        return 2
+
+    try:
+        report = run_drill(goal_count=int(args.goal_count))
+    except Exception as exc:
+        print(f"[invariant-burst-drill] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/invariant-monitor-watchdog-drill.py
+++ b/scripts/invariant-monitor-watchdog-drill.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from goal_ops_console.config import Settings
+from goal_ops_console.database import new_id, now_utc
+from goal_ops_console.main import create_app
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def run_drill(*, timeout_seconds: float) -> dict:
+    app = create_app(
+        Settings(
+            database_url=":memory:",
+            invariant_monitor_interval_seconds=1,
+            invariant_monitor_auto_safe_mode=True,
+        )
+    )
+
+    with TestClient(app) as client:
+        monitor_before = client.get("/system/invariants").json()["monitor"]
+        _expect(bool(monitor_before["is_running"]), f"Invariant monitor is not running: {monitor_before}")
+
+        goal_id = new_id()
+        timestamp = now_utc()
+        services = client.app.state.services
+        services.db.execute(
+            """INSERT INTO goals
+               (goal_id, title, description, state, blocked_reason, escalation_reason, version, created_at, updated_at)
+               VALUES (?, 'Invariant monitor drill goal', 'Injected violation', 'archived', NULL, NULL, 1, ?, ?)""",
+            goal_id,
+            timestamp,
+            timestamp,
+        )
+        services.db.execute(
+            """INSERT INTO goal_queue
+               (goal_id, urgency, value, deadline_score, base_priority, priority, wait_cycles, force_promoted,
+                status, version, created_at, updated_at)
+               VALUES (?, 0.1, 0.1, 0.1, 0.1, 0.1, 0, 0, 'queued', 1, ?, ?)""",
+            goal_id,
+            timestamp,
+            timestamp,
+        )
+
+        deadline = time.time() + max(1.0, float(timeout_seconds))
+        detected_payload: dict | None = None
+        while time.time() < deadline:
+            payload = client.get("/system/invariants").json()
+            monitor = payload["monitor"]
+            if int(monitor.get("violation_count") or 0) > 0:
+                detected_payload = payload
+                break
+            time.sleep(0.1)
+        _expect(detected_payload is not None, "Invariant monitor did not detect injected violation in time.")
+
+        safe_mode = client.get("/system/safe-mode").json()
+        _expect(
+            bool(safe_mode["active"]),
+            f"Safe mode was not activated by invariant monitor auto-safe-mode: {json.dumps(safe_mode, sort_keys=True)}",
+        )
+
+        blocked = client.post(
+            "/goals",
+            json={
+                "title": "blocked by invariant monitor",
+                "description": "should be blocked",
+                "urgency": 0.4,
+                "value": 0.4,
+                "deadline_score": 0.2,
+            },
+        )
+        _expect(
+            blocked.status_code == 503,
+            f"Mutating endpoint was not blocked after monitor-triggered safe mode: {blocked.status_code} {blocked.text}",
+        )
+
+        disable = client.post("/system/safe-mode/disable", json={"reason": "Invariant monitor drill cleanup"})
+        _expect(disable.status_code == 200, f"Failed to disable safe mode: {disable.text}")
+
+        return {
+            "success": True,
+            "detected_violation_count": int(detected_payload["monitor"]["violation_count"]),
+            "safe_mode_active_after_detection": bool(safe_mode["active"]),
+            "blocked_status_code": int(blocked.status_code),
+        }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Invariant monitor watchdog drill: inject a queue/state consistency violation and verify "
+            "periodic monitor detection plus auto-safe-mode activation."
+        )
+    )
+    parser.add_argument("--timeout-seconds", type=float, default=8.0)
+    args = parser.parse_args(argv)
+
+    if float(args.timeout_seconds) <= 0:
+        print("[invariant-monitor-watchdog-drill] ERROR: --timeout-seconds must be > 0.", file=sys.stderr)
+        return 2
+
+    try:
+        report = run_drill(timeout_seconds=float(args.timeout_seconds))
+    except Exception as exc:
+        print(f"[invariant-monitor-watchdog-drill] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/long-soak-budget-drill.py
+++ b/scripts/long-soak-budget-drill.py
@@ -1,0 +1,430 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from goal_ops_console.config import Settings
+from goal_ops_console.main import create_app
+
+TERMINAL_RUN_STATES = {"succeeded", "failed", "timed_out", "cancelled"}
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _percentile(values: list[float], p: float) -> float:
+    _expect(values, "Cannot compute percentile for empty sequence.")
+    sorted_values = sorted(values)
+    if len(sorted_values) == 1:
+        return float(sorted_values[0])
+    rank = (len(sorted_values) - 1) * max(0.0, min(100.0, float(p))) / 100.0
+    lower = math.floor(rank)
+    upper = math.ceil(rank)
+    if lower == upper:
+        return float(sorted_values[lower])
+    weight = rank - lower
+    return float(sorted_values[lower] * (1.0 - weight) + sorted_values[upper] * weight)
+
+
+def _wait_for_runs_terminal(client: TestClient, run_ids: list[str], timeout_seconds: float) -> None:
+    if not run_ids:
+        return
+    deadline = time.time() + max(1.0, float(timeout_seconds))
+    pending = set(run_ids)
+    while time.time() < deadline and pending:
+        finished: list[str] = []
+        for run_id in list(pending):
+            response = client.get(f"/workflows/runs/{run_id}")
+            if response.status_code != 200:
+                continue
+            status = str(response.json()["run"]["status"])
+            if status in TERMINAL_RUN_STATES:
+                finished.append(run_id)
+        for run_id in finished:
+            pending.discard(run_id)
+        if pending:
+            time.sleep(0.05)
+    _expect(not pending, f"Workflow runs did not reach terminal state: {sorted(pending)}")
+
+
+def _drain_consumer_until_empty(
+    client: TestClient,
+    *,
+    consumer_id: str,
+    drain_batch_size: int,
+    timeout_seconds: float,
+) -> int:
+    def _request_with_retry(
+        method: str,
+        url: str,
+        *,
+        expected_status: int,
+        max_retries: int = 8,
+        **kwargs,
+    ):
+        last_response = None
+        for attempt in range(max_retries + 1):
+            response = client.request(method, url, **kwargs)
+            last_response = response
+            if response.status_code == expected_status:
+                return response
+            if response.status_code >= 500:
+                time.sleep(min(0.2, 0.02 * (attempt + 1)))
+                continue
+            break
+        _expect(
+            False,
+            (
+                f"Consumer request failed for {method} {url}. "
+                f"expected={expected_status} "
+                f"observed={last_response.status_code if last_response else 'none'} "
+                f"body={last_response.text if last_response is not None else '<none>'}"
+            ),
+        )
+        return last_response
+
+    processed_total = 0
+    deadline = time.time() + max(1.0, float(timeout_seconds))
+    while time.time() < deadline:
+        snapshot_response = _request_with_retry("GET", "/system/backpressure", expected_status=200)
+        snapshot = snapshot_response.json()
+        pending = int(snapshot.get("pending_events") or 0)
+        if pending == 0:
+            return processed_total
+        drained = _request_with_retry(
+            "POST",
+            f"/system/consumers/{consumer_id}/drain",
+            expected_status=200,
+            params={"batch_size": int(drain_batch_size)},
+        )
+        processed_total += int(drained.json()["processed_count"])
+        time.sleep(0.02)
+    raise RuntimeError("Timed out while draining event backlog to zero.")
+
+
+def run_drill(
+    *,
+    duration_seconds: float,
+    max_p95_latency_ms: float,
+    max_p99_latency_ms: float,
+    max_max_latency_ms: float,
+    max_http_429_rate_percent: float,
+    max_error_rate_percent: float,
+    min_requests: int,
+    drain_batch_size: int,
+    workflow_start_every_cycles: int,
+) -> dict:
+    app = create_app(
+        Settings(
+            database_url=":memory:",
+            workflow_worker_poll_interval_seconds=0.02,
+            workflow_run_timeout_seconds=120,
+        )
+    )
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        consumer_id = str(client.app.state.services.settings.consumer_id)
+        deadline = time.time() + max(1.0, float(duration_seconds))
+        latencies_ms: list[float] = []
+        statuses = Counter()
+        cycle_count = 0
+        run_ids: list[str] = []
+        transient_retry_count = 0
+
+        def _request(method: str, url: str, **kwargs):
+            started = time.perf_counter()
+            response = client.request(method, url, **kwargs)
+            latencies_ms.append((time.perf_counter() - started) * 1000.0)
+            statuses[response.status_code] += 1
+            return response
+
+        def _request_expect(
+            method: str,
+            url: str,
+            expected_status: int,
+            *,
+            max_retries: int = 8,
+            **kwargs,
+        ):
+            nonlocal transient_retry_count
+            attempt = 0
+            last_response = None
+            while attempt <= max_retries:
+                response = _request(method, url, **kwargs)
+                last_response = response
+                if response.status_code == expected_status:
+                    return response
+                if response.status_code >= 500:
+                    transient_retry_count += 1
+                    attempt += 1
+                    time.sleep(min(0.2, 0.02 * attempt))
+                    continue
+                break
+            _expect(
+                False,
+                (
+                    f"Request failed for {method} {url}. "
+                    f"expected={expected_status} observed={last_response.status_code if last_response else 'none'} "
+                    f"body={last_response.text if last_response is not None else '<none>'}"
+                ),
+            )
+            return last_response
+
+        while time.time() < deadline:
+            cycle_count += 1
+            created = _request_expect(
+                "POST",
+                "/goals",
+                201,
+                json={
+                    "title": f"Long soak goal {cycle_count}",
+                    "description": "long soak budget drill",
+                    "urgency": 0.55,
+                    "value": 0.65,
+                    "deadline_score": 0.35,
+                },
+            )
+            goal_id = str(created.json()["goal_id"])
+
+            _request_expect("POST", f"/goals/{goal_id}/activate", 200)
+
+            task = _request_expect(
+                "POST",
+                "/tasks",
+                201,
+                json={"goal_id": goal_id, "title": f"Long soak task {cycle_count}"},
+            )
+            task_id = str(task.json()["task_id"])
+
+            _request_expect("POST", f"/tasks/{task_id}/success", 200)
+
+            _request_expect("POST", f"/goals/{goal_id}/block", 200)
+
+            _request_expect("POST", f"/goals/{goal_id}/archive", 200)
+
+            if int(workflow_start_every_cycles) > 0 and cycle_count % int(workflow_start_every_cycles) == 0:
+                started_run = _request_expect(
+                    "POST",
+                    "/workflows/maintenance.retention_cleanup/start",
+                    201,
+                    json={"requested_by": "long-soak-budget-drill", "payload": {"cycle": cycle_count}},
+                )
+                run_ids.append(str(started_run.json()["run"]["run_id"]))
+                # Keep the verification set bounded so terminal polling remains deterministic
+                # even during very long soak windows.
+                if len(run_ids) > 50:
+                    run_ids = run_ids[-50:]
+
+            _request_expect(
+                "POST",
+                f"/system/consumers/{consumer_id}/drain",
+                200,
+                params={"batch_size": int(drain_batch_size)},
+            )
+
+            if cycle_count % 5 == 0:
+                readiness = _request("GET", "/system/readiness")
+                _expect(readiness.status_code == 200, f"Readiness check failed: {readiness.text}")
+                _expect(
+                    bool(readiness.json().get("ready")),
+                    f"Readiness became false in cycle {cycle_count}: {readiness.text}",
+                )
+                slo = _request("GET", "/system/slo")
+                _expect(slo.status_code == 200, f"SLO check failed: {slo.text}")
+                _expect(
+                    str(slo.json().get("status")) == "ok",
+                    f"SLO became non-ok in cycle {cycle_count}: {slo.text}",
+                )
+
+        _wait_for_runs_terminal(client, run_ids, timeout_seconds=20.0)
+        drained_after = _drain_consumer_until_empty(
+            client,
+            consumer_id=consumer_id,
+            drain_batch_size=int(drain_batch_size),
+            timeout_seconds=20.0,
+        )
+
+        readiness_final = _request("GET", "/system/readiness")
+        slo_final = _request("GET", "/system/slo")
+        health_final = _request("GET", "/system/health")
+        _expect(readiness_final.status_code == 200, f"Final readiness failed: {readiness_final.text}")
+        _expect(slo_final.status_code == 200, f"Final SLO failed: {slo_final.text}")
+        _expect(health_final.status_code == 200, f"Final health failed: {health_final.text}")
+
+        readiness_payload = readiness_final.json()
+        slo_payload = slo_final.json()
+        health_payload = health_final.json()
+        invariant_violations = list(health_payload.get("invariant_violations") or [])
+        _expect(
+            bool(readiness_payload.get("ready")),
+            f"Final readiness is false: {json.dumps(readiness_payload, sort_keys=True)}",
+        )
+        worker_status = readiness_payload["checks"]["workflow_worker"]
+        _expect(
+            int(worker_status.get("queued_runs") or 0) == 0
+            and int(worker_status.get("running_runs") or 0) == 0,
+            f"Workflow runs still queued/running at end of soak: {json.dumps(worker_status, sort_keys=True)}",
+        )
+        _expect(
+            str(slo_payload.get("status")) == "ok",
+            f"Final SLO is not ok: {json.dumps(slo_payload, sort_keys=True)}",
+        )
+        _expect(
+            not invariant_violations,
+            f"Invariant violations after soak: {json.dumps(invariant_violations, sort_keys=True)}",
+        )
+
+        total_requests = int(sum(statuses.values()))
+        _expect(total_requests >= int(min_requests), f"Insufficient sample size: {total_requests} < {min_requests}")
+        _expect(latencies_ms, "No latency samples collected.")
+
+        http_429_count = int(statuses.get(429, 0))
+        error_count = int(sum(count for code, count in statuses.items() if int(code) >= 500))
+        http_429_rate_percent = (http_429_count / total_requests) * 100.0
+        error_rate_percent = (error_count / total_requests) * 100.0
+        p95_latency_ms = _percentile(latencies_ms, 95.0)
+        p99_latency_ms = _percentile(latencies_ms, 99.0)
+        max_latency_ms = max(latencies_ms)
+
+        _expect(
+            p95_latency_ms <= float(max_p95_latency_ms),
+            f"Latency budget exceeded: p95={p95_latency_ms:.3f}ms > {max_p95_latency_ms:.3f}ms",
+        )
+        _expect(
+            p99_latency_ms <= float(max_p99_latency_ms),
+            f"Latency budget exceeded: p99={p99_latency_ms:.3f}ms > {max_p99_latency_ms:.3f}ms",
+        )
+        _expect(
+            max_latency_ms <= float(max_max_latency_ms),
+            f"Latency budget exceeded: max={max_latency_ms:.3f}ms > {max_max_latency_ms:.3f}ms",
+        )
+        _expect(
+            http_429_rate_percent <= float(max_http_429_rate_percent),
+            (
+                "HTTP 429 budget exceeded: "
+                f"{http_429_rate_percent:.3f}% > {max_http_429_rate_percent:.3f}%"
+            ),
+        )
+        _expect(
+            error_rate_percent <= float(max_error_rate_percent),
+            f"Error budget exceeded: {error_rate_percent:.3f}% > {max_error_rate_percent:.3f}%",
+        )
+
+        return {
+            "success": True,
+            "duration_seconds": float(duration_seconds),
+            "cycle_count": cycle_count,
+            "requests_total": total_requests,
+            "status_counts": {str(code): int(count) for code, count in sorted(statuses.items())},
+            "latency_ms": {
+                "p50": round(_percentile(latencies_ms, 50.0), 3),
+                "p95": round(p95_latency_ms, 3),
+                "p99": round(p99_latency_ms, 3),
+                "max": round(max_latency_ms, 3),
+            },
+            "budgets": {
+                "max_p95_latency_ms": float(max_p95_latency_ms),
+                "max_p99_latency_ms": float(max_p99_latency_ms),
+                "max_max_latency_ms": float(max_max_latency_ms),
+                "max_http_429_rate_percent": float(max_http_429_rate_percent),
+                "max_error_rate_percent": float(max_error_rate_percent),
+            },
+            "observed_rates_percent": {
+                "http_429_rate": round(http_429_rate_percent, 4),
+                "error_rate": round(error_rate_percent, 4),
+            },
+            "workflow_runs_started": len(run_ids),
+            "transient_retry_count": transient_retry_count,
+            "drained_after_loop": drained_after,
+            "readiness_ready": bool(readiness_payload["ready"]),
+            "slo_status": str(slo_payload["status"]),
+            "invariant_violations": invariant_violations,
+        }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Long soak budget drill: sustain mixed API load and enforce p95 latency, HTTP 429, and error-rate budgets."
+        )
+    )
+    parser.add_argument("--duration-seconds", type=float, default=900.0)
+    parser.add_argument("--max-p95-latency-ms", type=float, default=250.0)
+    parser.add_argument("--max-p99-latency-ms", type=float, default=400.0)
+    parser.add_argument("--max-max-latency-ms", type=float, default=5000.0)
+    parser.add_argument("--max-http-429-rate-percent", type=float, default=1.0)
+    parser.add_argument("--max-error-rate-percent", type=float, default=1.0)
+    parser.add_argument("--min-requests", type=int, default=300)
+    parser.add_argument("--drain-batch-size", type=int, default=150)
+    parser.add_argument("--workflow-start-every-cycles", type=int, default=0)
+    args = parser.parse_args(argv)
+
+    if float(args.duration_seconds) <= 0:
+        print("[long-soak-budget-drill] ERROR: --duration-seconds must be > 0.", file=sys.stderr)
+        return 2
+    if float(args.max_p95_latency_ms) <= 0:
+        print("[long-soak-budget-drill] ERROR: --max-p95-latency-ms must be > 0.", file=sys.stderr)
+        return 2
+    if float(args.max_p99_latency_ms) <= 0:
+        print("[long-soak-budget-drill] ERROR: --max-p99-latency-ms must be > 0.", file=sys.stderr)
+        return 2
+    if float(args.max_max_latency_ms) <= 0:
+        print("[long-soak-budget-drill] ERROR: --max-max-latency-ms must be > 0.", file=sys.stderr)
+        return 2
+    if float(args.max_http_429_rate_percent) < 0:
+        print(
+            "[long-soak-budget-drill] ERROR: --max-http-429-rate-percent must be >= 0.",
+            file=sys.stderr,
+        )
+        return 2
+    if float(args.max_error_rate_percent) < 0:
+        print("[long-soak-budget-drill] ERROR: --max-error-rate-percent must be >= 0.", file=sys.stderr)
+        return 2
+    if int(args.min_requests) <= 0:
+        print("[long-soak-budget-drill] ERROR: --min-requests must be > 0.", file=sys.stderr)
+        return 2
+    if int(args.drain_batch_size) <= 0:
+        print("[long-soak-budget-drill] ERROR: --drain-batch-size must be > 0.", file=sys.stderr)
+        return 2
+    if int(args.workflow_start_every_cycles) < 0:
+        print(
+            "[long-soak-budget-drill] ERROR: --workflow-start-every-cycles must be >= 0.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        report = run_drill(
+            duration_seconds=float(args.duration_seconds),
+            max_p95_latency_ms=float(args.max_p95_latency_ms),
+            max_p99_latency_ms=float(args.max_p99_latency_ms),
+            max_max_latency_ms=float(args.max_max_latency_ms),
+            max_http_429_rate_percent=float(args.max_http_429_rate_percent),
+            max_error_rate_percent=float(args.max_error_rate_percent),
+            min_requests=int(args.min_requests),
+            drain_batch_size=int(args.drain_batch_size),
+            workflow_start_every_cycles=int(args.workflow_start_every_cycles),
+        )
+    except Exception as exc:
+        print(f"[long-soak-budget-drill] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/manage-desktop-rings.ps1
+++ b/scripts/manage-desktop-rings.ps1
@@ -1,11 +1,13 @@
 param(
     [string]$ManifestPath = "artifacts/desktop-rings.json",
-    [ValidateSet("show", "promote", "rollback")]
+    [ValidateSet("show", "promote", "rollback", "freeze", "unfreeze")]
     [string]$Action = "show",
     [ValidateSet("stable", "canary")]
     [string]$Ring = "stable",
     [string]$Version = "",
-    [string]$ReleaseManifestPath = ""
+    [string]$ReleaseManifestPath = "",
+    [string]$Reason = "",
+    [switch]$IgnoreReleaseFreeze
 )
 
 $ErrorActionPreference = "Stop"
@@ -45,6 +47,13 @@ function New-RingsState {
             }
         }
         releases = [ordered]@{}
+        release_freeze = [ordered]@{
+            active = $false
+            reason = $null
+            source = $null
+            activated_at_utc = $null
+            updated_at_utc = $null
+        }
     }
 }
 
@@ -109,6 +118,14 @@ function Read-RingsState {
                 artifacts = @($entry.Value.artifacts)
             }
         }
+    }
+
+    if ($loaded.release_freeze) {
+        $state.release_freeze.active = [bool]$loaded.release_freeze.active
+        $state.release_freeze.reason = To-NullableString $loaded.release_freeze.reason
+        $state.release_freeze.source = To-NullableString $loaded.release_freeze.source
+        $state.release_freeze.activated_at_utc = To-NullableString $loaded.release_freeze.activated_at_utc
+        $state.release_freeze.updated_at_utc = To-NullableString $loaded.release_freeze.updated_at_utc
     }
 
     return $state
@@ -218,6 +235,18 @@ if ($Action -eq "promote") {
     if ([string]::IsNullOrWhiteSpace($Version)) {
         throw "Version is required for Action=promote."
     }
+    if ([bool]$state.release_freeze.active -and -not $IgnoreReleaseFreeze) {
+        $freezeReason = [string]$state.release_freeze.reason
+        if ([string]::IsNullOrWhiteSpace($freezeReason)) {
+            $freezeReason = "unspecified"
+        }
+        throw (
+            "Release freeze is active; promotion blocked. " +
+            "Use -IgnoreReleaseFreeze only for supervised emergency overrides. " +
+            "Reason: $freezeReason"
+        )
+    }
+
     $target = [string]$Version
     Ensure-ReleaseStub -State $state -VersionValue $target -RingValue $Ring
 
@@ -252,6 +281,38 @@ if ($Action -eq "rollback") {
     Write-Host "Ring '$Ring' rolled back to version '$rollbackTarget'." -ForegroundColor Green
     if (-not [string]::IsNullOrWhiteSpace($current)) {
         Write-Host "Previous current version stored as rollback target: $current" -ForegroundColor Yellow
+    }
+    Write-Host "Manifest: $resolvedManifestPath" -ForegroundColor Cyan
+    exit 0
+}
+
+if ($Action -eq "freeze") {
+    $freezeReason = [string]$Reason
+    if ([string]::IsNullOrWhiteSpace($freezeReason)) {
+        $freezeReason = "Manual release freeze."
+    }
+    $state.release_freeze.active = $true
+    $state.release_freeze.reason = $freezeReason
+    $state.release_freeze.source = "operator"
+    $state.release_freeze.activated_at_utc = (Get-Date).ToUniversalTime().ToString("o")
+    $state.release_freeze.updated_at_utc = $state.release_freeze.activated_at_utc
+    Save-RingsState -PathValue $resolvedManifestPath -State $state
+    Write-Host "Release freeze activated." -ForegroundColor Yellow
+    Write-Host "Reason: $freezeReason"
+    Write-Host "Manifest: $resolvedManifestPath" -ForegroundColor Cyan
+    exit 0
+}
+
+if ($Action -eq "unfreeze") {
+    $state.release_freeze.active = $false
+    $state.release_freeze.reason = To-NullableString $Reason
+    $state.release_freeze.source = "operator"
+    $state.release_freeze.activated_at_utc = $null
+    $state.release_freeze.updated_at_utc = (Get-Date).ToUniversalTime().ToString("o")
+    Save-RingsState -PathValue $resolvedManifestPath -State $state
+    Write-Host "Release freeze cleared." -ForegroundColor Green
+    if (-not [string]::IsNullOrWhiteSpace($Reason)) {
+        Write-Host "Reason: $Reason"
     }
     Write-Host "Manifest: $resolvedManifestPath" -ForegroundColor Cyan
     exit 0

--- a/scripts/release-freeze-policy.py
+++ b/scripts/release-freeze-policy.py
@@ -1,0 +1,562 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable
+from urllib.parse import urljoin
+from urllib.request import urlopen
+
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from goal_ops_console.config import Settings
+from goal_ops_console.main import create_app
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _utc_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _powershell_executable() -> str | None:
+    for candidate in ("pwsh", "powershell"):
+        resolved = shutil.which(candidate)
+        if resolved:
+            return resolved
+    return None
+
+
+def _run_manage_rings(
+    *,
+    manifest_path: Path,
+    action: str,
+    ring: str = "stable",
+    version: str = "",
+    reason: str = "",
+    expect_success: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    executable = _powershell_executable()
+    if executable is None:
+        raise RuntimeError(
+            "PowerShell executable not found; cannot run manage-desktop-rings.ps1 for release freeze policy."
+        )
+
+    command = [
+        executable,
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        str(PROJECT_ROOT / "scripts" / "manage-desktop-rings.ps1"),
+        "-ManifestPath",
+        str(manifest_path),
+        "-Action",
+        action,
+        "-Ring",
+        ring,
+    ]
+    if version:
+        command.extend(["-Version", version])
+    if reason:
+        command.extend(["-Reason", reason])
+
+    completed = subprocess.run(
+        command,
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if expect_success and completed.returncode != 0:
+        raise RuntimeError(
+            "manage-desktop-rings.ps1 failed for action "
+            f"{action!r}: {completed.stderr.strip() or completed.stdout.strip()}"
+        )
+    return completed
+
+
+def _parse_json_object(raw_text: str) -> dict[str, Any]:
+    candidate = raw_text.strip()
+    _expect(bool(candidate), "Expected JSON output, but command returned empty output.")
+    try:
+        payload = json.loads(candidate)
+    except json.JSONDecodeError:
+        start = candidate.find("{")
+        end = candidate.rfind("}")
+        _expect(start >= 0 and end > start, "Command output did not contain JSON object.")
+        payload = json.loads(candidate[start : end + 1])
+    _expect(isinstance(payload, dict), "Expected JSON object output.")
+    return payload
+
+
+def _rings_show(manifest_path: Path, *, ring: str) -> dict[str, Any]:
+    payload = _run_manage_rings(
+        manifest_path=manifest_path,
+        action="show",
+        ring=ring,
+    )
+    return _parse_json_object(payload.stdout)
+
+
+def _rings_promote(manifest_path: Path, *, ring: str, version: str, expect_success: bool) -> subprocess.CompletedProcess[str]:
+    return _run_manage_rings(
+        manifest_path=manifest_path,
+        action="promote",
+        ring=ring,
+        version=version,
+        expect_success=expect_success,
+    )
+
+
+def _rings_freeze(manifest_path: Path, *, ring: str, reason: str) -> None:
+    _run_manage_rings(
+        manifest_path=manifest_path,
+        action="freeze",
+        ring=ring,
+        reason=reason,
+    )
+
+
+def _rings_unfreeze(manifest_path: Path, *, ring: str, reason: str) -> None:
+    _run_manage_rings(
+        manifest_path=manifest_path,
+        action="unfreeze",
+        ring=ring,
+        reason=reason,
+    )
+
+
+@dataclass(slots=True)
+class DrillPaths:
+    run_dir: Path
+    report_file: Path
+
+
+def _create_paths(workspace_root: Path) -> DrillPaths:
+    run_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+    run_dir = workspace_root / f"release-freeze-policy-{run_id}"
+    return DrillPaths(
+        run_dir=run_dir,
+        report_file=run_dir / "release-freeze-policy-report.json",
+    )
+
+
+def _fetch_slo_from_url(base_url: str) -> dict[str, Any]:
+    normalized = base_url.rstrip("/") + "/"
+    with urlopen(urljoin(normalized, "system/slo"), timeout=5) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    _expect(isinstance(payload, dict), "Remote /system/slo payload is not a JSON object.")
+    return payload
+
+
+def _build_mock_fetcher(
+    *,
+    mock_statuses: list[str],
+    mock_error_budget_burn_rates: list[float],
+) -> Callable[[], dict[str, Any]]:
+    statuses = [item.strip().lower() for item in mock_statuses if item.strip()]
+    _expect(statuses, "Mock SLO statuses are empty.")
+    for status in statuses:
+        _expect(status in {"ok", "degraded", "critical"}, f"Invalid mock status {status!r}")
+
+    burn_rates = [float(item) for item in mock_error_budget_burn_rates]
+    if not burn_rates:
+        burn_rates = [0.0 for _ in statuses]
+    if len(burn_rates) < len(statuses):
+        burn_rates.extend([burn_rates[-1]] * (len(statuses) - len(burn_rates)))
+
+    index = {"value": 0}
+
+    def _next_payload() -> dict[str, Any]:
+        current_index = index["value"]
+        if current_index >= len(statuses):
+            status = statuses[-1]
+            burn = burn_rates[-1]
+        else:
+            status = statuses[current_index]
+            burn = burn_rates[current_index]
+            index["value"] = current_index + 1
+
+        return {
+            "timestamp_utc": _utc_iso(),
+            "status": status,
+            "alerts": [{"code": "mock", "severity": "critical"}] if status == "critical" else [],
+            "indicators": {
+                "http_success_rate_percent": max(0.0, 100.0 - float(burn)),
+                "http_429_rate_percent": max(0.0, float(burn) / 2.0),
+                "event_failure_rate_percent": max(0.0, float(burn) / 2.0),
+            },
+        }
+
+    return _next_payload
+
+
+def _extract_error_budget_burn_rate_percent(payload: dict[str, Any]) -> float:
+    indicators = payload.get("indicators") or {}
+    success_rate = indicators.get("http_success_rate_percent")
+    http_429_rate = indicators.get("http_429_rate_percent")
+    event_failure_rate = indicators.get("event_failure_rate_percent")
+
+    candidates: list[float] = []
+    if isinstance(success_rate, (int, float)):
+        candidates.append(max(0.0, 100.0 - float(success_rate)))
+    if isinstance(http_429_rate, (int, float)):
+        candidates.append(max(0.0, float(http_429_rate)))
+    if isinstance(event_failure_rate, (int, float)):
+        candidates.append(max(0.0, float(event_failure_rate)))
+    if not candidates:
+        return 0.0
+    return max(candidates)
+
+
+def _observe_policy(
+    *,
+    fetch_payload: Callable[[], dict[str, Any]],
+    non_ok_window_seconds: int,
+    poll_interval_seconds: float,
+    max_observation_seconds: int,
+    max_error_budget_burn_rate_percent: float,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    deadline = started + max(1, int(max_observation_seconds))
+    non_ok_started: float | None = None
+    samples: list[dict[str, Any]] = []
+    trigger_sample: dict[str, Any] | None = None
+    trigger_reason = "none"
+
+    while time.perf_counter() <= deadline:
+        now = time.perf_counter()
+        payload = fetch_payload()
+        status = str(payload.get("status") or "").strip().lower()
+        _expect(status in {"ok", "degraded", "critical"}, f"Unknown SLO status {status!r}")
+
+        if status != "ok":
+            if non_ok_started is None:
+                non_ok_started = now
+            non_ok_streak_seconds = now - non_ok_started
+        else:
+            non_ok_started = None
+            non_ok_streak_seconds = 0.0
+
+        burn_rate = _extract_error_budget_burn_rate_percent(payload)
+        sample = {
+            "sampled_at_utc": _utc_iso(),
+            "status": status,
+            "non_ok_streak_seconds": round(float(non_ok_streak_seconds), 3),
+            "error_budget_burn_rate_percent": round(float(burn_rate), 4),
+            "alert_count": len(payload.get("alerts") or []),
+        }
+        samples.append(sample)
+
+        if status != "ok" and non_ok_streak_seconds >= float(non_ok_window_seconds):
+            trigger_sample = sample
+            trigger_reason = "non_ok_window"
+            break
+        if burn_rate > float(max_error_budget_burn_rate_percent):
+            trigger_sample = sample
+            trigger_reason = "error_budget_burn_rate"
+            break
+
+        time.sleep(max(0.05, float(poll_interval_seconds)))
+
+    observed_duration_seconds = time.perf_counter() - started
+    triggered = trigger_sample is not None
+    return {
+        "triggered": triggered,
+        "trigger_reason": trigger_reason,
+        "trigger_sample": trigger_sample,
+        "sample_count": len(samples),
+        "samples": samples,
+        "observed_duration_seconds": round(float(observed_duration_seconds), 3),
+    }
+
+
+def run_policy(
+    *,
+    workspace_root: Path,
+    keep_artifacts: bool,
+    label: str,
+    manifest_path: Path,
+    ring: str,
+    non_ok_window_seconds: int,
+    poll_interval_seconds: float,
+    max_observation_seconds: int,
+    max_error_budget_burn_rate_percent: float,
+    dry_run: bool,
+    database_url: str,
+    base_url: str,
+    mock_statuses: list[str],
+    mock_error_budget_burn_rates: list[float],
+    seed_previous_version: str,
+    seed_incident_version: str,
+    promotion_test_version: str,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    paths = _create_paths(workspace_root)
+    paths.run_dir.mkdir(parents=True, exist_ok=False)
+
+    report: dict[str, Any]
+    freeze_pre_state: dict[str, Any] | None = None
+    freeze_post_state: dict[str, Any] | None = None
+    freeze_attempted = False
+    freeze_executed = False
+    freeze_error = ""
+    promotion_blocked = False
+    promotion_probe_output = ""
+
+    try:
+        if seed_previous_version and seed_incident_version:
+            _expect(
+                seed_previous_version != seed_incident_version,
+                "--seed-previous-version and --seed-incident-version must differ.",
+            )
+            _rings_unfreeze(
+                manifest_path,
+                ring=ring,
+                reason="Reset freeze state before release-freeze drill seeding.",
+            )
+            _rings_promote(manifest_path, ring=ring, version=seed_previous_version, expect_success=True)
+            _rings_promote(manifest_path, ring=ring, version=seed_incident_version, expect_success=True)
+
+        if mock_statuses:
+            fetch_payload = _build_mock_fetcher(
+                mock_statuses=mock_statuses,
+                mock_error_budget_burn_rates=mock_error_budget_burn_rates,
+            )
+            source = {
+                "type": "mock",
+                "mock_statuses": [value.strip().lower() for value in mock_statuses if value.strip()],
+                "mock_error_budget_burn_rates": [float(value) for value in mock_error_budget_burn_rates],
+            }
+            observation = _observe_policy(
+                fetch_payload=fetch_payload,
+                non_ok_window_seconds=non_ok_window_seconds,
+                poll_interval_seconds=poll_interval_seconds,
+                max_observation_seconds=max_observation_seconds,
+                max_error_budget_burn_rate_percent=max_error_budget_burn_rate_percent,
+            )
+        elif base_url.strip():
+            source = {"type": "base_url", "base_url": base_url.strip()}
+            observation = _observe_policy(
+                fetch_payload=lambda: _fetch_slo_from_url(base_url.strip()),
+                non_ok_window_seconds=non_ok_window_seconds,
+                poll_interval_seconds=poll_interval_seconds,
+                max_observation_seconds=max_observation_seconds,
+                max_error_budget_burn_rate_percent=max_error_budget_burn_rate_percent,
+            )
+        else:
+            _expect(database_url.strip(), "Either --mock-slo-statuses, --base-url, or --database-url is required.")
+            source = {"type": "database_url", "database_url": database_url.strip()}
+            app = create_app(Settings(database_url=database_url.strip()))
+            with TestClient(app) as client:
+                observation = _observe_policy(
+                    fetch_payload=lambda: client.get("/system/slo").json(),
+                    non_ok_window_seconds=non_ok_window_seconds,
+                    poll_interval_seconds=poll_interval_seconds,
+                    max_observation_seconds=max_observation_seconds,
+                    max_error_budget_burn_rate_percent=max_error_budget_burn_rate_percent,
+                )
+
+        triggered = bool(observation["triggered"])
+        recommended_action = "no_action"
+        freeze_reason = ""
+
+        if triggered:
+            freeze_attempted = True
+            freeze_pre_state = _rings_show(manifest_path, ring=ring)
+            freeze_reason = (
+                "Auto release freeze: "
+                f"trigger_reason={observation['trigger_reason']} "
+                f"status={observation['trigger_sample']['status'] if observation['trigger_sample'] else 'unknown'} "
+                f"burn_rate={observation['trigger_sample']['error_budget_burn_rate_percent'] if observation['trigger_sample'] else 'n/a'}"
+            )
+            if dry_run:
+                recommended_action = "manual_freeze_required"
+            else:
+                try:
+                    _rings_freeze(
+                        manifest_path,
+                        ring=ring,
+                        reason=freeze_reason,
+                    )
+                    freeze_executed = True
+                    freeze_post_state = _rings_show(manifest_path, ring=ring)
+                    recommended_action = "release_freeze_executed"
+                except Exception as exc:
+                    freeze_error = str(exc)
+                    recommended_action = "release_freeze_failed_escalate_immediately"
+        else:
+            recommended_action = "no_action"
+
+        if freeze_executed and promotion_test_version.strip():
+            promotion_probe = _rings_promote(
+                manifest_path,
+                ring=ring,
+                version=promotion_test_version.strip(),
+                expect_success=False,
+            )
+            combined_output = "\n".join(
+                part for part in [promotion_probe.stdout.strip(), promotion_probe.stderr.strip()] if part
+            )
+            promotion_probe_output = combined_output
+            promotion_blocked = promotion_probe.returncode != 0 and "release freeze is active" in combined_output.lower()
+            _expect(
+                promotion_blocked,
+                (
+                    "Promotion was not blocked by release freeze policy. "
+                    f"probe_output={combined_output or '<empty>'}"
+                ),
+            )
+
+        success = (not triggered) or dry_run or (freeze_executed and (not promotion_test_version or promotion_blocked))
+        report = {
+            "label": label,
+            "success": success,
+            "source": source,
+            "policy": {
+                "non_ok_window_seconds": int(non_ok_window_seconds),
+                "poll_interval_seconds": float(poll_interval_seconds),
+                "max_observation_seconds": int(max_observation_seconds),
+                "max_error_budget_burn_rate_percent": float(max_error_budget_burn_rate_percent),
+                "dry_run": bool(dry_run),
+            },
+            "observation": observation,
+            "freeze": {
+                "attempted": freeze_attempted,
+                "executed": freeze_executed,
+                "error": freeze_error or None,
+                "reason": freeze_reason or None,
+                "ring": ring,
+                "manifest_path": str(manifest_path),
+                "pre_state": freeze_pre_state,
+                "post_state": freeze_post_state,
+            },
+            "promotion_block_verification": {
+                "promotion_test_version": promotion_test_version or None,
+                "blocked": promotion_blocked,
+                "probe_output": promotion_probe_output or None,
+            },
+            "decision": {
+                "triggered": triggered,
+                "recommended_action": recommended_action,
+                "runbook_path": "docs/production-runbook.md#1-release-checklist",
+            },
+            "paths": {
+                "run_dir": str(paths.run_dir),
+                "report_file": str(paths.report_file),
+            },
+            "duration_ms": int((time.perf_counter() - started) * 1000),
+        }
+
+        paths.report_file.write_text(
+            json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2),
+            encoding="utf-8",
+        )
+
+        if not success:
+            raise RuntimeError(f"Release freeze policy failed: {json.dumps(report, sort_keys=True)}")
+        return report
+    finally:
+        if not keep_artifacts:
+            shutil.rmtree(paths.run_dir, ignore_errors=True)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Operationalize release freeze policy: block ring promotion when /system/slo stays non-ok "
+            "for a sustained window or error budget burn rate spikes."
+        )
+    )
+    parser.add_argument("--workspace", default=str(PROJECT_ROOT / ".tmp" / "release-freeze-policy"))
+    parser.add_argument("--label", default="release-freeze-policy")
+    parser.add_argument("--manifest-path", default=str(PROJECT_ROOT / "artifacts" / "desktop-rings.json"))
+    parser.add_argument("--ring", default="stable")
+    parser.add_argument("--non-ok-window-seconds", type=int, default=300)
+    parser.add_argument("--poll-interval-seconds", type=float, default=30.0)
+    parser.add_argument("--max-observation-seconds", type=int, default=900)
+    parser.add_argument("--max-error-budget-burn-rate-percent", type=float, default=2.0)
+    parser.add_argument("--base-url", default="")
+    parser.add_argument("--database-url", default="")
+    parser.add_argument("--mock-slo-statuses", default="")
+    parser.add_argument("--mock-error-budget-burn-rates", default="")
+    parser.add_argument("--seed-previous-version", default="")
+    parser.add_argument("--seed-incident-version", default="")
+    parser.add_argument("--promotion-test-version", default="0.0.3")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--keep-artifacts", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if int(args.non_ok_window_seconds) <= 0:
+        print("[release-freeze-policy] ERROR: --non-ok-window-seconds must be > 0.", file=sys.stderr)
+        return 2
+    if float(args.poll_interval_seconds) <= 0:
+        print("[release-freeze-policy] ERROR: --poll-interval-seconds must be > 0.", file=sys.stderr)
+        return 2
+    if int(args.max_observation_seconds) <= 0:
+        print("[release-freeze-policy] ERROR: --max-observation-seconds must be > 0.", file=sys.stderr)
+        return 2
+    if float(args.max_error_budget_burn_rate_percent) < 0:
+        print(
+            "[release-freeze-policy] ERROR: --max-error-budget-burn-rate-percent must be >= 0.",
+            file=sys.stderr,
+        )
+        return 2
+    if args.base_url.strip() and args.database_url.strip():
+        print("[release-freeze-policy] ERROR: Specify either --base-url or --database-url, not both.", file=sys.stderr)
+        return 2
+
+    mock_statuses = [item.strip() for item in str(args.mock_slo_statuses).split(",") if item.strip()]
+    mock_burn_rates = [
+        float(item.strip())
+        for item in str(args.mock_error_budget_burn_rates).split(",")
+        if item.strip()
+    ]
+
+    try:
+        report = run_policy(
+            workspace_root=Path(args.workspace).expanduser(),
+            keep_artifacts=bool(args.keep_artifacts),
+            label=str(args.label),
+            manifest_path=Path(args.manifest_path).expanduser(),
+            ring=str(args.ring),
+            non_ok_window_seconds=int(args.non_ok_window_seconds),
+            poll_interval_seconds=float(args.poll_interval_seconds),
+            max_observation_seconds=int(args.max_observation_seconds),
+            max_error_budget_burn_rate_percent=float(args.max_error_budget_burn_rate_percent),
+            dry_run=bool(args.dry_run),
+            database_url=str(args.database_url),
+            base_url=str(args.base_url),
+            mock_statuses=mock_statuses,
+            mock_error_budget_burn_rates=mock_burn_rates,
+            seed_previous_version=str(args.seed_previous_version),
+            seed_incident_version=str(args.seed_incident_version),
+            promotion_test_version=str(args.promotion_test_version),
+        )
+    except Exception as exc:
+        print(f"[release-freeze-policy] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -4,6 +4,8 @@ param(
     [switch]$SkipDesktopSmoke,
     [switch]$SkipApiProbe,
     [switch]$SkipSloAlertCheck,
+    [switch]$SkipReleaseFreezePolicyDrill,
+    [switch]$StrictReleaseFreezePolicyDrill,
     [switch]$SkipFileDatabaseProbe,
     [switch]$StrictFileDatabaseProbe,
     [switch]$SkipAutoRollbackPolicyDrill,
@@ -18,6 +20,16 @@ param(
     [switch]$StrictWorkflowSoakDrill,
     [switch]$SkipWorkflowWorkerRestartDrill,
     [switch]$StrictWorkflowWorkerRestartDrill,
+    [switch]$SkipDbSafeModeWatchdogDrill,
+    [switch]$StrictDbSafeModeWatchdogDrill,
+    [switch]$SkipInvariantMonitorWatchdogDrill,
+    [switch]$StrictInvariantMonitorWatchdogDrill,
+    [switch]$SkipEventConsumerRecoveryChaosDrill,
+    [switch]$StrictEventConsumerRecoveryChaosDrill,
+    [switch]$SkipInvariantBurstDrill,
+    [switch]$StrictInvariantBurstDrill,
+    [switch]$SkipLongSoakBudgetDrill,
+    [switch]$StrictLongSoakBudgetDrill,
     [switch]$SkipMigrationRehearsal,
     [switch]$StrictMigrationRehearsal,
     [switch]$SkipBackupRestoreDrill,
@@ -89,6 +101,40 @@ if (-not $SkipSloAlertCheck) {
             "--database-url", ":memory:",
             "--allowed-status", "ok"
         )
+    }
+}
+
+if (-not $SkipReleaseFreezePolicyDrill) {
+    Invoke-GateStep -Name "Release freeze policy drill (sustained non-ok/burn-rate => promotion block)" -Action {
+        $workspace = Join-Path $ProjectRoot ".tmp\release-freeze-policy"
+        $manifestPath = Join-Path $workspace "desktop-rings.json"
+        New-Item -ItemType Directory -Force -Path $workspace | Out-Null
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\release-freeze-policy.py",
+                "--workspace", $workspace,
+                "--label", "release-gate",
+                "--manifest-path", $manifestPath,
+                "--ring", "stable",
+                "--mock-slo-statuses", "degraded,critical,critical,critical",
+                "--mock-error-budget-burn-rates", "0.5,1.0,2.5,2.5",
+                "--non-ok-window-seconds", "2",
+                "--poll-interval-seconds", "1",
+                "--max-observation-seconds", "8",
+                "--max-error-budget-burn-rate-percent", "2.0",
+                "--seed-previous-version", "0.0.1",
+                "--seed-incident-version", "0.0.2",
+                "--promotion-test-version", "0.0.3"
+            )
+        } catch {
+            if ($StrictReleaseFreezePolicyDrill) {
+                throw
+            }
+            Write-Warning (
+                "Release freeze policy drill failed but StrictReleaseFreezePolicyDrill is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
     }
 }
 
@@ -218,6 +264,112 @@ if (-not $SkipWorkflowWorkerRestartDrill) {
             }
             Write-Warning (
                 "Workflow worker restart drill failed but StrictWorkflowWorkerRestartDrill is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipDbSafeModeWatchdogDrill) {
+    Invoke-GateStep -Name "DB safe-mode watchdog drill (lock burst => guarded API mode)" -Action {
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\db-safe-mode-watchdog-drill.py",
+                "--lock-error-injections", "4"
+            )
+        } catch {
+            if ($StrictDbSafeModeWatchdogDrill) {
+                throw
+            }
+            Write-Warning (
+                "DB safe-mode watchdog drill failed but StrictDbSafeModeWatchdogDrill is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipInvariantMonitorWatchdogDrill) {
+    Invoke-GateStep -Name "Invariant monitor watchdog drill (periodic detector + auto-safe-mode)" -Action {
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\invariant-monitor-watchdog-drill.py",
+                "--timeout-seconds", "8"
+            )
+        } catch {
+            if ($StrictInvariantMonitorWatchdogDrill) {
+                throw
+            }
+            Write-Warning (
+                "Invariant monitor watchdog drill failed but StrictInvariantMonitorWatchdogDrill is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipEventConsumerRecoveryChaosDrill) {
+    Invoke-GateStep -Name "Event consumer recovery chaos drill (stale processing reclaim + drain)" -Action {
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\event-consumer-recovery-chaos-drill.py",
+                "--goal-count", "50",
+                "--stale-processing-count", "20",
+                "--drain-batch-size", "120",
+                "--timeout-seconds", "25"
+            )
+        } catch {
+            if ($StrictEventConsumerRecoveryChaosDrill) {
+                throw
+            }
+            Write-Warning (
+                "Event consumer recovery chaos drill failed but StrictEventConsumerRecoveryChaosDrill is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipInvariantBurstDrill) {
+    Invoke-GateStep -Name "Invariant burst drill (queue/goal/task consistency under load)" -Action {
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\invariant-burst-drill.py",
+                "--goal-count", "60"
+            )
+        } catch {
+            if ($StrictInvariantBurstDrill) {
+                throw
+            }
+            Write-Warning (
+                "Invariant burst drill failed but StrictInvariantBurstDrill is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipLongSoakBudgetDrill) {
+    Invoke-GateStep -Name "Long soak budget drill (latency/429/error budget gate)" -Action {
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\long-soak-budget-drill.py",
+                "--duration-seconds", "120",
+                "--max-p95-latency-ms", "300",
+                "--max-p99-latency-ms", "500",
+                "--max-max-latency-ms", "10000",
+                "--max-http-429-rate-percent", "2.0",
+                "--max-error-rate-percent", "1.0",
+                "--min-requests", "350",
+                "--drain-batch-size", "180",
+                "--workflow-start-every-cycles", "0"
+            )
+        } catch {
+            if ($StrictLongSoakBudgetDrill) {
+                throw
+            }
+            Write-Warning (
+                "Long soak budget drill failed but StrictLongSoakBudgetDrill is off. " +
                 "Continuing. Error: $($_.Exception.Message)"
             )
         }

--- a/scripts/run-db-safe-mode-watchdog-drill.ps1
+++ b/scripts/run-db-safe-mode-watchdog-drill.ps1
@@ -1,0 +1,21 @@
+param(
+    [string]$PythonExe = "python",
+    [int]$LockErrorInjections = 4
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$args = @(
+    ".\\scripts\\db-safe-mode-watchdog-drill.py",
+    "--lock-error-injections", [string]$LockErrorInjections
+)
+
+& $PythonExe @args
+if ($LASTEXITCODE -ne 0) {
+    throw "DB safe-mode watchdog drill failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "DB safe-mode watchdog drill passed." -ForegroundColor Green

--- a/scripts/run-event-consumer-recovery-chaos-drill.ps1
+++ b/scripts/run-event-consumer-recovery-chaos-drill.ps1
@@ -1,0 +1,29 @@
+param(
+    [string]$PythonExe = "python",
+    [int]$GoalCount = 40,
+    [int]$StaleProcessingCount = 15,
+    [string]$ConsumerId = "chaos-recovery",
+    [int]$DrainBatchSize = 100,
+    [double]$TimeoutSeconds = 20
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$args = @(
+    ".\\scripts\\event-consumer-recovery-chaos-drill.py",
+    "--goal-count", [string]$GoalCount,
+    "--stale-processing-count", [string]$StaleProcessingCount,
+    "--consumer-id", [string]$ConsumerId,
+    "--drain-batch-size", [string]$DrainBatchSize,
+    "--timeout-seconds", [string]$TimeoutSeconds
+)
+
+& $PythonExe @args
+if ($LASTEXITCODE -ne 0) {
+    throw "Event consumer recovery chaos drill failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Event consumer recovery chaos drill passed." -ForegroundColor Green

--- a/scripts/run-invariant-burst-drill.ps1
+++ b/scripts/run-invariant-burst-drill.ps1
@@ -1,0 +1,21 @@
+param(
+    [string]$PythonExe = "python",
+    [int]$GoalCount = 45
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$args = @(
+    ".\\scripts\\invariant-burst-drill.py",
+    "--goal-count", [string]$GoalCount
+)
+
+& $PythonExe @args
+if ($LASTEXITCODE -ne 0) {
+    throw "Invariant burst drill failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Invariant burst drill passed." -ForegroundColor Green

--- a/scripts/run-invariant-monitor-watchdog-drill.ps1
+++ b/scripts/run-invariant-monitor-watchdog-drill.ps1
@@ -1,0 +1,21 @@
+param(
+    [string]$PythonExe = "python",
+    [double]$TimeoutSeconds = 8
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$args = @(
+    ".\\scripts\\invariant-monitor-watchdog-drill.py",
+    "--timeout-seconds", [string]$TimeoutSeconds
+)
+
+& $PythonExe @args
+if ($LASTEXITCODE -ne 0) {
+    throw "Invariant monitor watchdog drill failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Invariant monitor watchdog drill passed." -ForegroundColor Green

--- a/scripts/run-long-soak-budget-drill.ps1
+++ b/scripts/run-long-soak-budget-drill.ps1
@@ -1,0 +1,37 @@
+param(
+    [string]$PythonExe = "python",
+    [double]$DurationSeconds = 900,
+    [double]$MaxP95LatencyMs = 250,
+    [double]$MaxP99LatencyMs = 400,
+    [double]$MaxMaxLatencyMs = 5000,
+    [double]$MaxHttp429RatePercent = 1.0,
+    [double]$MaxErrorRatePercent = 1.0,
+    [int]$MinRequests = 300,
+    [int]$DrainBatchSize = 150,
+    [int]$WorkflowStartEveryCycles = 0
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$args = @(
+    ".\\scripts\\long-soak-budget-drill.py",
+    "--duration-seconds", [string]$DurationSeconds,
+    "--max-p95-latency-ms", [string]$MaxP95LatencyMs,
+    "--max-p99-latency-ms", [string]$MaxP99LatencyMs,
+    "--max-max-latency-ms", [string]$MaxMaxLatencyMs,
+    "--max-http-429-rate-percent", [string]$MaxHttp429RatePercent,
+    "--max-error-rate-percent", [string]$MaxErrorRatePercent,
+    "--min-requests", [string]$MinRequests,
+    "--drain-batch-size", [string]$DrainBatchSize,
+    "--workflow-start-every-cycles", [string]$WorkflowStartEveryCycles
+)
+
+& $PythonExe @args
+if ($LASTEXITCODE -ne 0) {
+    throw "Long soak budget drill failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Long soak budget drill passed." -ForegroundColor Green

--- a/scripts/run-release-freeze-policy.ps1
+++ b/scripts/run-release-freeze-policy.ps1
@@ -1,0 +1,68 @@
+param(
+    [string]$PythonExe = "python",
+    [string]$WorkspaceDir = ".tmp\\release-freeze-policy",
+    [string]$ManifestPath = "artifacts\\desktop-rings.json",
+    [string]$Ring = "stable",
+    [int]$NonOkWindowSeconds = 300,
+    [int]$PollIntervalSeconds = 30,
+    [int]$MaxObservationSeconds = 900,
+    [double]$MaxErrorBudgetBurnRatePercent = 2.0,
+    [string]$BaseUrl = "",
+    [string]$DatabaseUrl = "",
+    [string]$MockSloStatuses = "",
+    [string]$MockErrorBudgetBurnRates = "",
+    [string]$SeedPreviousVersion = "",
+    [string]$SeedIncidentVersion = "",
+    [string]$PromotionTestVersion = "0.0.3",
+    [switch]$DryRun,
+    [switch]$KeepArtifacts
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$args = @(
+    ".\\scripts\\release-freeze-policy.py",
+    "--workspace", $WorkspaceDir,
+    "--label", "manual",
+    "--manifest-path", $ManifestPath,
+    "--ring", $Ring,
+    "--non-ok-window-seconds", [string]$NonOkWindowSeconds,
+    "--poll-interval-seconds", [string]$PollIntervalSeconds,
+    "--max-observation-seconds", [string]$MaxObservationSeconds,
+    "--max-error-budget-burn-rate-percent", [string]$MaxErrorBudgetBurnRatePercent,
+    "--promotion-test-version", [string]$PromotionTestVersion
+)
+if (-not [string]::IsNullOrWhiteSpace($BaseUrl)) {
+    $args += @("--base-url", $BaseUrl)
+}
+if (-not [string]::IsNullOrWhiteSpace($DatabaseUrl)) {
+    $args += @("--database-url", $DatabaseUrl)
+}
+if (-not [string]::IsNullOrWhiteSpace($MockSloStatuses)) {
+    $args += @("--mock-slo-statuses", $MockSloStatuses)
+}
+if (-not [string]::IsNullOrWhiteSpace($MockErrorBudgetBurnRates)) {
+    $args += @("--mock-error-budget-burn-rates", $MockErrorBudgetBurnRates)
+}
+if (-not [string]::IsNullOrWhiteSpace($SeedPreviousVersion)) {
+    $args += @("--seed-previous-version", $SeedPreviousVersion)
+}
+if (-not [string]::IsNullOrWhiteSpace($SeedIncidentVersion)) {
+    $args += @("--seed-incident-version", $SeedIncidentVersion)
+}
+if ($DryRun) {
+    $args += "--dry-run"
+}
+if ($KeepArtifacts) {
+    $args += "--keep-artifacts"
+}
+
+& $PythonExe @args
+if ($LASTEXITCODE -ne 0) {
+    throw "Release freeze policy execution failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Release freeze policy check passed." -ForegroundColor Green

--- a/scripts/stability-canary.py
+++ b/scripts/stability-canary.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _load_json_file(path: Path) -> dict[str, Any]:
+    _expect(path.exists(), f"JSON file not found: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    _expect(isinstance(data, dict), f"JSON file must contain object: {path}")
+    return data
+
+
+def _run_json_command(command: list[str]) -> tuple[dict[str, Any], float]:
+    started = time.perf_counter()
+    completed = subprocess.run(
+        command,
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    duration_seconds = time.perf_counter() - started
+    _expect(
+        completed.returncode == 0,
+        (
+            f"Command failed (exit={completed.returncode}): {' '.join(command)}\n"
+            f"STDERR:\n{completed.stderr}\nSTDOUT:\n{completed.stdout}"
+        ),
+    )
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    _expect(output_lines, f"Command produced no output: {' '.join(command)}")
+    payload = json.loads(output_lines[-1])
+    _expect(isinstance(payload, dict), f"Expected JSON object output: {' '.join(command)}")
+    return payload, duration_seconds
+
+
+def _regression_percent(current: float, baseline: float) -> float:
+    if baseline <= 0:
+        return 0.0
+    return ((current - baseline) / baseline) * 100.0
+
+
+def run_canary(
+    *,
+    baseline_file: Path,
+    output_file: Path,
+    long_soak_duration_seconds: int,
+) -> dict[str, Any]:
+    baseline = _load_json_file(baseline_file)
+    max_duration_regression_percent = float(baseline.get("max_duration_regression_percent", 25.0))
+
+    drill_commands: dict[str, list[str]] = {
+        "release_freeze_policy": [
+            sys.executable,
+            str(PROJECT_ROOT / "scripts" / "release-freeze-policy.py"),
+            "--workspace",
+            str(PROJECT_ROOT / ".tmp" / "stability-canary-release-freeze"),
+            "--label",
+            "stability-canary",
+            "--manifest-path",
+            str(PROJECT_ROOT / ".tmp" / "stability-canary-release-freeze" / "desktop-rings.json"),
+            "--ring",
+            "stable",
+            "--mock-slo-statuses",
+            "degraded,critical,critical,critical",
+            "--mock-error-budget-burn-rates",
+            "0.5,1.0,2.5,2.5",
+            "--non-ok-window-seconds",
+            "2",
+            "--poll-interval-seconds",
+            "1",
+            "--max-observation-seconds",
+            "8",
+            "--max-error-budget-burn-rate-percent",
+            "2.0",
+            "--seed-previous-version",
+            "0.0.1",
+            "--seed-incident-version",
+            "0.0.2",
+            "--promotion-test-version",
+            "0.0.3",
+        ],
+        "db_safe_mode_watchdog": [
+            sys.executable,
+            str(PROJECT_ROOT / "scripts" / "db-safe-mode-watchdog-drill.py"),
+            "--lock-error-injections",
+            "4",
+        ],
+        "invariant_monitor_watchdog": [
+            sys.executable,
+            str(PROJECT_ROOT / "scripts" / "invariant-monitor-watchdog-drill.py"),
+            "--timeout-seconds",
+            "8",
+        ],
+        "event_consumer_recovery_chaos": [
+            sys.executable,
+            str(PROJECT_ROOT / "scripts" / "event-consumer-recovery-chaos-drill.py"),
+            "--goal-count",
+            "30",
+            "--stale-processing-count",
+            "10",
+            "--drain-batch-size",
+            "100",
+            "--timeout-seconds",
+            "15",
+        ],
+        "invariant_burst": [
+            sys.executable,
+            str(PROJECT_ROOT / "scripts" / "invariant-burst-drill.py"),
+            "--goal-count",
+            "36",
+        ],
+        "long_soak_budget": [
+            sys.executable,
+            str(PROJECT_ROOT / "scripts" / "long-soak-budget-drill.py"),
+            "--duration-seconds",
+            str(int(long_soak_duration_seconds)),
+            "--max-p95-latency-ms",
+            "300",
+            "--max-p99-latency-ms",
+            "500",
+            "--max-max-latency-ms",
+            "10000",
+            "--max-http-429-rate-percent",
+            "1.0",
+            "--max-error-rate-percent",
+            "1.0",
+            "--min-requests",
+            "250",
+            "--drain-batch-size",
+            "180",
+            "--workflow-start-every-cycles",
+            "0",
+        ],
+    }
+
+    drill_results: dict[str, dict[str, Any]] = {}
+    for drill_name, command in drill_commands.items():
+        payload, duration_seconds = _run_json_command(command)
+        drill_results[drill_name] = {
+            "duration_seconds": round(float(duration_seconds), 3),
+            "payload": payload,
+        }
+
+    regressions: list[dict[str, Any]] = []
+    baseline_drills = baseline.get("drills") or {}
+    for drill_name, result in drill_results.items():
+        baseline_config = baseline_drills.get(drill_name) or {}
+        baseline_duration = float(baseline_config.get("baseline_duration_seconds", 0.0))
+        if baseline_duration > 0:
+            regression_percent = _regression_percent(result["duration_seconds"], baseline_duration)
+            if regression_percent > max_duration_regression_percent:
+                regressions.append(
+                    {
+                        "type": "duration_regression",
+                        "drill": drill_name,
+                        "current_duration_seconds": result["duration_seconds"],
+                        "baseline_duration_seconds": baseline_duration,
+                        "regression_percent": round(regression_percent, 3),
+                        "max_allowed_regression_percent": max_duration_regression_percent,
+                    }
+                )
+
+    long_soak_payload = drill_results["long_soak_budget"]["payload"]
+    max_429_rate = float((baseline_drills.get("long_soak_budget") or {}).get("max_http_429_rate_percent", 1.0))
+    max_error_rate = float((baseline_drills.get("long_soak_budget") or {}).get("max_error_rate_percent", 1.0))
+    observed_429_rate = float(long_soak_payload["observed_rates_percent"]["http_429_rate"])
+    observed_error_rate = float(long_soak_payload["observed_rates_percent"]["error_rate"])
+    if observed_429_rate > max_429_rate:
+        regressions.append(
+            {
+                "type": "http_429_rate_regression",
+                "drill": "long_soak_budget",
+                "observed": observed_429_rate,
+                "max_allowed": max_429_rate,
+            }
+        )
+    if observed_error_rate > max_error_rate:
+        regressions.append(
+            {
+                "type": "error_rate_regression",
+                "drill": "long_soak_budget",
+                "observed": observed_error_rate,
+                "max_allowed": max_error_rate,
+            }
+        )
+
+    report = {
+        "success": len(regressions) == 0,
+        "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "baseline_file": str(baseline_file),
+        "output_file": str(output_file),
+        "drills": drill_results,
+        "regressions": regressions,
+    }
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(
+        json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2),
+        encoding="utf-8",
+    )
+    if regressions:
+        raise RuntimeError(f"Stability canary regressions detected: {json.dumps(regressions, sort_keys=True)}")
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Nightly stability canary: run core stability drills and compare duration/rate trends against baseline."
+        )
+    )
+    parser.add_argument(
+        "--baseline-file",
+        default=str(PROJECT_ROOT / "docs" / "stability-canary-baseline.json"),
+    )
+    parser.add_argument(
+        "--output-file",
+        default=str(PROJECT_ROOT / "artifacts" / "stability-canary-report.json"),
+    )
+    parser.add_argument("--long-soak-duration-seconds", type=int, default=120)
+    args = parser.parse_args(argv)
+
+    if int(args.long_soak_duration_seconds) <= 0:
+        print("[stability-canary] ERROR: --long-soak-duration-seconds must be > 0.", file=sys.stderr)
+        return 2
+
+    try:
+        report = run_canary(
+            baseline_file=Path(args.baseline_file).expanduser(),
+            output_file=Path(args.output_file).expanduser(),
+            long_soak_duration_seconds=int(args.long_soak_duration_seconds),
+        )
+    except Exception as exc:
+        print(f"[stability-canary] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1983,3 +1983,317 @@ def test_85_workflow_worker_restart_drill_reports_success():
     assert payload["after"]["ready"] is True
     assert payload["after"]["worker_running"] is True
     assert payload["run"]["status"] == "succeeded"
+
+
+def test_86_event_consumer_recovery_chaos_drill_reports_success():
+    project_root = Path(__file__).resolve().parents[1]
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "event-consumer-recovery-chaos-drill.py"),
+        "--goal-count",
+        "20",
+        "--stale-processing-count",
+        "8",
+        "--drain-batch-size",
+        "80",
+        "--timeout-seconds",
+        "12",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    assert payload["success"] is True
+    assert payload["reclaimed_count"] >= payload["stale_processing_target"]
+    assert payload["status_counts"].get("processing", 0) == 0
+    assert payload["status_counts"].get("failed", 0) == 0
+    assert payload["readiness_ready"] is True
+    assert payload["slo_status"] == "ok"
+
+
+def test_87_invariant_burst_drill_reports_success():
+    project_root = Path(__file__).resolve().parents[1]
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "invariant-burst-drill.py"),
+        "--goal-count",
+        "24",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    assert payload["success"] is True
+    assert payload["goal_count"] == 24
+    assert payload["invariant_violations"]["direct"] == []
+    assert payload["invariant_violations"]["health"] == []
+    assert payload["readiness_ready"] is True
+
+
+def test_88_long_soak_budget_drill_reports_success():
+    project_root = Path(__file__).resolve().parents[1]
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "long-soak-budget-drill.py"),
+        "--duration-seconds",
+        "6",
+        "--max-p95-latency-ms",
+        "500",
+        "--max-p99-latency-ms",
+        "800",
+        "--max-max-latency-ms",
+        "5000",
+        "--max-http-429-rate-percent",
+        "1.0",
+        "--max-error-rate-percent",
+        "1.0",
+        "--min-requests",
+        "120",
+        "--drain-batch-size",
+        "120",
+        "--workflow-start-every-cycles",
+        "0",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    assert payload["success"] is True
+    assert payload["requests_total"] >= 120
+    assert payload["latency_ms"]["p95"] <= 500
+    assert payload["latency_ms"]["p99"] <= 800
+    assert payload["latency_ms"]["max"] <= 5000
+    assert payload["observed_rates_percent"]["http_429_rate"] <= 1.0
+    assert payload["observed_rates_percent"]["error_rate"] <= 1.0
+    assert payload["readiness_ready"] is True
+    assert payload["slo_status"] == "ok"
+
+
+def test_89_release_freeze_policy_drill_reports_success():
+    workspace = _local_test_dir("pytest-release-freeze-policy")
+    project_root = Path(__file__).resolve().parents[1]
+    manifest_path = workspace / "desktop-rings.json"
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "release-freeze-policy.py"),
+        "--workspace",
+        str(workspace),
+        "--label",
+        "pytest-drill",
+        "--manifest-path",
+        str(manifest_path),
+        "--ring",
+        "stable",
+        "--mock-slo-statuses",
+        "degraded,critical,critical,critical",
+        "--mock-error-budget-burn-rates",
+        "0.5,1.0,2.5,2.5",
+        "--non-ok-window-seconds",
+        "2",
+        "--poll-interval-seconds",
+        "1",
+        "--max-observation-seconds",
+        "8",
+        "--max-error-budget-burn-rate-percent",
+        "2.0",
+        "--seed-previous-version",
+        "0.0.1",
+        "--seed-incident-version",
+        "0.0.2",
+        "--promotion-test-version",
+        "0.0.3",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0 and "powershell executable not found" in completed.stderr.lower():
+        shutil.rmtree(workspace, ignore_errors=True)
+        pytest.skip("PowerShell is unavailable in this environment")
+    assert completed.returncode == 0, completed.stderr
+
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    assert payload["success"] is True
+    assert payload["observation"]["triggered"] is True
+    assert payload["freeze"]["executed"] is True
+    assert payload["promotion_block_verification"]["blocked"] is True
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_90_db_safe_mode_watchdog_drill_reports_success():
+    project_root = Path(__file__).resolve().parents[1]
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "db-safe-mode-watchdog-drill.py"),
+        "--lock-error-injections",
+        "4",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    assert payload["success"] is True
+    assert payload["safe_mode_active_after_injection"] is True
+    assert payload["blocked_status_code"] == 503
+    assert payload["allowed_reclaim_status_code"] == 200
+    assert payload["safe_mode_active_after_disable"] is False
+    assert payload["post_disable_goal_create_status_code"] == 201
+
+
+def test_91_invariant_monitor_watchdog_drill_reports_success():
+    project_root = Path(__file__).resolve().parents[1]
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "invariant-monitor-watchdog-drill.py"),
+        "--timeout-seconds",
+        "8",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    assert payload["success"] is True
+    assert payload["detected_violation_count"] > 0
+    assert payload["safe_mode_active_after_detection"] is True
+    assert payload["blocked_status_code"] == 503
+
+
+def test_92_mutation_idempotency_replays_goal_create_response(client):
+    headers = {"Idempotency-Key": "goal-create-idem-1"}
+    payload = {
+        "title": "Idempotent Goal",
+        "description": "ensure replay",
+        "urgency": 0.5,
+        "value": 0.5,
+        "deadline_score": 0.2,
+    }
+
+    first = client.post("/goals", json=payload, headers=headers)
+    second = client.post("/goals", json=payload, headers=headers)
+    assert first.status_code == 201
+    assert second.status_code == 201
+    assert second.headers.get("x-idempotency-replay") == "true"
+
+    first_goal = first.json()
+    second_goal = second.json()
+    assert first_goal["goal_id"] == second_goal["goal_id"]
+
+    rows = client.app.state.services.db.fetch_all("SELECT goal_id FROM goals WHERE title = ?", "Idempotent Goal")
+    assert len(rows) == 1
+
+
+def test_93_mutation_idempotency_rejects_payload_mismatch(client):
+    headers = {"Idempotency-Key": "goal-create-idem-2"}
+    first = client.post(
+        "/goals",
+        json={
+            "title": "Idempotent A",
+            "description": "first",
+            "urgency": 0.4,
+            "value": 0.5,
+            "deadline_score": 0.1,
+        },
+        headers=headers,
+    )
+    second = client.post(
+        "/goals",
+        json={
+            "title": "Idempotent B",
+            "description": "second",
+            "urgency": 0.7,
+            "value": 0.6,
+            "deadline_score": 0.3,
+        },
+        headers=headers,
+    )
+    assert first.status_code == 201
+    assert second.status_code == 409
+    assert "different payload" in second.json()["detail"].lower()
+
+
+def test_94_stability_canary_reports_success_with_short_soak():
+    workspace = _local_test_dir("pytest-stability-canary")
+    project_root = Path(__file__).resolve().parents[1]
+    baseline_file = workspace / "baseline.json"
+    report_file = workspace / "report.json"
+    baseline_file.write_text(
+        json.dumps(
+            {
+                "max_duration_regression_percent": 10_000.0,
+                "drills": {
+                    "release_freeze_policy": {"baseline_duration_seconds": 0.1},
+                    "db_safe_mode_watchdog": {"baseline_duration_seconds": 0.1},
+                    "invariant_monitor_watchdog": {"baseline_duration_seconds": 0.1},
+                    "event_consumer_recovery_chaos": {"baseline_duration_seconds": 0.1},
+                    "invariant_burst": {"baseline_duration_seconds": 0.1},
+                    "long_soak_budget": {
+                        "baseline_duration_seconds": 0.1,
+                        "max_http_429_rate_percent": 1.0,
+                        "max_error_rate_percent": 1.0,
+                    },
+                },
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "stability-canary.py"),
+        "--baseline-file",
+        str(baseline_file),
+        "--output-file",
+        str(report_file),
+        "--long-soak-duration-seconds",
+        "6",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0 and "powershell executable not found" in completed.stderr.lower():
+        shutil.rmtree(workspace, ignore_errors=True)
+        pytest.skip("PowerShell is unavailable in this environment")
+    assert completed.returncode == 0, completed.stderr
+
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    assert payload["success"] is True
+    assert report_file.exists()
+    shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
﻿## Summary
- implement runtime stability guardrails for hard-abort and lock/IO failure scenarios:
  - new `RuntimeGuard` with automatic safe-mode activation based on DB lock/IO error windows
  - new background `InvariantMonitor` with optional auto-safe-mode activation
  - readiness/SLO integration for safe-mode and invariant-monitor health
  - operator endpoints: `GET /system/safe-mode`, `POST /system/safe-mode/enable|disable`, `GET /system/invariants`
- extend idempotency protection for mutating endpoints (`Idempotency-Key`) with payload-hash conflict detection and replay headers
- add retention cleanup support for stored idempotency responses
- add release-freeze policy support to desktop ring management (`freeze`/`unfreeze`) and promotion blocking while freeze is active
- add new stability drills and wrappers:
  - release-freeze policy
  - DB safe-mode watchdog
  - invariant monitor watchdog
  - event-consumer recovery chaos
  - invariant burst consistency
  - long soak budget (p95/p99/max + 429/error budgets)
- add nightly stability canary workflow and baseline file
- integrate all new drills into `release-gate.ps1` and CI strict gate flags
- update README and production runbook for new endpoints, drills, freeze operations, and canary runbook

## Validation
- `python -m pytest -q` -> `110 passed, 5 skipped`
- `python -m pytest -q tests/test_goal_ops.py::test_88_long_soak_budget_drill_reports_success tests/test_goal_ops.py::test_94_stability_canary_reports_success_with_short_soak`
- `powershell -ExecutionPolicy Bypass -File .\scripts\release-gate.ps1 -SkipPytest -SkipDesktopSmoke -SkipApiProbe -SkipSloAlertCheck -SkipFileDatabaseProbe -SkipAutoRollbackPolicyDrill -SkipDesktopUpdateSafetyDrill -SkipRecoveryHardAbortDrill -SkipWorkflowLockResilienceDrill -SkipWorkflowSoakDrill -SkipWorkflowWorkerRestartDrill -SkipMigrationRehearsal -SkipBackupRestoreDrill -SkipIncidentRollbackDrill -StrictReleaseFreezePolicyDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill`

## Notes
- hardened `long-soak-budget-drill` against transient SQLite lock spikes by using response-based retries (`raise_server_exceptions=False`) and retry logic in final drain checks.
