### PR TITLE
P0 stability: DB corruption quarantine startup recovery drill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run release gate
         shell: pwsh
         run: |
-          .\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+          .\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictDbCorruptionQuarantineDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 
   test:
     name: Pytest (Python ${{ matrix.python-version }})

--- a/README.md
+++ b/README.md
@@ -410,11 +410,11 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + backup/restore drill + incident/rollback drill under burst load):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + DB corruption quarantine drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + backup/restore drill + incident/rollback drill under burst load):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictDbCorruptionQuarantineDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 ```
 
 Standalone backup/restore drill:
@@ -457,6 +457,13 @@ Standalone recovery hard-abort drill:
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-recovery-hard-abort-drill.ps1
+```
+
+Standalone DB corruption quarantine drill:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-db-corruption-quarantine-drill.ps1 -CorruptionBytes 256
 ```
 
 Standalone workflow lock-resilience drill:
@@ -572,7 +579,7 @@ python .\scripts\desktop-smoke.py
 
 ## Nightly Stability Canary
 
-Run the full canary profile locally (includes release-freeze policy, watchdog drills, recovery chaos, invariant burst, and long soak budgets):
+Run the full canary profile locally (includes release-freeze policy, DB corruption quarantine, watchdog drills, recovery chaos, invariant burst, and long soak budgets):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
@@ -696,6 +703,8 @@ If a value is rejected:
 - If you see old goals or tasks, reset the local database.
 - In this sandboxed environment, file-backed SQLite can behave differently than in a normal local shell. For normal local use, keep `GOAL_OPS_DATABASE_URL="goal_ops.db"` set before starting the server.
 - Optional: set `GOAL_OPS_DB_MIGRATION_BACKUP_DIR` to control where pre-migration SQLite backups are written.
+- Optional: set `GOAL_OPS_DB_QUARANTINE_DIR` to control where corrupted DB files are quarantined on startup recovery.
+- Optional: set `GOAL_OPS_DB_STARTUP_CORRUPTION_RECOVERY_ENABLED=false` to disable automatic startup quarantine recovery.
 - If you start `uvicorn` from outside the project directory, keep the `--app-dir` flag.
 
 ## Key Files
@@ -725,6 +734,8 @@ If a value is rejected:
 - [recovery-hard-abort-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/recovery-hard-abort-drill.py)
 - [recovery-hard-abort-target.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/recovery-hard-abort-target.py)
 - [run-recovery-hard-abort-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-recovery-hard-abort-drill.ps1)
+- [db-corruption-quarantine-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/db-corruption-quarantine-drill.py)
+- [run-db-corruption-quarantine-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-db-corruption-quarantine-drill.ps1)
 - [workflow-lock-resilience-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/workflow-lock-resilience-drill.py)
 - [run-workflow-lock-resilience-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-workflow-lock-resilience-drill.ps1)
 - [workflow-soak-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/workflow-soak-drill.py)

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -9,7 +9,7 @@ This runbook is optimized for reliability-first releases of the desktop app and 
 Run in repo root:
 
 ```powershell
-.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictDbCorruptionQuarantineDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 ```
 
 This gate covers:
@@ -21,6 +21,7 @@ This gate covers:
 - auto-rollback-policy drill (`critical` sustained window triggers stable ring rollback path)
 - desktop-update-safety drill (hash validation + rollback-to-stable fallback path)
 - recovery hard-abort drill (kill running worker process, restart, and verify no hanging `running` runs)
+- DB corruption quarantine drill (startup quarantines corrupted SQLite file and enters guarded safe mode)
 - workflow lock-resilience drill (transient SQLite lock conflicts while worker remains healthy)
 - workflow soak drill (burst enqueue with zero lingering `running` or `queued` runs)
 - workflow worker restart drill (stop worker, enqueue run, and verify self-healing restart path)
@@ -63,6 +64,12 @@ Manual recovery hard-abort drill invocation:
 
 ```powershell
 .\scripts\run-recovery-hard-abort-drill.ps1
+```
+
+Manual DB corruption quarantine drill invocation:
+
+```powershell
+.\scripts\run-db-corruption-quarantine-drill.ps1 -CorruptionBytes 256
 ```
 
 Manual workflow lock-resilience drill invocation:
@@ -171,7 +178,7 @@ After release is live:
 
 ### 1.6 Nightly stability canary
 
-The scheduled workflow [stability-canary.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/stability-canary.yml) runs a nightly trend check against [stability-canary-baseline.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/stability-canary-baseline.json).
+The scheduled workflow [stability-canary.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/stability-canary.yml) runs a nightly trend check against [stability-canary-baseline.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/stability-canary-baseline.json), including DB corruption quarantine startup recovery.
 
 Manual canary invocation:
 
@@ -216,6 +223,7 @@ Actions:
    ```
 2. Check failing check:
    - `checks.database.ok = false`: inspect DB path/permissions/locking.
+   - `checks.database.startup_recovery.triggered = true`: validate quarantined DB file and keep safe mode active until recovery validation is complete.
    - `checks.workflow_worker.ok = false`: worker thread failed to start.
 3. If the database check fails, run integrity probe:
    ```powershell
@@ -524,6 +532,28 @@ Actions:
    .\scripts\run-invariant-monitor-watchdog-drill.ps1 -TimeoutSeconds 8
    ```
 3. If violations persist, keep safe mode enabled and hold promotion until root cause is fixed.
+
+### 3.19 Startup DB corruption quarantine was triggered
+
+Symptoms:
+- readiness shows `checks.database.startup_recovery.triggered = true`
+- SLO includes `database.startup_recovery.triggered` alert
+- mutating endpoints are blocked by safe mode until operator validation
+
+Actions:
+1. Inspect startup recovery payload and quarantined file path:
+   ```powershell
+   Invoke-RestMethod http://127.0.0.1:8000/system/database/integrity?mode=quick
+   ```
+2. Run DB corruption quarantine drill to confirm recovery flow remains healthy:
+   ```powershell
+   .\scripts\run-db-corruption-quarantine-drill.ps1 -CorruptionBytes 256
+   ```
+3. Validate restored runtime state and backup posture before re-enabling mutations.
+4. Disable safe mode with explicit operator reason only after validation:
+   ```powershell
+   Invoke-RestMethod -Method Post -Uri http://127.0.0.1:8000/system/safe-mode/disable -ContentType "application/json" -Body '{"reason":"DB quarantine validated and recovery complete"}'
+   ```
 
 ## 4. Operational Defaults
 

--- a/docs/stability-canary-baseline.json
+++ b/docs/stability-canary-baseline.json
@@ -4,6 +4,9 @@
     "release_freeze_policy": {
       "baseline_duration_seconds": 6.0
     },
+    "db_corruption_quarantine": {
+      "baseline_duration_seconds": 5.0
+    },
     "db_safe_mode_watchdog": {
       "baseline_duration_seconds": 3.0
     },

--- a/goal_ops_console/config.py
+++ b/goal_ops_console/config.py
@@ -91,6 +91,11 @@ WORKFLOW_STARTUP_RECOVERY_MAX_AGE_SECONDS = _env_int(
 )
 DIAGNOSTICS_DIR = os.getenv("GOAL_OPS_DIAGNOSTICS_DIR", "")
 DB_MIGRATION_BACKUP_DIR = os.getenv("GOAL_OPS_DB_MIGRATION_BACKUP_DIR", "")
+DB_QUARANTINE_DIR = os.getenv("GOAL_OPS_DB_QUARANTINE_DIR", "")
+DB_STARTUP_CORRUPTION_RECOVERY_ENABLED = _env_bool(
+    "GOAL_OPS_DB_STARTUP_CORRUPTION_RECOVERY_ENABLED",
+    True,
+)
 
 # SLO / Alerting
 SLO_MIN_HTTP_REQUEST_SAMPLE = _env_int("GOAL_OPS_SLO_MIN_HTTP_REQUEST_SAMPLE", 20)
@@ -169,6 +174,8 @@ class Settings:
     workflow_startup_recovery_max_age_seconds: int = WORKFLOW_STARTUP_RECOVERY_MAX_AGE_SECONDS
     diagnostics_dir: str = DIAGNOSTICS_DIR
     db_migration_backup_dir: str = DB_MIGRATION_BACKUP_DIR
+    db_quarantine_dir: str = DB_QUARANTINE_DIR
+    db_startup_corruption_recovery_enabled: bool = DB_STARTUP_CORRUPTION_RECOVERY_ENABLED
     slo_min_http_request_sample: int = SLO_MIN_HTTP_REQUEST_SAMPLE
     slo_min_event_attempt_sample: int = SLO_MIN_EVENT_ATTEMPT_SAMPLE
     slo_min_http_success_rate_percent: float = SLO_MIN_HTTP_SUCCESS_RATE_PERCENT

--- a/goal_ops_console/database.py
+++ b/goal_ops_console/database.py
@@ -1,4 +1,5 @@
 import contextlib
+import shutil
 import sqlite3
 import time
 import uuid
@@ -249,6 +250,13 @@ CREATE INDEX IF NOT EXISTS idx_metrics_updated_at ON metrics_counters(updated_at
 SQLITE_BUSY_TIMEOUT_MS = 5_000
 LOCK_RETRY_ATTEMPTS = 8
 LOCK_RETRY_BASE_SECONDS = 0.01
+SQLITE_CORRUPTION_SIGNATURES = (
+    "database disk image is malformed",
+    "file is not a database",
+    "malformed database schema",
+    "database malformed",
+    "file is encrypted or is not a database",
+)
 MIGRATIONS: tuple[tuple[int, str], ...] = (
     (
         1,
@@ -341,11 +349,15 @@ class Database:
         database_url: str,
         *,
         migration_backup_dir: str = "",
+        quarantine_dir: str = "",
+        startup_corruption_recovery_enabled: bool = True,
     ):
         self.original_url = database_url
         self.database_url = self._normalize_database_url(database_url)
         self._uri = self.database_url.startswith("file:")
         self.migration_backup_dir = migration_backup_dir.strip()
+        self.quarantine_dir = quarantine_dir.strip()
+        self.startup_corruption_recovery_enabled = bool(startup_corruption_recovery_enabled)
         self._database_path = self._resolve_database_file_path(self.database_url)
         self._database_existed_at_startup = bool(
             self._database_path is not None and self._database_path.exists()
@@ -353,6 +365,18 @@ class Database:
         self._last_migration_backup_path: str | None = None
         self._last_migration_backup_created_at: str | None = None
         self._last_migration_backup_versions: list[int] = []
+        quarantine_root = self._resolve_quarantine_root()
+        self._startup_recovery_state: dict[str, object] = {
+            "triggered": False,
+            "recovered": False,
+            "error": None,
+            "reason": None,
+            "at_utc": None,
+            "original_path": str(self._database_path) if self._database_path is not None else None,
+            "quarantined_path": None,
+            "quarantine_dir": str(quarantine_root) if quarantine_root is not None else None,
+            "operator_action": None,
+        }
         self._keeper = None
         if "mode=memory" in self.database_url:
             self._keeper = self._connect()
@@ -369,6 +393,13 @@ class Database:
         if normalized.name == ":memory:":
             return None
         return normalized
+
+    def _resolve_quarantine_root(self) -> Path | None:
+        if self._database_path is None:
+            return None
+        if self.quarantine_dir:
+            return Path(self.quarantine_dir).expanduser()
+        return self._database_path.parent / "db_quarantine"
 
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(
@@ -390,6 +421,12 @@ class Database:
             or "database schema is locked" in message
         )
 
+    def _is_corruption_error(self, error: Exception) -> bool:
+        message = str(error).strip().lower()
+        if not message:
+            return False
+        return any(signature in message for signature in SQLITE_CORRUPTION_SIGNATURES)
+
     def _run_with_retry(self, operation: Callable[[sqlite3.Connection], T]) -> T:
         last_error: sqlite3.OperationalError | None = None
         for attempt in range(LOCK_RETRY_ATTEMPTS):
@@ -407,7 +444,7 @@ class Database:
             raise last_error
         raise RuntimeError("SQLite retry loop exited unexpectedly")
 
-    def initialize(self) -> None:
+    def _initialize_once(self) -> None:
         conn = self._keeper or self._connect()
         try:
             conn.executescript(SCHEMA)
@@ -415,6 +452,90 @@ class Database:
         finally:
             if conn is not self._keeper:
                 conn.close()
+
+    def _quarantine_corrupted_database(self, *, reason: str) -> dict[str, object]:
+        if self._database_path is None:
+            raise RuntimeError("Corruption quarantine requires a file-backed database path.")
+        if not self._database_path.exists():
+            raise RuntimeError(f"Corrupted database file not found: {self._database_path}")
+
+        quarantine_root = self._resolve_quarantine_root()
+        if quarantine_root is None:
+            raise RuntimeError("Failed to resolve quarantine directory for corrupted database.")
+
+        timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        suffix = self._database_path.suffix or ".sqlite3"
+        quarantined_path = quarantine_root / (
+            f"{self._database_path.stem}-corrupt-{timestamp}-{uuid.uuid4().hex[:8]}{suffix}"
+        )
+
+        quarantine_root.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(self._database_path), str(quarantined_path))
+        return {
+            "triggered": True,
+            "recovered": True,
+            "error": None,
+            "reason": reason,
+            "at_utc": datetime.now(UTC).isoformat(),
+            "original_path": str(self._database_path),
+            "quarantined_path": str(quarantined_path),
+            "quarantine_dir": str(quarantine_root),
+            "operator_action": (
+                "Inspect quarantined DB, restore from known-good backup if needed, "
+                "then disable safe mode with operator reason."
+            ),
+        }
+
+    def startup_recovery_status(self) -> dict[str, object]:
+        snapshot = dict(self._startup_recovery_state)
+        quarantined_path = snapshot.get("quarantined_path")
+        if isinstance(quarantined_path, str) and quarantined_path:
+            snapshot["quarantined_exists"] = Path(quarantined_path).exists()
+        else:
+            snapshot["quarantined_exists"] = False
+        return snapshot
+
+    def initialize(self) -> None:
+        startup_error: Exception | None = None
+        try:
+            self._initialize_once()
+            return
+        except Exception as exc:
+            startup_error = exc
+            can_attempt_recovery = (
+                self.startup_corruption_recovery_enabled
+                and self._database_path is not None
+                and self._database_path.exists()
+                and self._is_corruption_error(exc)
+            )
+            if not can_attempt_recovery:
+                raise
+
+        try:
+            self._startup_recovery_state = self._quarantine_corrupted_database(
+                reason=str(startup_error),
+            )
+        except Exception as quarantine_error:
+            self._startup_recovery_state = {
+                **self._startup_recovery_state,
+                "triggered": True,
+                "recovered": False,
+                "error": str(quarantine_error),
+                "reason": str(startup_error),
+                "at_utc": datetime.now(UTC).isoformat(),
+                "operator_action": (
+                    "Manually quarantine or replace the database file before restarting the service."
+                ),
+            }
+            raise RuntimeError(
+                "Detected SQLite corruption but quarantine recovery failed during startup."
+            ) from quarantine_error
+
+        self._database_existed_at_startup = False
+        self._last_migration_backup_path = None
+        self._last_migration_backup_created_at = None
+        self._last_migration_backup_versions = []
+        self._initialize_once()
 
     def _apply_migrations(self, conn: sqlite3.Connection) -> None:
         pending = self._pending_migrations(conn)

--- a/goal_ops_console/observability.py
+++ b/goal_ops_console/observability.py
@@ -62,6 +62,7 @@ class ObservabilityService:
             "runtime.safe_mode.activated",
             "runtime.db_errors.lock",
             "runtime.db_errors.io",
+            "runtime.db_startup_recovery.quarantined",
             "invariants.violations.detected",
         )
         summary: dict[str, int] = {}

--- a/goal_ops_console/routers/system.py
+++ b/goal_ops_console/routers/system.py
@@ -58,12 +58,14 @@ def _build_health_payload(services: AppServices) -> dict[str, Any]:
         "invariant_violations": services.state_manager.find_invariant_violations(),
         "invariant_monitor": services.invariant_monitor.status(),
         "safe_mode": services.runtime_guard.safe_mode_snapshot(),
+        "database_startup_recovery": services.db.startup_recovery_status(),
     }
 
 
 def _build_readiness_payload(services: AppServices) -> dict[str, Any]:
     db_ok = True
     db_error: str | None = None
+    db_startup_recovery = services.db.startup_recovery_status()
     try:
         services.db.fetch_scalar("SELECT 1")
     except Exception as exc:
@@ -158,6 +160,7 @@ def _build_readiness_payload(services: AppServices) -> dict[str, Any]:
             "database": {
                 "ok": db_ok,
                 "error": db_error,
+                "startup_recovery": db_startup_recovery,
             },
             "workflow_worker": {
                 **worker_status,
@@ -198,6 +201,8 @@ def _status_from_alerts(alerts: list[dict[str, Any]]) -> str:
 
 def _build_slo_payload(services: AppServices) -> dict[str, Any]:
     readiness = _build_readiness_payload(services)
+    database_check = readiness["checks"].get("database", {})
+    db_startup_recovery = database_check.get("startup_recovery", {})
     safe_mode = readiness["checks"].get("safe_mode", {})
     invariant_monitor = readiness["checks"].get("invariant_monitor", {})
     db_integrity = services.db.integrity_check(mode="quick")
@@ -282,6 +287,15 @@ def _build_slo_payload(services: AppServices) -> dict[str, Any]:
             "Database quick integrity check failed.",
             observed=db_integrity.get("result"),
             threshold="ok",
+        )
+
+    if bool(db_startup_recovery.get("triggered")):
+        add_alert(
+            "database.startup_recovery.triggered",
+            "critical",
+            "Startup corruption recovery quarantined the database and requires operator validation.",
+            observed=db_startup_recovery,
+            threshold=False,
         )
 
     if bool(safe_mode.get("active")):
@@ -373,6 +387,7 @@ def _build_slo_payload(services: AppServices) -> dict[str, Any]:
         "event_failure_rate_percent": event_failure_rate_percent,
         "backlog_utilization_percent": backlog_utilization_percent,
         "stuck_events_count": stuck_events_count,
+        "database_startup_recovery_triggered": bool(db_startup_recovery.get("triggered")),
         "safe_mode_active": bool(safe_mode.get("active")),
         "invariant_violation_count": invariant_violation_count,
     }
@@ -457,6 +472,7 @@ def database_integrity(
         "timestamp_utc": _utc_iso(),
         "integrity": check,
         "file": services.db.database_file_info(),
+        "startup_recovery": services.db.startup_recovery_status(),
         "migrations": services.db.migration_status(),
     }
 
@@ -479,6 +495,7 @@ def export_system_diagnostics(services: AppServices = Depends(get_services)) -> 
             "normalized_url": services.db.database_url,
             "file": services.db.database_file_info(),
             "integrity": services.db.integrity_check(mode="quick"),
+            "startup_recovery": services.db.startup_recovery_status(),
             "migrations": services.db.migration_status(),
         },
         "readiness": _build_readiness_payload(services),

--- a/goal_ops_console/services.py
+++ b/goal_ops_console/services.py
@@ -39,6 +39,8 @@ def build_services(settings: Settings | None = None) -> AppServices:
     db = Database(
         app_settings.database_url,
         migration_backup_dir=app_settings.db_migration_backup_dir,
+        quarantine_dir=app_settings.db_quarantine_dir,
+        startup_corruption_recovery_enabled=app_settings.db_startup_corruption_recovery_enabled,
     )
     db.initialize()
     observability = ObservabilityService(db)
@@ -50,6 +52,19 @@ def build_services(settings: Settings | None = None) -> AppServices:
         auto_disable_after_seconds=app_settings.safe_mode_auto_disable_after_seconds,
         observability=observability,
     )
+    startup_recovery = db.startup_recovery_status()
+    if bool(startup_recovery.get("triggered")) and bool(startup_recovery.get("recovered")):
+        quarantined_path = str(startup_recovery.get("quarantined_path") or "")
+        runtime_guard.activate_safe_mode(
+            reason=(
+                "Startup detected SQLite corruption; file was quarantined"
+                + (f" at {quarantined_path}." if quarantined_path else ".")
+                + " Verify backup/restore plan before re-enabling mutating API operations."
+            ),
+            source="db_startup_recovery",
+            auto=True,
+        )
+        observability.increment_metric("runtime.db_startup_recovery.quarantined")
     event_bus = EventBus(
         db,
         default_consumer_id=app_settings.consumer_id,

--- a/scripts/db-corruption-quarantine-drill.py
+++ b/scripts/db-corruption-quarantine-drill.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sqlite3
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from goal_ops_console.config import Settings
+from goal_ops_console.main import create_app
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+@dataclass(slots=True)
+class DrillPaths:
+    run_dir: Path
+    database_path: Path
+    quarantine_dir: Path
+
+
+def _create_paths(workspace_root: Path) -> DrillPaths:
+    run_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+    run_dir = workspace_root / f"db-corruption-quarantine-{run_id}"
+    return DrillPaths(
+        run_dir=run_dir,
+        database_path=run_dir / "corrupted-startup.db",
+        quarantine_dir=run_dir / "quarantine",
+    )
+
+
+def _seed_corrupted_database(path: Path, *, bytes_count: int) -> None:
+    payload = bytes(((idx * 37 + 19) % 256 for idx in range(max(64, int(bytes_count)))))
+    path.write_bytes(payload)
+
+
+def _assert_sqlite_healthy(database_path: Path) -> None:
+    connection = sqlite3.connect(str(database_path))
+    try:
+        row = connection.execute("PRAGMA quick_check").fetchone()
+        _expect(row is not None, "PRAGMA quick_check returned no rows after recovery.")
+        _expect(str(row[0]).lower() == "ok", f"Recovered database integrity is not ok: {row[0]!r}")
+    finally:
+        connection.close()
+
+
+def run_drill(
+    *,
+    workspace_root: Path,
+    label: str,
+    keep_artifacts: bool,
+    corruption_bytes: int,
+) -> dict:
+    started = time.perf_counter()
+    paths = _create_paths(workspace_root)
+    paths.run_dir.mkdir(parents=True, exist_ok=False)
+    paths.quarantine_dir.mkdir(parents=True, exist_ok=True)
+    _seed_corrupted_database(paths.database_path, bytes_count=corruption_bytes)
+
+    try:
+        app = create_app(
+            Settings(
+                database_url=str(paths.database_path),
+                db_quarantine_dir=str(paths.quarantine_dir),
+                db_startup_corruption_recovery_enabled=True,
+                workflow_worker_poll_interval_seconds=0.05,
+            )
+        )
+        with TestClient(app) as client:
+            readiness_before = client.get("/system/readiness")
+            _expect(readiness_before.status_code == 200, "Readiness endpoint failed after startup recovery.")
+            readiness_before_payload = readiness_before.json()
+
+            health = client.get("/system/health")
+            _expect(health.status_code == 200, "Health endpoint failed after startup recovery.")
+            health_payload = health.json()
+
+            integrity = client.get("/system/database/integrity?mode=quick")
+            _expect(integrity.status_code == 200, "Database integrity endpoint failed after startup recovery.")
+            integrity_payload = integrity.json()
+
+            blocked_goal = client.post(
+                "/goals",
+                json={
+                    "title": "Blocked During Startup Recovery",
+                    "description": "safe mode should block this mutation",
+                    "urgency": 0.5,
+                    "value": 0.5,
+                    "deadline_score": 0.2,
+                },
+            )
+
+            disable_safe_mode = client.post(
+                "/system/safe-mode/disable",
+                json={"reason": "Startup DB corruption drill completed and validated."},
+            )
+            _expect(
+                disable_safe_mode.status_code == 200,
+                f"Safe-mode disable failed: {disable_safe_mode.text}",
+            )
+
+            post_disable_goal = client.post(
+                "/goals",
+                json={
+                    "title": "Allowed After Startup Recovery",
+                    "description": "safe mode disabled after validation",
+                    "urgency": 0.6,
+                    "value": 0.7,
+                    "deadline_score": 0.3,
+                },
+            )
+
+            readiness_after = client.get("/system/readiness")
+            _expect(readiness_after.status_code == 200, "Readiness endpoint failed after safe-mode disable.")
+            readiness_after_payload = readiness_after.json()
+
+        startup_recovery = (
+            integrity_payload.get("startup_recovery")
+            if isinstance(integrity_payload, dict)
+            else {}
+        )
+        if not isinstance(startup_recovery, dict):
+            startup_recovery = {}
+        quarantined_path = str(startup_recovery.get("quarantined_path") or "")
+        _expect(bool(startup_recovery.get("triggered")), "Startup recovery was not triggered by corrupted DB.")
+        _expect(bool(startup_recovery.get("recovered")), "Startup recovery did not report successful recovery.")
+        _expect(bool(startup_recovery.get("quarantined_exists")), "Quarantined DB file was not found.")
+        _expect(quarantined_path, "Startup recovery did not report quarantined_path.")
+        _expect(
+            Path(quarantined_path).exists(),
+            f"Reported quarantined database file does not exist: {quarantined_path}",
+        )
+        _expect(blocked_goal.status_code == 503, "Mutating endpoint was not blocked while safe mode was active.")
+        _expect(
+            post_disable_goal.status_code == 201,
+            f"Mutating endpoint not restored after disabling safe mode: {post_disable_goal.text}",
+        )
+        _expect(
+            readiness_before_payload.get("ready") is False,
+            "Readiness should be false while safe mode is active after startup recovery.",
+        )
+        _expect(
+            readiness_after_payload.get("ready") is True,
+            "Readiness should recover to true after explicit safe-mode disable.",
+        )
+
+        _assert_sqlite_healthy(paths.database_path)
+
+        return {
+            "label": label,
+            "success": True,
+            "startup_recovery": startup_recovery,
+            "blocked_status_code": int(blocked_goal.status_code),
+            "post_disable_goal_create_status_code": int(post_disable_goal.status_code),
+            "readiness_before": readiness_before_payload,
+            "readiness_after": readiness_after_payload,
+            "health_safe_mode": health_payload.get("safe_mode"),
+            "database_integrity": integrity_payload.get("integrity"),
+            "paths": {
+                "run_dir": str(paths.run_dir),
+                "database_path": str(paths.database_path),
+                "quarantine_dir": str(paths.quarantine_dir),
+            },
+            "duration_ms": int((time.perf_counter() - started) * 1000),
+        }
+    finally:
+        if not keep_artifacts:
+            shutil.rmtree(paths.run_dir, ignore_errors=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Startup DB corruption quarantine drill: seed a corrupted SQLite file, verify automatic "
+            "quarantine + safe-mode activation, then validate operator recovery path."
+        )
+    )
+    parser.add_argument("--workspace", default=str(PROJECT_ROOT / ".tmp" / "db-corruption-quarantine-drills"))
+    parser.add_argument("--label", default="db-corruption-quarantine-drill")
+    parser.add_argument("--corruption-bytes", type=int, default=256)
+    parser.add_argument("--keep-artifacts", action="store_true")
+    args = parser.parse_args(argv)
+
+    workspace_root = Path(str(args.workspace)).expanduser()
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    try:
+        report = run_drill(
+            workspace_root=workspace_root,
+            label=str(args.label),
+            keep_artifacts=bool(args.keep_artifacts),
+            corruption_bytes=int(args.corruption_bytes),
+        )
+    except Exception as exc:
+        print(f"[db-corruption-quarantine-drill] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -14,6 +14,8 @@ param(
     [switch]$StrictDesktopUpdateSafetyDrill,
     [switch]$SkipRecoveryHardAbortDrill,
     [switch]$StrictRecoveryHardAbortDrill,
+    [switch]$SkipDbCorruptionQuarantineDrill,
+    [switch]$StrictDbCorruptionQuarantineDrill,
     [switch]$SkipWorkflowLockResilienceDrill,
     [switch]$StrictWorkflowLockResilienceDrill,
     [switch]$SkipWorkflowSoakDrill,
@@ -205,6 +207,27 @@ if (-not $SkipRecoveryHardAbortDrill) {
             }
             Write-Warning (
                 "Recovery hard-abort drill failed but StrictRecoveryHardAbortDrill is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipDbCorruptionQuarantineDrill) {
+    Invoke-GateStep -Name "DB corruption quarantine drill (startup quarantine + safe-mode recovery path)" -Action {
+        $workspace = Join-Path $ProjectRoot ".tmp\db-corruption-quarantine-drills"
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\db-corruption-quarantine-drill.py",
+                "--workspace", $workspace,
+                "--label", "release-gate"
+            )
+        } catch {
+            if ($StrictDbCorruptionQuarantineDrill) {
+                throw
+            }
+            Write-Warning (
+                "DB corruption quarantine drill failed but StrictDbCorruptionQuarantineDrill is off. " +
                 "Continuing. Error: $($_.Exception.Message)"
             )
         }

--- a/scripts/run-db-corruption-quarantine-drill.ps1
+++ b/scripts/run-db-corruption-quarantine-drill.ps1
@@ -1,0 +1,28 @@
+param(
+    [string]$PythonExe = "python",
+    [string]$WorkspaceDir = ".tmp\\db-corruption-quarantine-drills",
+    [int]$CorruptionBytes = 256,
+    [switch]$KeepArtifacts
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$args = @(
+    ".\\scripts\\db-corruption-quarantine-drill.py",
+    "--workspace", $WorkspaceDir,
+    "--label", "manual",
+    "--corruption-bytes", [string]$CorruptionBytes
+)
+if ($KeepArtifacts) {
+    $args += "--keep-artifacts"
+}
+
+& $PythonExe @args
+if ($LASTEXITCODE -ne 0) {
+    throw "DB corruption quarantine drill failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "DB corruption quarantine drill passed." -ForegroundColor Green

--- a/scripts/stability-canary.py
+++ b/scripts/stability-canary.py
@@ -92,6 +92,16 @@ def run_canary(
             "--promotion-test-version",
             "0.0.3",
         ],
+        "db_corruption_quarantine": [
+            sys.executable,
+            str(PROJECT_ROOT / "scripts" / "db-corruption-quarantine-drill.py"),
+            "--workspace",
+            str(PROJECT_ROOT / ".tmp" / "stability-canary-db-corruption"),
+            "--label",
+            "stability-canary",
+            "--corruption-bytes",
+            "256",
+        ],
         "db_safe_mode_watchdog": [
             sys.executable,
             str(PROJECT_ROOT / "scripts" / "db-safe-mode-watchdog-drill.py"),

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -2255,6 +2255,7 @@ def test_94_stability_canary_reports_success_with_short_soak():
                 "max_duration_regression_percent": 10_000.0,
                 "drills": {
                     "release_freeze_policy": {"baseline_duration_seconds": 0.1},
+                    "db_corruption_quarantine": {"baseline_duration_seconds": 0.1},
                     "db_safe_mode_watchdog": {"baseline_duration_seconds": 0.1},
                     "invariant_monitor_watchdog": {"baseline_duration_seconds": 0.1},
                     "event_consumer_recovery_chaos": {"baseline_duration_seconds": 0.1},
@@ -2296,4 +2297,112 @@ def test_94_stability_canary_reports_success_with_short_soak():
     payload = json.loads(output_lines[-1])
     assert payload["success"] is True
     assert report_file.exists()
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_95_startup_db_corruption_quarantine_activates_safe_mode():
+    workspace = _local_test_dir("pytest-db-corruption-startup-recovery")
+    db_path = workspace / "corrupted.db"
+    quarantine_dir = workspace / "quarantine"
+    db_path.write_bytes(b"this is not a sqlite database file")
+
+    app = create_app(
+        Settings(
+            database_url=str(db_path),
+            db_quarantine_dir=str(quarantine_dir),
+            db_startup_corruption_recovery_enabled=True,
+            workflow_worker_poll_interval_seconds=0.05,
+        )
+    )
+    with TestClient(app) as local_client:
+        readiness_before = local_client.get("/system/readiness")
+        assert readiness_before.status_code == 200
+        readiness_before_payload = readiness_before.json()
+
+        startup_recovery = readiness_before_payload["checks"]["database"]["startup_recovery"]
+        assert readiness_before_payload["ready"] is False
+        assert startup_recovery["triggered"] is True
+        assert startup_recovery["recovered"] is True
+        assert startup_recovery["quarantined_exists"] is True
+        assert startup_recovery["quarantined_path"]
+
+        safe_mode = local_client.get("/system/safe-mode").json()
+        assert safe_mode["active"] is True
+        assert safe_mode["source"] == "db_startup_recovery"
+
+        blocked = local_client.post(
+            "/goals",
+            json={
+                "title": "Blocked by startup recovery safe mode",
+                "description": "mutation should be blocked",
+                "urgency": 0.4,
+                "value": 0.5,
+                "deadline_score": 0.2,
+            },
+        )
+        assert blocked.status_code == 503
+
+        disable = local_client.post(
+            "/system/safe-mode/disable",
+            json={"reason": "Startup corruption recovered and validated in test."},
+        )
+        assert disable.status_code == 200
+
+        created = local_client.post(
+            "/goals",
+            json={
+                "title": "Allowed after startup recovery",
+                "description": "safe mode disabled",
+                "urgency": 0.6,
+                "value": 0.7,
+                "deadline_score": 0.3,
+            },
+        )
+        assert created.status_code == 201
+
+        readiness_after = local_client.get("/system/readiness")
+        assert readiness_after.status_code == 200
+        assert readiness_after.json()["ready"] is True
+
+        integrity = local_client.get("/system/database/integrity?mode=quick")
+        assert integrity.status_code == 200
+        startup_recovery_integrity = integrity.json()["startup_recovery"]
+        assert startup_recovery_integrity["triggered"] is True
+        assert startup_recovery_integrity["recovered"] is True
+        assert startup_recovery_integrity["quarantined_exists"] is True
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_96_db_corruption_quarantine_drill_reports_success():
+    workspace = _local_test_dir("pytest-db-corruption-quarantine-drill")
+    project_root = Path(__file__).resolve().parents[1]
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "db-corruption-quarantine-drill.py"),
+        "--workspace",
+        str(workspace),
+        "--label",
+        "pytest-drill",
+        "--corruption-bytes",
+        "192",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0 and "disk i/o error" in completed.stderr.lower():
+        shutil.rmtree(workspace, ignore_errors=True)
+        pytest.skip("File-backed SQLite is unavailable in this sandbox")
+    assert completed.returncode == 0, completed.stderr
+
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    assert payload["success"] is True
+    assert payload["startup_recovery"]["triggered"] is True
+    assert payload["startup_recovery"]["recovered"] is True
+    assert payload["blocked_status_code"] == 503
+    assert payload["post_disable_goal_create_status_code"] == 201
     shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
﻿## Summary
- add startup SQLite corruption recovery with quarantine in `Database.initialize()`
  - detect corruption signatures (`file is not a database`, `database disk image is malformed`, etc.)
  - move corrupted file into quarantine directory
  - initialize a fresh database file and expose structured startup-recovery status
- add automatic safe-mode activation when startup DB quarantine recovery is triggered
  - source: `db_startup_recovery`
  - explicit operator guidance in safe-mode reason
- expose startup DB recovery status in system payloads:
  - `GET /system/health`
  - `GET /system/readiness` (`checks.database.startup_recovery`)
  - `GET /system/database/integrity`
  - diagnostics export payload
- add new P0 drill + wrapper:
  - `scripts/db-corruption-quarantine-drill.py`
  - `scripts/run-db-corruption-quarantine-drill.ps1`
- integrate drill into release gate and CI strict gate:
  - new flags `-SkipDbCorruptionQuarantineDrill` / `-StrictDbCorruptionQuarantineDrill`
  - CI now runs `-StrictDbCorruptionQuarantineDrill`
- include drill in nightly stability canary baseline/runner
- extend docs (README + production runbook) with recovery flow, operator actions, and commands
- add tests for startup corruption recovery and drill success

## Validation
- `python -m pytest -q tests/test_goal_ops.py::test_95_startup_db_corruption_quarantine_activates_safe_mode tests/test_goal_ops.py::test_96_db_corruption_quarantine_drill_reports_success tests/test_goal_ops.py::test_94_stability_canary_reports_success_with_short_soak`
- `powershell -ExecutionPolicy Bypass -File .\scripts\release-gate.ps1 -SkipPytest -SkipDesktopSmoke -SkipApiProbe -SkipSloAlertCheck -SkipReleaseFreezePolicyDrill -SkipFileDatabaseProbe -SkipAutoRollbackPolicyDrill -SkipDesktopUpdateSafetyDrill -SkipRecoveryHardAbortDrill -StrictDbCorruptionQuarantineDrill -SkipWorkflowLockResilienceDrill -SkipWorkflowSoakDrill -SkipWorkflowWorkerRestartDrill -SkipDbSafeModeWatchdogDrill -SkipInvariantMonitorWatchdogDrill -SkipEventConsumerRecoveryChaosDrill -SkipInvariantBurstDrill -SkipLongSoakBudgetDrill -SkipMigrationRehearsal -SkipBackupRestoreDrill -SkipIncidentRollbackDrill`
- `python -m pytest -q` -> `117 passed`

## Operator Impact
- On detected startup DB corruption (file-backed DB), app now quarantines the corrupted DB automatically and enters safe mode.
- Mutating endpoints stay blocked until operator explicitly disables safe mode after validation.
- Recovery evidence is available via readiness/integrity/diagnostics payloads.
