### PR TITLE
P0: WAL checkpoint crash durability drill + strict gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run release gate
         shell: pwsh
         run: |
-          .\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictPowerLossDurabilityDrill -StrictDiskPressureFaultInjectionDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+          .\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 
   test:
     name: Pytest (Python ${{ matrix.python-version }})

--- a/README.md
+++ b/README.md
@@ -410,11 +410,11 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + power-loss durability drill + disk-pressure fault-injection drill + real SQLite FULL saturation drill + DB corruption quarantine drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + incident/rollback drill under burst load):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + real SQLite FULL saturation drill + DB corruption quarantine drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + incident/rollback drill under burst load):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictPowerLossDurabilityDrill -StrictDiskPressureFaultInjectionDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 ```
 
 Standalone backup/restore drill:
@@ -471,6 +471,13 @@ Standalone power-loss durability drill:
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-power-loss-durability-drill.ps1 -TransactionRows 240 -PayloadBytes 256
+```
+
+Standalone WAL checkpoint crash drill (hard-abort before checkpoint completion + recovery checkpoint):
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-wal-checkpoint-crash-drill.ps1 -Rows 240 -PayloadBytes 1024 -CheckpointMode TRUNCATE
 ```
 
 Standalone disk-pressure fault-injection drill (SQLITE_FULL, IOERR, readonly/permission-flip simulation):
@@ -765,6 +772,9 @@ If a value is rejected:
 - [power-loss-durability-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/power-loss-durability-drill.py)
 - [power-loss-durability-target.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/power-loss-durability-target.py)
 - [run-power-loss-durability-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-power-loss-durability-drill.ps1)
+- [wal-checkpoint-crash-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/wal-checkpoint-crash-drill.py)
+- [wal-checkpoint-crash-target.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/wal-checkpoint-crash-target.py)
+- [run-wal-checkpoint-crash-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-wal-checkpoint-crash-drill.ps1)
 - [disk-pressure-fault-injection-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/disk-pressure-fault-injection-drill.py)
 - [run-disk-pressure-fault-injection-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-disk-pressure-fault-injection-drill.ps1)
 - [sqlite-real-full-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/sqlite-real-full-drill.py)

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -9,7 +9,7 @@ This runbook is optimized for reliability-first releases of the desktop app and 
 Run in repo root:
 
 ```powershell
-.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictPowerLossDurabilityDrill -StrictDiskPressureFaultInjectionDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
+.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictIncidentRollbackDrill
 ```
 
 This gate covers:
@@ -22,6 +22,7 @@ This gate covers:
 - desktop-update-safety drill (hash validation + rollback-to-stable fallback path)
 - recovery hard-abort drill (kill running worker process, restart, and verify no hanging `running` runs)
 - power-loss durability drill (abort transaction process before commit and after commit, validate rollback + durable persistence)
+- WAL checkpoint crash drill (hard-abort after commit but before checkpoint completion, verify durability + checkpoint recovery)
 - disk-pressure fault-injection drill (SQLITE_FULL/IOERR/readonly signatures trigger deterministic safe-mode degradation and recovery)
 - real SQLite FULL drill (actual `max_page_count` saturation to force natural write failure + controlled recovery)
 - DB corruption quarantine drill (startup quarantines corrupted SQLite file and enters guarded safe mode)
@@ -80,6 +81,12 @@ Manual power-loss durability drill invocation:
 
 ```powershell
 .\scripts\run-power-loss-durability-drill.ps1 -TransactionRows 240 -PayloadBytes 256
+```
+
+Manual WAL checkpoint crash drill invocation:
+
+```powershell
+.\scripts\run-wal-checkpoint-crash-drill.ps1 -Rows 240 -PayloadBytes 1024 -CheckpointMode TRUNCATE
 ```
 
 Manual disk-pressure fault-injection drill invocation:
@@ -619,7 +626,26 @@ Actions:
    - `app_probe.slo_status = ok`
 3. If durability checks fail, block release, preserve artifacts (`-KeepArtifacts`), and escalate with drill JSON + diagnostics snapshot.
 
-### 3.22 Disk pressure, IO errors, or permission-flip uncertainty
+### 3.22 WAL checkpoint crash durability uncertainty
+
+Symptoms:
+- process crash/power-loss concern after a transaction commit but before WAL checkpoint completion
+- uncertainty whether committed rows remain durable and whether recovery checkpoint returns the DB to a clean steady state
+
+Actions:
+1. Run WAL checkpoint crash drill:
+   ```powershell
+   .\scripts\run-wal-checkpoint-crash-drill.ps1 -Rows 240 -PayloadBytes 1024 -CheckpointMode TRUNCATE
+   ```
+2. Confirm drill outputs:
+   - `scenario.rows_persisted_before_crash = rows`
+   - `scenario.rows_observed_after_crash = rows`
+   - `checkpoint_recovery.busy = 0`
+   - `app_probe.readiness_ready = true`
+   - `app_probe.slo_status = ok`
+3. If durability, integrity, or checkpoint recovery checks fail, hold release, preserve artifacts (`-KeepArtifacts`), and escalate with drill JSON + diagnostics snapshot.
+
+### 3.23 Disk pressure, IO errors, or permission-flip uncertainty
 
 Symptoms:
 - intermittent writes fail with SQLite errors such as `database or disk is full`, `disk i/o error`, or `attempt to write a readonly database`
@@ -639,7 +665,7 @@ Actions:
    - `slo.after_recovery = ok`
 3. If any case fails, hold release and escalate with drill JSON + diagnostics snapshot before retrying rollout.
 
-### 3.23 Real SQLite FULL saturation uncertainty
+### 3.24 Real SQLite FULL saturation uncertainty
 
 Symptoms:
 - uncertainty whether the app handles true file-backed `SQLITE_FULL` behavior (not only simulated exceptions)

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -16,6 +16,8 @@ param(
     [switch]$StrictRecoveryHardAbortDrill,
     [switch]$SkipPowerLossDurabilityDrill,
     [switch]$StrictPowerLossDurabilityDrill,
+    [switch]$SkipWalCheckpointCrashDrill,
+    [switch]$StrictWalCheckpointCrashDrill,
     [switch]$SkipDiskPressureFaultInjectionDrill,
     [switch]$StrictDiskPressureFaultInjectionDrill,
     [switch]$SkipSqliteRealFullDrill,
@@ -239,6 +241,32 @@ if (-not $SkipPowerLossDurabilityDrill) {
             }
             Write-Warning (
                 "Power-loss durability drill failed but StrictPowerLossDurabilityDrill is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipWalCheckpointCrashDrill) {
+    Invoke-GateStep -Name "WAL checkpoint crash drill (hard-abort before checkpoint + post-restart recovery)" -Action {
+        $workspace = Join-Path $ProjectRoot ".tmp\wal-checkpoint-crash-drills"
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\wal-checkpoint-crash-drill.py",
+                "--workspace", $workspace,
+                "--label", "release-gate",
+                "--rows", "240",
+                "--payload-bytes", "1024",
+                "--startup-timeout-seconds", "15",
+                "--sleep-before-checkpoint-seconds", "30",
+                "--checkpoint-mode", "TRUNCATE"
+            )
+        } catch {
+            if ($StrictWalCheckpointCrashDrill) {
+                throw
+            }
+            Write-Warning (
+                "WAL checkpoint crash drill failed but StrictWalCheckpointCrashDrill is off. " +
                 "Continuing. Error: $($_.Exception.Message)"
             )
         }

--- a/scripts/run-wal-checkpoint-crash-drill.ps1
+++ b/scripts/run-wal-checkpoint-crash-drill.ps1
@@ -1,0 +1,37 @@
+param(
+    [string]$PythonExe = "python",
+    [string]$WorkspaceDir = ".tmp\\wal-checkpoint-crash-drills",
+    [int]$Rows = 240,
+    [int]$PayloadBytes = 1024,
+    [double]$StartupTimeoutSeconds = 15.0,
+    [double]$SleepBeforeCheckpointSeconds = 30.0,
+    [ValidateSet("PASSIVE", "FULL", "TRUNCATE")]
+    [string]$CheckpointMode = "TRUNCATE",
+    [switch]$KeepArtifacts
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$args = @(
+    ".\\scripts\\wal-checkpoint-crash-drill.py",
+    "--workspace", $WorkspaceDir,
+    "--label", "manual",
+    "--rows", [string]$Rows,
+    "--payload-bytes", [string]$PayloadBytes,
+    "--startup-timeout-seconds", [string]$StartupTimeoutSeconds,
+    "--sleep-before-checkpoint-seconds", [string]$SleepBeforeCheckpointSeconds,
+    "--checkpoint-mode", [string]$CheckpointMode
+)
+if ($KeepArtifacts) {
+    $args += "--keep-artifacts"
+}
+
+& $PythonExe @args
+if ($LASTEXITCODE -ne 0) {
+    throw "WAL checkpoint crash drill failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "WAL checkpoint crash drill passed." -ForegroundColor Green

--- a/scripts/wal-checkpoint-crash-drill.py
+++ b/scripts/wal-checkpoint-crash-drill.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sqlite3
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from goal_ops_console.config import Settings
+from goal_ops_console.main import create_app
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _connect(database_path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(
+        str(database_path),
+        check_same_thread=False,
+        isolation_level=None,
+    )
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.execute("PRAGMA busy_timeout = 5000")
+    return connection
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    _expect(isinstance(payload, dict), f"Expected JSON object in {path}")
+    return payload
+
+
+def _consume_process_output(process: subprocess.Popen[str]) -> tuple[str, str]:
+    stdout_text = process.stdout.read() if process.stdout is not None else ""
+    stderr_text = process.stderr.read() if process.stderr is not None else ""
+    return stdout_text, stderr_text
+
+
+def _stop_process(process: subprocess.Popen[str], *, timeout_seconds: float = 10.0) -> tuple[int, str, str]:
+    if process.poll() is None:
+        process.kill()
+    try:
+        process.wait(timeout=max(1.0, float(timeout_seconds)))
+    except subprocess.TimeoutExpired:
+        process.terminate()
+        process.wait(timeout=5.0)
+    stdout_text, stderr_text = _consume_process_output(process)
+    return int(process.returncode if process.returncode is not None else -1), stdout_text, stderr_text
+
+
+def _wait_for_state(
+    *,
+    process: subprocess.Popen[str],
+    state_file: Path,
+    expected_status: str,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    deadline = time.time() + max(1.0, float(timeout_seconds))
+    while time.time() < deadline:
+        if state_file.exists():
+            try:
+                payload = _read_json(state_file)
+            except Exception:
+                payload = {}
+            status = str(payload.get("status") or "")
+            if status == "error":
+                raise RuntimeError(
+                    f"Target process reported error state: {json.dumps(payload, sort_keys=True)}"
+                )
+            if status == expected_status:
+                return payload
+        if process.poll() is not None:
+            stdout_text, stderr_text = _consume_process_output(process)
+            raise RuntimeError(
+                "Target process exited before expected state. "
+                f"expected={expected_status!r} rc={process.returncode} "
+                f"stdout={stdout_text!r} stderr={stderr_text!r}"
+            )
+        time.sleep(0.05)
+    raise RuntimeError(
+        f"Target process did not report state {expected_status!r} within {timeout_seconds}s."
+    )
+
+
+def _row_count(database_path: Path, marker: str) -> int:
+    connection = _connect(database_path)
+    try:
+        row = connection.execute(
+            "SELECT COUNT(*) FROM wal_checkpoint_probe WHERE marker = ?",
+            (marker,),
+        ).fetchone()
+        return int(row[0] if row is not None else 0)
+    finally:
+        connection.close()
+
+
+def _wal_artifacts(database_path: Path) -> dict[str, dict[str, Any]]:
+    artifacts: dict[str, dict[str, Any]] = {}
+    for suffix in ("-wal", "-shm"):
+        artifact_path = Path(str(database_path) + suffix)
+        exists = artifact_path.exists()
+        artifacts[suffix] = {
+            "path": str(artifact_path),
+            "exists": exists,
+            "size_bytes": int(artifact_path.stat().st_size) if exists else 0,
+        }
+    return artifacts
+
+
+def _integrity_profile(database_path: Path) -> dict[str, Any]:
+    connection = _connect(database_path)
+    try:
+        journal_mode = str(connection.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+        quick_check = str(connection.execute("PRAGMA quick_check").fetchone()[0])
+        full_check = str(connection.execute("PRAGMA integrity_check").fetchone()[0])
+    finally:
+        connection.close()
+    return {
+        "journal_mode": journal_mode,
+        "quick_check": quick_check,
+        "full_check": full_check,
+        "quick_ok": quick_check.lower() == "ok",
+        "full_ok": full_check.lower() == "ok",
+    }
+
+
+def _run_checkpoint(database_path: Path, checkpoint_mode: str) -> dict[str, Any]:
+    connection = _connect(database_path)
+    try:
+        row = connection.execute(f"PRAGMA wal_checkpoint({checkpoint_mode})").fetchone()
+    finally:
+        connection.close()
+    return {
+        "mode": str(checkpoint_mode),
+        "busy": int(row[0]) if row is not None else -1,
+        "log_frames": int(row[1]) if row is not None else -1,
+        "checkpointed_frames": int(row[2]) if row is not None else -1,
+    }
+
+
+def _running_runs(client: TestClient) -> list[str]:
+    response = client.get("/workflows/runs?limit=200")
+    _expect(response.status_code == 200, f"Workflow runs endpoint failed: {response.status_code}")
+    runs = response.json().get("runs") or []
+    running: list[str] = []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        if str(run.get("status")) == "running" and run.get("run_id"):
+            running.append(str(run.get("run_id")))
+    return running
+
+
+def _app_probe(database_path: Path) -> dict[str, Any]:
+    app = create_app(
+        Settings(
+            database_url=str(database_path),
+            workflow_worker_poll_interval_seconds=0.05,
+            workflow_startup_recovery_max_age_seconds=0,
+        )
+    )
+    with TestClient(app, raise_server_exceptions=False) as client:
+        readiness = client.get("/system/readiness")
+        slo = client.get("/system/slo")
+        safe_mode = client.get("/system/safe-mode")
+        integrity_quick = client.get("/system/database/integrity?mode=quick")
+        integrity_full = client.get("/system/database/integrity?mode=full")
+        created = client.post(
+            "/goals",
+            json={
+                "title": "WAL Checkpoint Crash Drill Goal",
+                "description": "Post-crash checkpoint recovery mutation probe",
+                "urgency": 0.6,
+                "value": 0.7,
+                "deadline_score": 0.3,
+            },
+        )
+        running_runs = _running_runs(client)
+
+    _expect(readiness.status_code == 200, f"Readiness probe failed: {readiness.status_code}")
+    _expect(slo.status_code == 200, f"SLO probe failed: {slo.status_code}")
+    _expect(safe_mode.status_code == 200, f"Safe mode probe failed: {safe_mode.status_code}")
+    _expect(integrity_quick.status_code == 200, f"Quick integrity probe failed: {integrity_quick.status_code}")
+    _expect(integrity_full.status_code == 200, f"Full integrity probe failed: {integrity_full.status_code}")
+    _expect(
+        created.status_code == 201,
+        f"Post-recovery goal write failed: {created.status_code} {created.text}",
+    )
+
+    readiness_payload = readiness.json()
+    slo_payload = slo.json()
+    safe_mode_payload = safe_mode.json()
+    integrity_quick_payload = integrity_quick.json()
+    integrity_full_payload = integrity_full.json()
+    created_payload = created.json()
+
+    _expect(
+        bool(readiness_payload.get("ready")),
+        f"Readiness not ready after WAL checkpoint crash recovery: {readiness_payload}",
+    )
+    _expect(
+        str(slo_payload.get("status")) == "ok",
+        f"SLO status not ok after WAL checkpoint crash recovery: {slo_payload}",
+    )
+    _expect(
+        safe_mode_payload.get("active") is False,
+        f"Safe mode unexpectedly active after WAL checkpoint crash recovery: {safe_mode_payload}",
+    )
+    _expect(
+        bool((integrity_quick_payload.get("integrity") or {}).get("ok")),
+        f"Quick integrity endpoint is not ok: {integrity_quick_payload}",
+    )
+    _expect(
+        bool((integrity_full_payload.get("integrity") or {}).get("ok")),
+        f"Full integrity endpoint is not ok: {integrity_full_payload}",
+    )
+    _expect(
+        not running_runs,
+        f"Found running workflow runs after WAL checkpoint crash recovery: {running_runs}",
+    )
+
+    return {
+        "readiness": readiness_payload,
+        "slo": slo_payload,
+        "safe_mode": safe_mode_payload,
+        "integrity_quick": integrity_quick_payload,
+        "integrity_full": integrity_full_payload,
+        "post_recovery_goal": created_payload,
+        "post_recovery_goal_status_code": int(created.status_code),
+        "running_run_ids": running_runs,
+    }
+
+
+@dataclass(slots=True)
+class DrillPaths:
+    run_dir: Path
+    database_path: Path
+    state_file: Path
+
+
+def _create_paths(workspace_root: Path) -> DrillPaths:
+    run_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+    run_dir = workspace_root / f"wal-checkpoint-crash-{run_id}"
+    return DrillPaths(
+        run_dir=run_dir,
+        database_path=run_dir / "wal-checkpoint-crash.db",
+        state_file=run_dir / "target-state.json",
+    )
+
+
+def run_drill(
+    *,
+    workspace_root: Path,
+    label: str,
+    rows: int,
+    payload_bytes: int,
+    startup_timeout_seconds: float,
+    sleep_before_checkpoint_seconds: float,
+    checkpoint_mode: str,
+    keep_artifacts: bool,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    paths = _create_paths(workspace_root)
+    paths.run_dir.mkdir(parents=True, exist_ok=False)
+
+    target_script = PROJECT_ROOT / "scripts" / "wal-checkpoint-crash-target.py"
+    _expect(target_script.exists(), f"Target helper script missing: {target_script}")
+
+    marker = f"wal-checkpoint-crash-{uuid.uuid4().hex[:10]}"
+    target_process: subprocess.Popen[str] | None = None
+    target_return_code = -1
+    target_stdout = ""
+    target_stderr = ""
+
+    try:
+        target_process = subprocess.Popen(
+            [
+                sys.executable,
+                str(target_script),
+                "--database-path",
+                str(paths.database_path),
+                "--state-file",
+                str(paths.state_file),
+                "--marker",
+                marker,
+                "--rows",
+                str(int(rows)),
+                "--payload-bytes",
+                str(int(payload_bytes)),
+                "--sleep-before-checkpoint-seconds",
+                str(float(sleep_before_checkpoint_seconds)),
+                "--checkpoint-mode",
+                str(checkpoint_mode),
+            ],
+            cwd=PROJECT_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        pending_state = _wait_for_state(
+            process=target_process,
+            state_file=paths.state_file,
+            expected_status="checkpoint_pending",
+            timeout_seconds=max(5.0, float(startup_timeout_seconds)),
+        )
+        target_return_code, target_stdout, target_stderr = _stop_process(target_process)
+        target_process = None
+
+        rows_after_crash = _row_count(paths.database_path, marker)
+        _expect(
+            rows_after_crash == int(rows),
+            (
+                "Committed WAL rows were not durable after checkpoint crash simulation. "
+                f"observed={rows_after_crash} expected={int(rows)} marker={marker}"
+            ),
+        )
+
+        profile_after_crash = _integrity_profile(paths.database_path)
+        _expect(
+            bool(profile_after_crash["quick_ok"]) and bool(profile_after_crash["full_ok"]),
+            f"Database integrity check failed after checkpoint crash: {profile_after_crash}",
+        )
+        wal_artifacts_after_crash = _wal_artifacts(paths.database_path)
+
+        recovery_checkpoint = _run_checkpoint(paths.database_path, checkpoint_mode=str(checkpoint_mode))
+        _expect(
+            int(recovery_checkpoint["busy"]) == 0,
+            f"Checkpoint recovery reported busy writer: {recovery_checkpoint}",
+        )
+        profile_after_recovery = _integrity_profile(paths.database_path)
+        _expect(
+            bool(profile_after_recovery["quick_ok"]) and bool(profile_after_recovery["full_ok"]),
+            f"Database integrity check failed after recovery checkpoint: {profile_after_recovery}",
+        )
+        wal_artifacts_after_recovery = _wal_artifacts(paths.database_path)
+
+        app_probe = _app_probe(paths.database_path)
+
+        return {
+            "label": label,
+            "success": True,
+            "scenario": {
+                "marker": marker,
+                "rows_requested": int(rows),
+                "rows_persisted_before_crash": int(pending_state.get("persisted_rows") or -1),
+                "rows_observed_after_crash": int(rows_after_crash),
+                "target_state": pending_state,
+                "target_process_return_code": int(target_return_code),
+                "target_stdout": target_stdout.strip(),
+                "target_stderr": target_stderr.strip(),
+            },
+            "checkpoint_recovery": recovery_checkpoint,
+            "integrity": {
+                "after_crash": profile_after_crash,
+                "after_recovery_checkpoint": profile_after_recovery,
+            },
+            "wal_artifacts": {
+                "after_crash": wal_artifacts_after_crash,
+                "after_recovery_checkpoint": wal_artifacts_after_recovery,
+            },
+            "app_probe": {
+                "readiness_ready": bool(app_probe["readiness"]["ready"]),
+                "slo_status": str(app_probe["slo"]["status"]),
+                "safe_mode_active": bool(app_probe["safe_mode"]["active"]),
+                "integrity_quick_ok": bool((app_probe["integrity_quick"]["integrity"] or {}).get("ok")),
+                "integrity_full_ok": bool((app_probe["integrity_full"]["integrity"] or {}).get("ok")),
+                "post_recovery_goal_status_code": int(app_probe["post_recovery_goal_status_code"]),
+                "post_recovery_goal_id": str(app_probe["post_recovery_goal"]["goal_id"]),
+                "running_run_ids": app_probe["running_run_ids"],
+            },
+            "decision": {
+                "release_blocked": False,
+                "recommended_action": "proceed",
+            },
+            "paths": {
+                "run_dir": str(paths.run_dir),
+                "database_path": str(paths.database_path),
+                "state_file": str(paths.state_file),
+                "target_script": str(target_script),
+            },
+            "duration_ms": int((time.perf_counter() - started) * 1000),
+        }
+    finally:
+        if target_process is not None and target_process.poll() is None:
+            try:
+                target_process.kill()
+                target_process.wait(timeout=5.0)
+            except Exception:
+                pass
+        if not keep_artifacts:
+            shutil.rmtree(paths.run_dir, ignore_errors=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "WAL checkpoint crash drill: commit rows in WAL mode, hard-abort before checkpoint "
+            "completion, then verify durability, integrity, deterministic readiness/SLO, and "
+            "checkpoint recovery."
+        )
+    )
+    parser.add_argument("--workspace", default=str(PROJECT_ROOT / ".tmp" / "wal-checkpoint-crash-drills"))
+    parser.add_argument("--label", default="wal-checkpoint-crash-drill")
+    parser.add_argument("--rows", type=int, default=240)
+    parser.add_argument("--payload-bytes", type=int, default=1024)
+    parser.add_argument("--startup-timeout-seconds", type=float, default=15.0)
+    parser.add_argument("--sleep-before-checkpoint-seconds", type=float, default=30.0)
+    parser.add_argument("--checkpoint-mode", default="TRUNCATE", choices=("PASSIVE", "FULL", "TRUNCATE"))
+    parser.add_argument("--keep-artifacts", action="store_true")
+    args = parser.parse_args(argv)
+
+    if int(args.rows) <= 0:
+        print("[wal-checkpoint-crash-drill] ERROR: --rows must be > 0.", file=sys.stderr)
+        return 2
+    if int(args.payload_bytes) <= 0:
+        print("[wal-checkpoint-crash-drill] ERROR: --payload-bytes must be > 0.", file=sys.stderr)
+        return 2
+    if float(args.startup_timeout_seconds) <= 0:
+        print("[wal-checkpoint-crash-drill] ERROR: --startup-timeout-seconds must be > 0.", file=sys.stderr)
+        return 2
+    if float(args.sleep_before_checkpoint_seconds) <= 0:
+        print("[wal-checkpoint-crash-drill] ERROR: --sleep-before-checkpoint-seconds must be > 0.", file=sys.stderr)
+        return 2
+
+    workspace_root = Path(str(args.workspace)).expanduser()
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    try:
+        report = run_drill(
+            workspace_root=workspace_root,
+            label=str(args.label),
+            rows=int(args.rows),
+            payload_bytes=int(args.payload_bytes),
+            startup_timeout_seconds=float(args.startup_timeout_seconds),
+            sleep_before_checkpoint_seconds=float(args.sleep_before_checkpoint_seconds),
+            checkpoint_mode=str(args.checkpoint_mode),
+            keep_artifacts=bool(args.keep_artifacts),
+        )
+    except Exception as exc:
+        print(f"[wal-checkpoint-crash-drill] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/wal-checkpoint-crash-target.py
+++ b/scripts/wal-checkpoint-crash-target.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+def _utc_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _connect(database_path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(
+        str(database_path),
+        check_same_thread=False,
+        isolation_level=None,
+    )
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.execute("PRAGMA busy_timeout = 5000")
+    return connection
+
+
+def _write_state(state_file: Path, payload: dict[str, Any]) -> None:
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(
+        json.dumps(payload, ensure_ascii=True, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _wal_size(database_path: Path) -> int:
+    wal_path = Path(str(database_path) + "-wal")
+    if not wal_path.exists():
+        return 0
+    return int(wal_path.stat().st_size)
+
+
+def _setup_schema(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """CREATE TABLE IF NOT EXISTS wal_checkpoint_probe (
+               marker      TEXT NOT NULL,
+               seq         INTEGER NOT NULL,
+               payload     TEXT NOT NULL,
+               created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+               PRIMARY KEY (marker, seq)
+           )"""
+    )
+
+
+def _insert_rows(
+    connection: sqlite3.Connection,
+    *,
+    marker: str,
+    rows: int,
+    payload_bytes: int,
+) -> None:
+    blob = "x" * max(64, int(payload_bytes))
+    for index in range(max(1, int(rows))):
+        payload = json.dumps(
+            {"marker": marker, "sequence": index, "payload": blob},
+            ensure_ascii=True,
+            sort_keys=True,
+        )
+        connection.execute(
+            """INSERT INTO wal_checkpoint_probe (marker, seq, payload)
+               VALUES (?, ?, ?)""",
+            (marker, index, payload),
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Internal helper for WAL checkpoint crash drill: write committed WAL rows, "
+            "pause before checkpoint, then optionally execute checkpoint."
+        )
+    )
+    parser.add_argument("--database-path", required=True)
+    parser.add_argument("--state-file", required=True)
+    parser.add_argument("--marker", required=True)
+    parser.add_argument("--rows", type=int, default=240)
+    parser.add_argument("--payload-bytes", type=int, default=1024)
+    parser.add_argument("--sleep-before-checkpoint-seconds", type=float, default=30.0)
+    parser.add_argument("--checkpoint-mode", default="TRUNCATE", choices=("PASSIVE", "FULL", "TRUNCATE"))
+    args = parser.parse_args(argv)
+
+    if int(args.rows) <= 0:
+        print("[wal-checkpoint-crash-target] ERROR: --rows must be > 0.", file=sys.stderr)
+        return 2
+    if int(args.payload_bytes) <= 0:
+        print("[wal-checkpoint-crash-target] ERROR: --payload-bytes must be > 0.", file=sys.stderr)
+        return 2
+    if float(args.sleep_before_checkpoint_seconds) <= 0:
+        print("[wal-checkpoint-crash-target] ERROR: --sleep-before-checkpoint-seconds must be > 0.", file=sys.stderr)
+        return 2
+
+    database_path = Path(str(args.database_path)).expanduser()
+    state_file = Path(str(args.state_file)).expanduser()
+    marker = str(args.marker)
+
+    connection: sqlite3.Connection | None = None
+    try:
+        connection = _connect(database_path)
+        journal_mode = str(connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]).lower()
+        connection.execute("PRAGMA wal_autocheckpoint = 0")
+        connection.execute("PRAGMA synchronous = FULL")
+        _setup_schema(connection)
+
+        connection.execute("BEGIN IMMEDIATE")
+        _insert_rows(
+            connection,
+            marker=marker,
+            rows=int(args.rows),
+            payload_bytes=int(args.payload_bytes),
+        )
+        connection.commit()
+
+        persisted_rows = int(
+            connection.execute(
+                "SELECT COUNT(*) FROM wal_checkpoint_probe WHERE marker = ?",
+                (marker,),
+            ).fetchone()[0]
+        )
+        _write_state(
+            state_file,
+            {
+                "status": "checkpoint_pending",
+                "marker": marker,
+                "rows_requested": int(args.rows),
+                "persisted_rows": persisted_rows,
+                "journal_mode": journal_mode,
+                "wal_size_bytes": _wal_size(database_path),
+                "checkpoint_mode": str(args.checkpoint_mode),
+                "pid": os.getpid(),
+                "timestamp_utc": _utc_iso(),
+            },
+        )
+
+        time.sleep(float(args.sleep_before_checkpoint_seconds))
+
+        row = connection.execute(f"PRAGMA wal_checkpoint({str(args.checkpoint_mode)})").fetchone()
+        checkpoint_result = {
+            "busy": int(row[0]) if row is not None else -1,
+            "log_frames": int(row[1]) if row is not None else -1,
+            "checkpointed_frames": int(row[2]) if row is not None else -1,
+        }
+        _write_state(
+            state_file,
+            {
+                "status": "checkpoint_completed",
+                "marker": marker,
+                "rows_requested": int(args.rows),
+                "persisted_rows": persisted_rows,
+                "journal_mode": journal_mode,
+                "wal_size_bytes": _wal_size(database_path),
+                "checkpoint_mode": str(args.checkpoint_mode),
+                "checkpoint_result": checkpoint_result,
+                "pid": os.getpid(),
+                "timestamp_utc": _utc_iso(),
+            },
+        )
+        return 0
+    except Exception as exc:
+        try:
+            _write_state(
+                state_file,
+                {
+                    "status": "error",
+                    "marker": marker,
+                    "error": str(exc),
+                    "pid": os.getpid(),
+                    "timestamp_utc": _utc_iso(),
+                },
+            )
+        except Exception:
+            pass
+        print(f"[wal-checkpoint-crash-target] ERROR: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        if connection is not None:
+            connection.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -2592,3 +2592,53 @@ def test_100_sqlite_real_full_drill_reports_success():
     assert payload["workflow_runs"]["running_during_fault"] == []
     assert payload["workflow_runs"]["running_after_recovery"] == []
     shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_101_wal_checkpoint_crash_drill_reports_success():
+    workspace = _local_test_dir("pytest-wal-checkpoint-crash-drill")
+    project_root = Path(__file__).resolve().parents[1]
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "wal-checkpoint-crash-drill.py"),
+        "--workspace",
+        str(workspace),
+        "--label",
+        "pytest-drill",
+        "--rows",
+        "60",
+        "--payload-bytes",
+        "128",
+        "--startup-timeout-seconds",
+        "15",
+        "--sleep-before-checkpoint-seconds",
+        "30",
+        "--checkpoint-mode",
+        "TRUNCATE",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0 and "disk i/o error" in completed.stderr.lower():
+        shutil.rmtree(workspace, ignore_errors=True)
+        pytest.skip("File-backed SQLite is unavailable in this sandbox")
+    assert completed.returncode == 0, completed.stderr
+
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    assert payload["success"] is True
+    assert payload["scenario"]["rows_persisted_before_crash"] == 60
+    assert payload["scenario"]["rows_observed_after_crash"] == 60
+    assert payload["checkpoint_recovery"]["busy"] == 0
+    assert payload["integrity"]["after_crash"]["quick_ok"] is True
+    assert payload["integrity"]["after_crash"]["full_ok"] is True
+    assert payload["integrity"]["after_recovery_checkpoint"]["quick_ok"] is True
+    assert payload["integrity"]["after_recovery_checkpoint"]["full_ok"] is True
+    assert payload["app_probe"]["readiness_ready"] is True
+    assert payload["app_probe"]["slo_status"] == "ok"
+    assert payload["app_probe"]["safe_mode_active"] is False
+    assert payload["app_probe"]["post_recovery_goal_status_code"] == 201
+    assert payload["app_probe"]["running_run_ids"] == []
+    shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
﻿## Summary
- add WAL checkpoint crash durability drill with hard-abort before checkpoint completion and explicit checkpoint recovery validation
- add PowerShell wrapper, automated pytest coverage, release-gate flags (`Skip/StrictWalCheckpointCrashDrill`), and CI strict gate wiring
- update README and production runbook with invocation, gate flags, and incident playbook entry

## Validation
- `python -m py_compile scripts/wal-checkpoint-crash-target.py scripts/wal-checkpoint-crash-drill.py tests/test_goal_ops.py`
- `python -m pytest -q tests/test_goal_ops.py -k "test_100_sqlite_real_full_drill_reports_success or test_101_wal_checkpoint_crash_drill_reports_success"`
- `powershell -NoLogo -NoProfile -File .\scripts\release-gate.ps1 -SkipPytest -SkipDesktopSmoke -SkipApiProbe -SkipSloAlertCheck -SkipReleaseFreezePolicyDrill -SkipFileDatabaseProbe -SkipAutoRollbackPolicyDrill -SkipDesktopUpdateSafetyDrill -SkipRecoveryHardAbortDrill -SkipPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -SkipDiskPressureFaultInjectionDrill -SkipSqliteRealFullDrill -SkipDbCorruptionQuarantineDrill -SkipWorkflowLockResilienceDrill -SkipWorkflowSoakDrill -SkipWorkflowWorkerRestartDrill -SkipDbSafeModeWatchdogDrill -SkipInvariantMonitorWatchdogDrill -SkipEventConsumerRecoveryChaosDrill -SkipInvariantBurstDrill -SkipLongSoakBudgetDrill -SkipMigrationRehearsal -SkipUpgradeDowngradeCompatibilityDrill -SkipBackupRestoreDrill -SkipIncidentRollbackDrill`
