### PR TITLE
[codex] Add P0 burn-in consecutive green monitor and gate integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,10 @@ jobs:
 
       - name: Run release gate
         shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          .\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate
+          .\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen
 
   test:
     name: Pytest (Python ${{ matrix.python-version }})

--- a/.github/workflows/p0-burnin-monitor.yml
+++ b/.github/workflows/p0-burnin-monitor.yml
@@ -1,0 +1,57 @@
+name: P0 Burn-In Monitor
+
+on:
+  schedule:
+    - cron: "15 2 * * *"
+  workflow_dispatch:
+    inputs:
+      required_consecutive:
+        description: "Required number of consecutive green CI runs"
+        required: false
+        default: "10"
+      allow_not_met:
+        description: "Do not fail workflow when threshold is not yet met"
+        required: false
+        default: "false"
+
+jobs:
+  burnin:
+    name: P0 Burn-In Consecutive Green Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Run burn-in monitor
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUIRED_CONSECUTIVE: ${{ github.event.inputs.required_consecutive || '10' }}
+          ALLOW_NOT_MET: ${{ github.event.inputs.allow_not_met || 'false' }}
+        run: |
+          EXTRA_ARGS=""
+          if [ "$ALLOW_NOT_MET" = "true" ]; then
+            EXTRA_ARGS="--allow-not-met"
+          fi
+          python ./scripts/p0-burnin-consecutive-green.py \
+            --label github-actions \
+            --repo "${{ github.repository }}" \
+            --branch master \
+            --workflow-name "CI" \
+            --required-jobs "Release Gate (Windows),Pytest (Python 3.11),Pytest (Python 3.12),Desktop Smoke (Windows)" \
+            --required-consecutive "$REQUIRED_CONSECUTIVE" \
+            --per-page 50 \
+            --output-file ./artifacts/p0-burnin-consecutive-green-report.json \
+            $EXTRA_ARGS
+
+      - name: Upload burn-in report
+        uses: actions/upload-artifact@v4
+        with:
+          name: p0-burnin-consecutive-green-report
+          path: artifacts/p0-burnin-consecutive-green-report.json
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -410,11 +410,11 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate
+.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen
 ```
 
 Standalone backup/restore drill:
@@ -627,6 +627,13 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-release-gate-runtime-stability-drill.ps1 -Samples 2 -RepeatsPerSample 1
 ```
 
+Standalone P0 burn-in consecutive-green monitor (CI history hard gate):
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-p0-burnin-consecutive-green.ps1 -RequiredConsecutive 10
+```
+
 Current result during implementation:
 
 ```text
@@ -649,6 +656,9 @@ Desktop workflow file:
 
 Nightly stability canary workflow:
 [stability-canary.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/stability-canary.yml)
+
+Nightly burn-in monitor workflow:
+[p0-burnin-monitor.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/p0-burnin-monitor.yml)
 
 Recommended branch protection on `master`:
 
@@ -881,5 +891,7 @@ If a value is rejected:
 - [run-critical-drill-flake-gate.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-critical-drill-flake-gate.ps1)
 - [release-gate-runtime-stability-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/release-gate-runtime-stability-drill.py)
 - [run-release-gate-runtime-stability-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-release-gate-runtime-stability-drill.ps1)
+- [p0-burnin-consecutive-green.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/p0-burnin-consecutive-green.py)
+- [run-p0-burnin-consecutive-green.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-p0-burnin-consecutive-green.ps1)
 - [test_goal_ops.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_goal_ops.py)
 - [test_desktop_launcher.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_desktop_launcher.py)

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -9,7 +9,7 @@ This runbook is optimized for reliability-first releases of the desktop app and 
 Run in repo root:
 
 ```powershell
-.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate
+.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen
 ```
 
 This gate covers:
@@ -47,6 +47,7 @@ This gate covers:
 - multi-db atomic-switch drill (pointer update crash simulation, corrupted-candidate reject, and deterministic switch rollback path)
 - incident/rollback drill with controlled burst load, SLO incident detection, and stable-ring rollback validation
 - release-gate runtime stability drill (critical-drill duration/variance budget sampling)
+- P0 burn-in consecutive-green monitor (latest CI history must satisfy N consecutive fully green runs)
 
 Manual migration rehearsal invocation (same thresholds as gate defaults):
 
@@ -210,12 +211,19 @@ Manual release-gate runtime stability drill invocation:
 .\scripts\run-release-gate-runtime-stability-drill.ps1 -Samples 2 -RepeatsPerSample 1
 ```
 
+Manual P0 burn-in consecutive-green monitor invocation:
+
+```powershell
+.\scripts\run-p0-burnin-consecutive-green.ps1 -RequiredConsecutive 10
+```
+
 Verify before release:
 - CI checks green:
   - `Release Gate (Windows)`
   - `Pytest (Python 3.11)`
   - `Pytest (Python 3.12)`
   - `Desktop Smoke (Windows)`
+- burn-in monitor report confirms threshold met (`metrics.consecutive_green >= metrics.required_consecutive`)
 - `master` branch only receives PR merges (no direct pushes).
 - No unresolved high-severity bug tickets for release scope.
 

--- a/scripts/p0-burnin-consecutive-green.py
+++ b/scripts/p0-burnin-consecutive-green.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_REQUIRED_JOBS = [
+    "Release Gate (Windows)",
+    "Pytest (Python 3.11)",
+    "Pytest (Python 3.12)",
+    "Desktop Smoke (Windows)",
+]
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _run_gh_api(path: str) -> dict[str, Any]:
+    command = ["gh", "api", path]
+    completed = subprocess.run(command, capture_output=True, text=True)
+    _expect(
+        completed.returncode == 0,
+        f"gh api failed ({completed.returncode}) for '{path}': {completed.stderr.strip()}",
+    )
+    payload = json.loads(completed.stdout)
+    _expect(isinstance(payload, dict), f"Expected JSON object from gh api path '{path}'.")
+    return payload
+
+
+def _load_json_file(path: Path) -> dict[str, Any]:
+    _expect(path.exists(), f"JSON file not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    _expect(isinstance(payload, dict), f"Expected JSON object in file: {path}")
+    return payload
+
+
+def _parse_required_jobs(text: str) -> list[str]:
+    jobs = [item.strip() for item in str(text).split(",") if item.strip()]
+    _expect(jobs, "At least one required job must be configured.")
+    return jobs
+
+
+def _fetch_workflow_id(*, repo: str, workflow_name: str) -> int:
+    payload = _run_gh_api(f"repos/{repo}/actions/workflows?per_page=100")
+    workflows = payload.get("workflows") or []
+    _expect(isinstance(workflows, list), "Invalid workflows payload format.")
+    for workflow in workflows:
+        if not isinstance(workflow, dict):
+            continue
+        if str(workflow.get("name") or "") == str(workflow_name):
+            workflow_id = int(workflow.get("id") or 0)
+            _expect(workflow_id > 0, f"Workflow '{workflow_name}' has invalid id.")
+            return workflow_id
+    raise RuntimeError(f"Workflow '{workflow_name}' not found in repo '{repo}'.")
+
+
+def _fetch_runs_from_github(
+    *,
+    repo: str,
+    branch: str,
+    workflow_name: str,
+    per_page: int,
+) -> list[dict[str, Any]]:
+    workflow_id = _fetch_workflow_id(repo=repo, workflow_name=workflow_name)
+    payload = _run_gh_api(
+        f"repos/{repo}/actions/workflows/{workflow_id}/runs?branch={branch}&status=completed&per_page={per_page}"
+    )
+    runs = payload.get("workflow_runs") or []
+    _expect(isinstance(runs, list), "Invalid workflow runs payload format.")
+    return [item for item in runs if isinstance(item, dict)]
+
+
+def _fetch_run_jobs_from_github(*, repo: str, run_id: int) -> list[dict[str, Any]]:
+    payload = _run_gh_api(f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100")
+    jobs = payload.get("jobs") or []
+    _expect(isinstance(jobs, list), f"Invalid jobs payload format for run {run_id}.")
+    return [item for item in jobs if isinstance(item, dict)]
+
+
+def _load_run_jobs_from_dir(*, jobs_dir: Path, run_id: int) -> list[dict[str, Any]]:
+    candidate_paths = [
+        jobs_dir / f"{run_id}.json",
+        jobs_dir / f"run-{run_id}.json",
+        jobs_dir / f"run-{run_id}-jobs.json",
+    ]
+    file_path = next((path for path in candidate_paths if path.exists()), None)
+    _expect(file_path is not None, f"No jobs fixture file found for run id {run_id} in {jobs_dir}")
+    payload = _load_json_file(file_path)
+    jobs = payload.get("jobs") or []
+    _expect(isinstance(jobs, list), f"Invalid jobs fixture payload format for run {run_id}: {file_path}")
+    return [item for item in jobs if isinstance(item, dict)]
+
+
+def _evaluate_run(
+    *,
+    run: dict[str, Any],
+    required_jobs: list[str],
+    jobs: list[dict[str, Any]],
+) -> dict[str, Any]:
+    run_id = int(run.get("id") or 0)
+    run_name = str(run.get("name") or "")
+    run_conclusion = str(run.get("conclusion") or "")
+    run_status = str(run.get("status") or "")
+    run_head_sha = str(run.get("head_sha") or "")
+    run_updated_at = str(run.get("updated_at") or "")
+
+    job_map: dict[str, str] = {}
+    for job in jobs:
+        name = str(job.get("name") or "")
+        if not name:
+            continue
+        job_map[name] = str(job.get("conclusion") or "")
+
+    missing_jobs = [job_name for job_name in required_jobs if job_name not in job_map]
+    failing_jobs = [
+        {"name": job_name, "conclusion": job_map.get(job_name, "")}
+        for job_name in required_jobs
+        if job_name in job_map and str(job_map.get(job_name) or "") != "success"
+    ]
+
+    is_green = (
+        run_status == "completed"
+        and run_conclusion == "success"
+        and not missing_jobs
+        and not failing_jobs
+    )
+
+    return {
+        "run_id": run_id,
+        "run_name": run_name,
+        "run_status": run_status,
+        "run_conclusion": run_conclusion,
+        "head_sha": run_head_sha,
+        "updated_at": run_updated_at,
+        "required_jobs": {name: job_map.get(name, "") for name in required_jobs},
+        "missing_jobs": missing_jobs,
+        "failing_jobs": failing_jobs,
+        "is_green": bool(is_green),
+    }
+
+
+def run_burnin_check(
+    *,
+    label: str,
+    repo: str,
+    branch: str,
+    workflow_name: str,
+    required_jobs: list[str],
+    required_consecutive: int,
+    per_page: int,
+    runs_file: Path | None,
+    jobs_dir: Path | None,
+    allow_not_met: bool,
+) -> dict[str, Any]:
+    _expect(required_consecutive > 0, "required_consecutive must be > 0.")
+    _expect(per_page > 0, "per_page must be > 0.")
+    _expect(per_page >= required_consecutive, "per_page should be >= required_consecutive.")
+
+    started = time.perf_counter()
+    if runs_file is not None:
+        runs_payload = _load_json_file(runs_file)
+        runs = runs_payload.get("workflow_runs") or []
+        _expect(isinstance(runs, list), f"Invalid runs fixture payload format in {runs_file}")
+        run_items = [item for item in runs if isinstance(item, dict)]
+    else:
+        run_items = _fetch_runs_from_github(
+            repo=repo,
+            branch=branch,
+            workflow_name=workflow_name,
+            per_page=per_page,
+        )
+
+    _expect(run_items, "No workflow runs available for burn-in evaluation.")
+    evaluations: list[dict[str, Any]] = []
+    consecutive_green = 0
+    first_non_green: dict[str, Any] | None = None
+
+    for run in run_items:
+        run_id = int(run.get("id") or 0)
+        _expect(run_id > 0, f"Invalid run id in workflow runs payload: {run!r}")
+        if jobs_dir is not None:
+            jobs = _load_run_jobs_from_dir(jobs_dir=jobs_dir, run_id=run_id)
+        else:
+            jobs = _fetch_run_jobs_from_github(repo=repo, run_id=run_id)
+        evaluation = _evaluate_run(run=run, required_jobs=required_jobs, jobs=jobs)
+        evaluations.append(evaluation)
+        if evaluation["is_green"]:
+            consecutive_green += 1
+            if consecutive_green >= required_consecutive:
+                break
+        else:
+            first_non_green = evaluation
+            break
+
+    success = consecutive_green >= required_consecutive
+    report = {
+        "label": label,
+        "success": bool(success),
+        "config": {
+            "repo": repo,
+            "branch": branch,
+            "workflow_name": workflow_name,
+            "required_jobs": required_jobs,
+            "required_consecutive": int(required_consecutive),
+            "per_page": int(per_page),
+            "allow_not_met": bool(allow_not_met),
+            "fixture_runs_file": str(runs_file) if runs_file is not None else None,
+            "fixture_jobs_dir": str(jobs_dir) if jobs_dir is not None else None,
+        },
+        "metrics": {
+            "consecutive_green": int(consecutive_green),
+            "required_consecutive": int(required_consecutive),
+            "evaluated_runs": int(len(evaluations)),
+        },
+        "first_non_green": first_non_green,
+        "evaluations": evaluations,
+        "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "duration_ms": int((time.perf_counter() - started) * 1000),
+    }
+    if (not success) and (not allow_not_met):
+        raise RuntimeError(f"P0 burn-in consecutive-green check not met: {json.dumps(report, sort_keys=True)}")
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check P0 burn-in criteria by verifying required CI jobs are green for N consecutive "
+            "completed runs on a branch."
+        )
+    )
+    parser.add_argument("--label", default="p0-burnin-consecutive-green")
+    parser.add_argument("--repo", default="donatomaurizio99-collab/GOC")
+    parser.add_argument("--branch", default="master")
+    parser.add_argument("--workflow-name", default="CI")
+    parser.add_argument("--required-jobs", default=",".join(DEFAULT_REQUIRED_JOBS))
+    parser.add_argument("--required-consecutive", type=int, default=10)
+    parser.add_argument("--per-page", type=int, default=50)
+    parser.add_argument("--runs-file")
+    parser.add_argument("--jobs-dir")
+    parser.add_argument("--output-file")
+    parser.add_argument("--allow-not-met", action="store_true")
+    args = parser.parse_args(argv)
+
+    if int(args.required_consecutive) <= 0:
+        print("[p0-burnin-consecutive-green] ERROR: --required-consecutive must be > 0.", file=sys.stderr)
+        return 2
+    if int(args.per_page) <= 0:
+        print("[p0-burnin-consecutive-green] ERROR: --per-page must be > 0.", file=sys.stderr)
+        return 2
+
+    runs_file = Path(str(args.runs_file)).expanduser() if args.runs_file else None
+    jobs_dir = Path(str(args.jobs_dir)).expanduser() if args.jobs_dir else None
+    output_file = Path(str(args.output_file)).expanduser() if args.output_file else None
+
+    try:
+        report = run_burnin_check(
+            label=str(args.label),
+            repo=str(args.repo),
+            branch=str(args.branch),
+            workflow_name=str(args.workflow_name),
+            required_jobs=_parse_required_jobs(str(args.required_jobs)),
+            required_consecutive=int(args.required_consecutive),
+            per_page=int(args.per_page),
+            runs_file=runs_file,
+            jobs_dir=jobs_dir,
+            allow_not_met=bool(args.allow_not_met),
+        )
+    except Exception as exc:
+        print(f"[p0-burnin-consecutive-green] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if output_file is not None:
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2), encoding="utf-8")
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -63,7 +63,9 @@ param(
     [switch]$SkipReleaseGateRuntimeStabilityDrill,
     [switch]$StrictReleaseGateRuntimeStabilityDrill,
     [switch]$SkipCriticalDrillFlakeGate,
-    [switch]$StrictCriticalDrillFlakeGate
+    [switch]$StrictCriticalDrillFlakeGate,
+    [switch]$SkipP0BurnInConsecutiveGreen,
+    [switch]$StrictP0BurnInConsecutiveGreen
 )
 
 $ErrorActionPreference = "Stop"
@@ -826,6 +828,38 @@ if (-not $SkipCriticalDrillFlakeGate) {
             }
             Write-Warning (
                 "Critical drill flake gate failed but StrictCriticalDrillFlakeGate is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipP0BurnInConsecutiveGreen) {
+    Invoke-GateStep -Name "P0 burn-in consecutive-green monitor (CI history hard gate)" -Action {
+        $reportPath = Join-Path $ProjectRoot "artifacts\p0-burnin-consecutive-green-release-gate.json"
+        $repository = if ($env:GITHUB_REPOSITORY) {
+            $env:GITHUB_REPOSITORY
+        } else {
+            "donatomaurizio99-collab/GOC"
+        }
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\p0-burnin-consecutive-green.py",
+                "--label", "release-gate",
+                "--repo", $repository,
+                "--branch", "master",
+                "--workflow-name", "CI",
+                "--required-jobs", "Release Gate (Windows),Pytest (Python 3.11),Pytest (Python 3.12),Desktop Smoke (Windows)",
+                "--required-consecutive", "10",
+                "--per-page", "50",
+                "--output-file", $reportPath
+            )
+        } catch {
+            if ($StrictP0BurnInConsecutiveGreen) {
+                throw
+            }
+            Write-Warning (
+                "P0 burn-in consecutive-green monitor failed but StrictP0BurnInConsecutiveGreen is off. " +
                 "Continuing. Error: $($_.Exception.Message)"
             )
         }

--- a/scripts/run-p0-burnin-consecutive-green.ps1
+++ b/scripts/run-p0-burnin-consecutive-green.ps1
@@ -1,0 +1,38 @@
+param(
+    [string]$PythonExe = "python",
+    [string]$Repo = "donatomaurizio99-collab/GOC",
+    [string]$Branch = "master",
+    [string]$WorkflowName = "CI",
+    [string]$RequiredJobs = "Release Gate (Windows),Pytest (Python 3.11),Pytest (Python 3.12),Desktop Smoke (Windows)",
+    [int]$RequiredConsecutive = 10,
+    [int]$PerPage = 50,
+    [string]$OutputFile = "artifacts\\p0-burnin-consecutive-green-report.json",
+    [switch]$AllowNotMet
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$args = @(
+    ".\\scripts\\p0-burnin-consecutive-green.py",
+    "--label", "manual",
+    "--repo", $Repo,
+    "--branch", $Branch,
+    "--workflow-name", $WorkflowName,
+    "--required-jobs", $RequiredJobs,
+    "--required-consecutive", [string]$RequiredConsecutive,
+    "--per-page", [string]$PerPage,
+    "--output-file", $OutputFile
+)
+if ($AllowNotMet) {
+    $args += "--allow-not-met"
+}
+
+& $PythonExe @args
+if ($LASTEXITCODE -ne 0) {
+    throw "P0 burn-in consecutive-green check failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "P0 burn-in consecutive-green check passed." -ForegroundColor Green

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -3054,3 +3054,218 @@ def test_109_release_gate_runtime_stability_drill_reports_success():
     for sample in payload["samples"]:
         assert sample["success"] is True
         assert sample["return_code"] == 0
+
+
+def test_110_p0_burnin_consecutive_green_reports_success_after_recovery_window():
+    workspace = _local_test_dir("pytest-p0-burnin-consecutive-green")
+    project_root = Path(__file__).resolve().parents[1]
+    fixtures_dir = workspace / "fixtures"
+    jobs_dir = fixtures_dir / "jobs"
+    fixtures_dir.mkdir(parents=True, exist_ok=True)
+    jobs_dir.mkdir(parents=True, exist_ok=True)
+
+    runs_payload = {
+        "workflow_runs": [
+            {
+                "id": 9003,
+                "name": "CI",
+                "status": "completed",
+                "conclusion": "success",
+                "head_sha": "sha-9003",
+                "updated_at": "2026-04-16T10:00:03Z",
+            },
+            {
+                "id": 9002,
+                "name": "CI",
+                "status": "completed",
+                "conclusion": "success",
+                "head_sha": "sha-9002",
+                "updated_at": "2026-04-16T10:00:02Z",
+            },
+            {
+                "id": 9001,
+                "name": "CI",
+                "status": "completed",
+                "conclusion": "success",
+                "head_sha": "sha-9001",
+                "updated_at": "2026-04-16T10:00:01Z",
+            },
+            {
+                "id": 9000,
+                "name": "CI",
+                "status": "completed",
+                "conclusion": "failure",
+                "head_sha": "sha-9000",
+                "updated_at": "2026-04-16T10:00:00Z",
+            },
+        ]
+    }
+    # Older failure after a sequence of fresh green runs models recovery after a transient incident.
+    runs_file = fixtures_dir / "runs.json"
+    runs_file.write_text(json.dumps(runs_payload, ensure_ascii=True, sort_keys=True), encoding="utf-8")
+
+    required_jobs = [
+        "Release Gate (Windows)",
+        "Pytest (Python 3.11)",
+        "Pytest (Python 3.12)",
+        "Desktop Smoke (Windows)",
+    ]
+    for run_id in (9003, 9002, 9001, 9000):
+        conclusion = "success" if run_id != 9000 else "failure"
+        jobs_payload = {
+            "jobs": [
+                {"name": required_jobs[0], "conclusion": conclusion},
+                {"name": required_jobs[1], "conclusion": conclusion},
+                {"name": required_jobs[2], "conclusion": conclusion},
+                {"name": required_jobs[3], "conclusion": conclusion},
+                {"name": "Auxiliary Check", "conclusion": "success"},
+            ]
+        }
+        (jobs_dir / f"{run_id}.json").write_text(
+            json.dumps(jobs_payload, ensure_ascii=True, sort_keys=True),
+            encoding="utf-8",
+        )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "p0-burnin-consecutive-green.py"),
+        "--label",
+        "pytest-drill",
+        "--repo",
+        "donatomaurizio99-collab/GOC",
+        "--branch",
+        "master",
+        "--workflow-name",
+        "CI",
+        "--required-jobs",
+        ",".join(required_jobs),
+        "--required-consecutive",
+        "3",
+        "--per-page",
+        "10",
+        "--runs-file",
+        str(runs_file),
+        "--jobs-dir",
+        str(jobs_dir),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    assert payload["success"] is True
+    assert payload["config"]["required_consecutive"] == 3
+    assert payload["metrics"]["consecutive_green"] == 3
+    assert payload["metrics"]["evaluated_runs"] == 3
+    assert payload["first_non_green"] is None
+    assert len(payload["evaluations"]) == 3
+    for evaluation in payload["evaluations"]:
+        assert evaluation["is_green"] is True
+        assert evaluation["missing_jobs"] == []
+        assert evaluation["failing_jobs"] == []
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_111_p0_burnin_consecutive_green_reports_failure_for_latest_non_green_run():
+    workspace = _local_test_dir("pytest-p0-burnin-consecutive-green-failure")
+    project_root = Path(__file__).resolve().parents[1]
+    fixtures_dir = workspace / "fixtures"
+    jobs_dir = fixtures_dir / "jobs"
+    fixtures_dir.mkdir(parents=True, exist_ok=True)
+    jobs_dir.mkdir(parents=True, exist_ok=True)
+
+    required_jobs = [
+        "Release Gate (Windows)",
+        "Pytest (Python 3.11)",
+        "Pytest (Python 3.12)",
+        "Desktop Smoke (Windows)",
+    ]
+    runs_payload = {
+        "workflow_runs": [
+            {
+                "id": 9102,
+                "name": "CI",
+                "status": "completed",
+                "conclusion": "failure",
+                "head_sha": "sha-9102",
+                "updated_at": "2026-04-16T11:00:02Z",
+            },
+            {
+                "id": 9101,
+                "name": "CI",
+                "status": "completed",
+                "conclusion": "success",
+                "head_sha": "sha-9101",
+                "updated_at": "2026-04-16T11:00:01Z",
+            },
+        ]
+    }
+    runs_file = fixtures_dir / "runs.json"
+    runs_file.write_text(json.dumps(runs_payload, ensure_ascii=True, sort_keys=True), encoding="utf-8")
+
+    jobs_payload_failure = {
+        "jobs": [
+            {"name": required_jobs[0], "conclusion": "failure"},
+            {"name": required_jobs[1], "conclusion": "success"},
+            {"name": required_jobs[2], "conclusion": "success"},
+            {"name": required_jobs[3], "conclusion": "success"},
+        ]
+    }
+    (jobs_dir / "9102.json").write_text(
+        json.dumps(jobs_payload_failure, ensure_ascii=True, sort_keys=True),
+        encoding="utf-8",
+    )
+    jobs_payload_success = {
+        "jobs": [{"name": job_name, "conclusion": "success"} for job_name in required_jobs]
+    }
+    (jobs_dir / "9101.json").write_text(
+        json.dumps(jobs_payload_success, ensure_ascii=True, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "p0-burnin-consecutive-green.py"),
+        "--label",
+        "pytest-drill",
+        "--repo",
+        "donatomaurizio99-collab/GOC",
+        "--branch",
+        "master",
+        "--workflow-name",
+        "CI",
+        "--required-jobs",
+        ",".join(required_jobs),
+        "--required-consecutive",
+        "2",
+        "--per-page",
+        "10",
+        "--runs-file",
+        str(runs_file),
+        "--jobs-dir",
+        str(jobs_dir),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "P0 burn-in consecutive-green check not met: "
+    assert marker in completed.stderr
+
+    report = json.loads(completed.stderr.split(marker, 1)[1].strip())
+    assert report["success"] is False
+    assert report["metrics"]["consecutive_green"] == 0
+    assert report["metrics"]["evaluated_runs"] == 1
+    assert report["first_non_green"]["run_id"] == 9102
+    assert report["first_non_green"]["is_green"] is False
+
+    shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
﻿## Summary
- add a new CI-history burn-in monitor script (`p0-burnin-consecutive-green.py`) that enforces N consecutive fully green CI runs across required jobs
- add a PowerShell wrapper (`run-p0-burnin-consecutive-green.ps1`) and a nightly/manual GitHub workflow (`p0-burnin-monitor.yml`) that uploads a JSON report artifact
- integrate the burn-in monitor into `release-gate.ps1` with full `Skip/Strict` semantics (`-SkipP0BurnInConsecutiveGreen`, `-StrictP0BurnInConsecutiveGreen`)
- wire CI release-gate job with `GH_TOKEN` and strict burn-in gating
- extend automated tests for burn-in recovery and failure paths, and update README + production runbook docs

## Why
This hardens P0 stability posture by requiring sustained CI health (not just a single green run) before promotion decisions, with deterministic failure/recovery reporting and release-gate integration.

## Validation
- `python -m py_compile scripts/p0-burnin-consecutive-green.py tests/test_goal_ops.py`
- `python -m pytest -q tests/test_goal_ops.py -k "test_110_p0_burnin_consecutive_green_reports_success_after_recovery_window or test_111_p0_burnin_consecutive_green_reports_failure_for_latest_non_green_run"`
- `./scripts/release-gate.ps1` parameter smoke with all `-Skip*` flags including `-SkipP0BurnInConsecutiveGreen`
