### PR TITLE
[codex] Add P0 release evidence bundle and CI artifact export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,17 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          .\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck
+          .\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle
+
+      - name: Upload release evidence artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: p0-release-evidence-bundle
+          path: |
+            artifacts/p0-*-release-gate.json
+            artifacts/p0-release-evidence-bundle-release-gate.json
+            artifacts/p0-release-evidence-files-release-gate/**
+          if-no-files-found: error
 
   test:
     name: Pytest (Python ${{ matrix.python-version }})

--- a/README.md
+++ b/README.md
@@ -410,11 +410,11 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck
+.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle
 ```
 
 Standalone backup/restore drill:
@@ -641,6 +641,13 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-p0-runbook-contract-check.ps1
 ```
 
+Standalone P0 release evidence bundle (aggregate P0 reports into one manifest):
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-p0-release-evidence-bundle.ps1
+```
+
 Current result during implementation:
 
 ```text
@@ -657,6 +664,8 @@ GitHub Actions now runs `pytest` automatically for:
 
 Workflow file:
 [ci.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/ci.yml)
+
+Release Gate workflow artifact includes `p0-release-evidence-bundle` (manifest + copied evidence reports).
 
 Desktop workflow file:
 [desktop-build.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/desktop-build.yml)
@@ -902,5 +911,7 @@ If a value is rejected:
 - [run-p0-burnin-consecutive-green.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-p0-burnin-consecutive-green.ps1)
 - [p0-runbook-contract-check.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/p0-runbook-contract-check.py)
 - [run-p0-runbook-contract-check.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-p0-runbook-contract-check.ps1)
+- [p0-release-evidence-bundle.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/p0-release-evidence-bundle.py)
+- [run-p0-release-evidence-bundle.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-p0-release-evidence-bundle.ps1)
 - [test_goal_ops.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_goal_ops.py)
 - [test_desktop_launcher.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_desktop_launcher.py)

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -9,7 +9,7 @@ This runbook is optimized for reliability-first releases of the desktop app and 
 Run in repo root:
 
 ```powershell
-.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck
+.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle
 ```
 
 This gate covers:
@@ -49,6 +49,7 @@ This gate covers:
 - release-gate runtime stability drill (critical-drill duration/variance budget sampling)
 - P0 burn-in consecutive-green monitor (latest CI history must satisfy N consecutive fully green runs)
 - P0 runbook contract check (release-gate/CI/runbook strict-flag and script-reference consistency)
+- P0 release evidence bundle (single artifact with required P0 report files and status summary)
 
 Manual migration rehearsal invocation (same thresholds as gate defaults):
 
@@ -224,6 +225,12 @@ Manual P0 runbook contract check invocation:
 .\scripts\run-p0-runbook-contract-check.ps1
 ```
 
+Manual P0 release evidence bundle invocation:
+
+```powershell
+.\scripts\run-p0-release-evidence-bundle.ps1
+```
+
 Verify before release:
 - CI checks green:
   - `Release Gate (Windows)`
@@ -232,6 +239,7 @@ Verify before release:
   - `Desktop Smoke (Windows)`
 - burn-in monitor report confirms threshold met (`metrics.consecutive_green >= metrics.required_consecutive`)
 - runbook contract report confirms zero missing flags/scripts (`success=true`)
+- release evidence bundle report confirms all required P0 reports present and successful (`success=true`)
 - `master` branch only receives PR merges (no direct pushes).
 - No unresolved high-severity bug tickets for release scope.
 

--- a/scripts/p0-release-evidence-bundle.py
+++ b/scripts/p0-release-evidence-bundle.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _parse_csv_list(text: str) -> list[str]:
+    return [item.strip() for item in str(text).split(",") if item.strip()]
+
+
+def _resolve_path(project_root: Path, value: str) -> Path:
+    path = Path(str(value)).expanduser()
+    if not path.is_absolute():
+        path = project_root / path
+    return path.resolve()
+
+
+def _read_json_file(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    _expect(isinstance(payload, dict), f"Expected JSON object in report file: {path}")
+    return payload
+
+
+def run_bundle(
+    *,
+    label: str,
+    project_root: Path,
+    artifacts_dir: Path,
+    include_glob: str,
+    required_files: list[str],
+    output_file: Path,
+    bundle_dir: Path,
+    allow_empty: bool,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+
+    discovered_paths = sorted(
+        [
+            path.resolve()
+            for path in artifacts_dir.glob(include_glob)
+            if path.is_file() and path.resolve() != output_file.resolve()
+        ]
+    )
+    required_paths = sorted([_resolve_path(project_root, rel_path) for rel_path in required_files])
+    required_missing = [str(path) for path in required_paths if not path.exists()]
+
+    discovered_map = {str(path): path for path in discovered_paths}
+    for path in required_paths:
+        discovered_map.setdefault(str(path), path)
+
+    evaluated_reports: list[dict[str, Any]] = []
+    invalid_reports: list[dict[str, Any]] = []
+    copied_files: list[str] = []
+    for file_path in sorted(discovered_map.values(), key=lambda item: str(item).lower()):
+        if not file_path.exists():
+            continue
+        copy_target = bundle_dir / file_path.name
+        shutil.copy2(file_path, copy_target)
+        copied_files.append(str(copy_target))
+        try:
+            payload = _read_json_file(file_path)
+            success_value = payload.get("success")
+            has_success_flag = isinstance(success_value, bool)
+            report_entry = {
+                "path": str(file_path),
+                "label": str(payload.get("label") or ""),
+                "success": bool(success_value) if has_success_flag else None,
+                "has_success_flag": bool(has_success_flag),
+            }
+            if has_success_flag and success_value is False:
+                report_entry["failure_excerpt"] = str(payload.get("error") or "")[:200]
+            evaluated_reports.append(report_entry)
+        except Exception as exc:  # pragma: no cover - defensive path
+            invalid_reports.append({"path": str(file_path), "error": str(exc)})
+
+    parsed_success_reports = [item for item in evaluated_reports if item.get("success") is True]
+    parsed_failed_reports = [item for item in evaluated_reports if item.get("success") is False]
+    parsed_without_flag = [item for item in evaluated_reports if item.get("success") is None]
+
+    success = (
+        not required_missing
+        and not invalid_reports
+        and not parsed_failed_reports
+        and (allow_empty or bool(evaluated_reports))
+    )
+    report = {
+        "label": label,
+        "success": bool(success),
+        "paths": {
+            "project_root": str(project_root),
+            "artifacts_dir": str(artifacts_dir),
+            "bundle_dir": str(bundle_dir),
+            "output_file": str(output_file),
+        },
+        "config": {
+            "include_glob": include_glob,
+            "required_files": required_files,
+            "allow_empty": bool(allow_empty),
+        },
+        "metrics": {
+            "discovered_reports": len(evaluated_reports),
+            "required_missing_reports": len(required_missing),
+            "invalid_reports": len(invalid_reports),
+            "failed_reports": len(parsed_failed_reports),
+            "success_reports": len(parsed_success_reports),
+            "reports_without_success_flag": len(parsed_without_flag),
+        },
+        "reports": evaluated_reports,
+        "required_missing": required_missing,
+        "invalid_reports": invalid_reports,
+        "copied_files": copied_files,
+        "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "duration_ms": int((time.perf_counter() - started) * 1000),
+    }
+    output_file.write_text(json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2), encoding="utf-8")
+    if not success:
+        raise RuntimeError(f"P0 release evidence bundle check failed: {json.dumps(report, sort_keys=True)}")
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build and validate a P0 release evidence bundle from report JSON files "
+            "written during release-gate execution."
+        )
+    )
+    parser.add_argument("--label", default="p0-release-evidence-bundle")
+    parser.add_argument("--project-root")
+    parser.add_argument("--artifacts-dir", default="artifacts")
+    parser.add_argument("--include-glob", default="p0-*-release-gate.json")
+    parser.add_argument("--required-files", default="")
+    parser.add_argument("--output-file", default="artifacts/p0-release-evidence-bundle.json")
+    parser.add_argument("--bundle-dir", default="artifacts/p0-release-evidence-files")
+    parser.add_argument("--allow-empty", action="store_true")
+    args = parser.parse_args(argv)
+
+    inferred_project_root = Path(__file__).resolve().parents[1]
+    project_root = _resolve_path(inferred_project_root, args.project_root) if args.project_root else inferred_project_root
+    artifacts_dir = _resolve_path(project_root, args.artifacts_dir)
+    output_file = _resolve_path(project_root, args.output_file)
+    bundle_dir = _resolve_path(project_root, args.bundle_dir)
+    required_files = _parse_csv_list(args.required_files)
+
+    try:
+        report = run_bundle(
+            label=str(args.label),
+            project_root=project_root,
+            artifacts_dir=artifacts_dir,
+            include_glob=str(args.include_glob),
+            required_files=required_files,
+            output_file=output_file,
+            bundle_dir=bundle_dir,
+            allow_empty=bool(args.allow_empty),
+        )
+    except Exception as exc:
+        print(f"[p0-release-evidence-bundle] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/p0-runbook-contract-check.py
+++ b/scripts/p0-runbook-contract-check.py
@@ -16,6 +16,7 @@ DEFAULT_REQUIRED_RUNBOOK_SCRIPTS = [
     "run-backup-restore-stress-drill.ps1",
     "run-release-gate-runtime-stability-drill.ps1",
     "run-p0-burnin-consecutive-green.ps1",
+    "run-p0-release-evidence-bundle.ps1",
 ]
 
 

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -67,13 +67,16 @@ param(
     [switch]$SkipP0BurnInConsecutiveGreen,
     [switch]$StrictP0BurnInConsecutiveGreen,
     [switch]$SkipP0RunbookContractCheck,
-    [switch]$StrictP0RunbookContractCheck
+    [switch]$StrictP0RunbookContractCheck,
+    [switch]$SkipP0ReleaseEvidenceBundle,
+    [switch]$StrictP0ReleaseEvidenceBundle
 )
 
 $ErrorActionPreference = "Stop"
 
 $ProjectRoot = Split-Path -Parent $PSScriptRoot
 Set-Location $ProjectRoot
+$P0EvidenceReportPaths = @()
 
 function Invoke-NativeCommand {
     param(
@@ -839,6 +842,7 @@ if (-not $SkipCriticalDrillFlakeGate) {
 if (-not $SkipP0BurnInConsecutiveGreen) {
     Invoke-GateStep -Name "P0 burn-in consecutive-green monitor (CI history hard gate)" -Action {
         $reportPath = Join-Path $ProjectRoot "artifacts\p0-burnin-consecutive-green-release-gate.json"
+        $P0EvidenceReportPaths += $reportPath
         $repository = if ($env:GITHUB_REPOSITORY) {
             $env:GITHUB_REPOSITORY
         } else {
@@ -871,6 +875,7 @@ if (-not $SkipP0BurnInConsecutiveGreen) {
 if (-not $SkipP0RunbookContractCheck) {
     Invoke-GateStep -Name "P0 runbook contract check (release-gate/CI/runbook consistency)" -Action {
         $reportPath = Join-Path $ProjectRoot "artifacts\p0-runbook-contract-check-release-gate.json"
+        $P0EvidenceReportPaths += $reportPath
         try {
             Invoke-NativeCommand -Executable $PythonExe -Arguments @(
                 ".\scripts\p0-runbook-contract-check.py",
@@ -883,6 +888,37 @@ if (-not $SkipP0RunbookContractCheck) {
             }
             Write-Warning (
                 "P0 runbook contract check failed but StrictP0RunbookContractCheck is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipP0ReleaseEvidenceBundle) {
+    Invoke-GateStep -Name "P0 release evidence bundle (aggregate release-gate reports)" -Action {
+        $bundleOutputPath = Join-Path $ProjectRoot "artifacts\p0-release-evidence-bundle-release-gate.json"
+        $bundleDir = Join-Path $ProjectRoot "artifacts\p0-release-evidence-files-release-gate"
+        $arguments = @(
+            ".\scripts\p0-release-evidence-bundle.py",
+            "--label", "release-gate",
+            "--artifacts-dir", "artifacts",
+            "--include-glob", "p0-*-release-gate.json",
+            "--output-file", $bundleOutputPath,
+            "--bundle-dir", $bundleDir
+        )
+        if ($P0EvidenceReportPaths.Count -gt 0) {
+            $arguments += @("--required-files", ($P0EvidenceReportPaths -join ","))
+        } else {
+            $arguments += "--allow-empty"
+        }
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments $arguments
+        } catch {
+            if ($StrictP0ReleaseEvidenceBundle) {
+                throw
+            }
+            Write-Warning (
+                "P0 release evidence bundle failed but StrictP0ReleaseEvidenceBundle is off. " +
                 "Continuing. Error: $($_.Exception.Message)"
             )
         }

--- a/scripts/run-p0-release-evidence-bundle.ps1
+++ b/scripts/run-p0-release-evidence-bundle.ps1
@@ -1,0 +1,36 @@
+param(
+    [string]$PythonExe = "python",
+    [string]$ArtifactsDir = "artifacts",
+    [string]$IncludeGlob = "p0-*-release-gate.json",
+    [string]$RequiredFiles = "",
+    [string]$OutputFile = "artifacts\\p0-release-evidence-bundle.json",
+    [string]$BundleDir = "artifacts\\p0-release-evidence-files",
+    [switch]$AllowEmpty
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$arguments = @(
+    ".\\scripts\\p0-release-evidence-bundle.py",
+    "--label", "manual",
+    "--artifacts-dir", $ArtifactsDir,
+    "--include-glob", $IncludeGlob,
+    "--output-file", $OutputFile,
+    "--bundle-dir", $BundleDir
+)
+if (-not [string]::IsNullOrWhiteSpace($RequiredFiles)) {
+    $arguments += @("--required-files", $RequiredFiles)
+}
+if ($AllowEmpty) {
+    $arguments += "--allow-empty"
+}
+
+& $PythonExe @arguments
+if ($LASTEXITCODE -ne 0) {
+    throw "P0 release evidence bundle check failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "P0 release evidence bundle check passed." -ForegroundColor Green

--- a/scripts/run-p0-runbook-contract-check.ps1
+++ b/scripts/run-p0-runbook-contract-check.ps1
@@ -1,7 +1,7 @@
 param(
     [string]$PythonExe = "python",
     [string]$OutputFile = "artifacts\\p0-runbook-contract-check-report.json",
-    [string]$RequiredRunbookScripts = "run-power-loss-durability-drill.ps1,run-disk-pressure-fault-injection-drill.ps1,run-upgrade-downgrade-compatibility-drill.ps1,run-backup-restore-stress-drill.ps1,run-release-gate-runtime-stability-drill.ps1,run-p0-burnin-consecutive-green.ps1",
+    [string]$RequiredRunbookScripts = "run-power-loss-durability-drill.ps1,run-disk-pressure-fault-injection-drill.ps1,run-upgrade-downgrade-compatibility-drill.ps1,run-backup-restore-stress-drill.ps1,run-release-gate-runtime-stability-drill.ps1,run-p0-burnin-consecutive-green.ps1,run-p0-release-evidence-bundle.ps1",
     [string]$RequiredStrictFlags = ""
 )
 

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -3307,3 +3307,104 @@ def test_112_p0_runbook_contract_check_reports_success():
     assert report_file_payload["success"] is True
 
     shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_113_p0_release_evidence_bundle_reports_success_with_required_files():
+    workspace = _local_test_dir("pytest-p0-release-evidence-bundle-success").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    artifacts_dir = workspace / "artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    burnin_report = artifacts_dir / "p0-burnin-consecutive-green-release-gate.json"
+    runbook_report = artifacts_dir / "p0-runbook-contract-check-release-gate.json"
+    burnin_report.write_text(
+        json.dumps({"label": "burnin", "success": True}, ensure_ascii=True, sort_keys=True),
+        encoding="utf-8",
+    )
+    runbook_report.write_text(
+        json.dumps({"label": "runbook", "success": True}, ensure_ascii=True, sort_keys=True),
+        encoding="utf-8",
+    )
+    output_file = artifacts_dir / "p0-release-evidence-bundle-release-gate.json"
+    bundle_dir = artifacts_dir / "p0-release-evidence-files-release-gate"
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "p0-release-evidence-bundle.py"),
+        "--label",
+        "pytest-drill",
+        "--project-root",
+        str(workspace.resolve()),
+        "--artifacts-dir",
+        str(artifacts_dir.resolve()),
+        "--required-files",
+        ",".join([str(burnin_report.resolve()), str(runbook_report.resolve())]),
+        "--output-file",
+        str(output_file.resolve()),
+        "--bundle-dir",
+        str(bundle_dir.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    output_lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    payload = json.loads(output_lines[-1])
+    assert payload["success"] is True
+    assert payload["metrics"]["required_missing_reports"] == 0
+    assert payload["metrics"]["failed_reports"] == 0
+    assert payload["metrics"]["success_reports"] == 2
+    assert output_file.exists()
+    assert (bundle_dir / burnin_report.name).exists()
+    assert (bundle_dir / runbook_report.name).exists()
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_114_p0_release_evidence_bundle_fails_when_required_file_missing():
+    workspace = _local_test_dir("pytest-p0-release-evidence-bundle-missing").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    artifacts_dir = workspace / "artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    existing_report = artifacts_dir / "p0-burnin-consecutive-green-release-gate.json"
+    missing_report = artifacts_dir / "p0-runbook-contract-check-release-gate.json"
+    existing_report.write_text(
+        json.dumps({"label": "burnin", "success": True}, ensure_ascii=True, sort_keys=True),
+        encoding="utf-8",
+    )
+    output_file = artifacts_dir / "p0-release-evidence-bundle-release-gate.json"
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "p0-release-evidence-bundle.py"),
+        "--label",
+        "pytest-drill",
+        "--project-root",
+        str(workspace.resolve()),
+        "--artifacts-dir",
+        str(artifacts_dir.resolve()),
+        "--required-files",
+        ",".join([str(existing_report.resolve()), str(missing_report.resolve())]),
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "P0 release evidence bundle check failed: "
+    assert marker in completed.stderr
+    report = json.loads(completed.stderr.split(marker, 1)[1].strip())
+    assert report["success"] is False
+    assert report["metrics"]["required_missing_reports"] == 1
+    assert str(missing_report) in report["required_missing"]
+
+    shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
﻿## Summary
- add `scripts/p0-release-evidence-bundle.py` to aggregate/validate P0 release evidence reports and emit a single manifest
- add `scripts/run-p0-release-evidence-bundle.ps1` wrapper for local operator execution
- extend `scripts/release-gate.ps1` with `-SkipP0ReleaseEvidenceBundle` / `-StrictP0ReleaseEvidenceBundle` and automatic required-report tracking
- upload release evidence artifacts in CI (`p0-release-evidence-bundle` artifact)
- update runbook/readme and expand tests with success/failure coverage for evidence bundling

## Why
This creates deterministic release evidence output for P0 stability closure, so go/no-go decisions and audits can rely on one machine-readable artifact instead of scattered logs.

## Validation
- `python -m py_compile scripts/p0-release-evidence-bundle.py scripts/p0-runbook-contract-check.py tests/test_goal_ops.py`
- `python -m pytest -q tests/test_goal_ops.py -k "test_110_p0_burnin_consecutive_green_reports_success_after_recovery_window or test_111_p0_burnin_consecutive_green_reports_failure_for_latest_non_green_run or test_112_p0_runbook_contract_check_reports_success or test_113_p0_release_evidence_bundle_reports_success_with_required_files or test_114_p0_release_evidence_bundle_fails_when_required_file_missing"`
- `./scripts/run-p0-runbook-contract-check.ps1`
- `./scripts/run-p0-release-evidence-bundle.ps1 -AllowEmpty`
- `./scripts/release-gate.ps1` skip-smoke including new `-SkipP0ReleaseEvidenceBundle`
