### PR TITLE
[codex] Add P0 closure go-no-go report and strict gate hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          .\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle
+          .\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 
       - name: Upload release evidence artifacts
         uses: actions/upload-artifact@v4
@@ -50,6 +50,7 @@ jobs:
             artifacts/p0-*-release-gate.json
             artifacts/p0-release-evidence-bundle-release-gate.json
             artifacts/p0-release-evidence-files-release-gate/**
+            artifacts/p0-closure-report-release-gate.json
           if-no-files-found: error
 
   test:

--- a/README.md
+++ b/README.md
@@ -410,11 +410,11 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle + P0 closure go/no-go report):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle
+.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 ```
 
 Standalone backup/restore drill:
@@ -648,6 +648,13 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-p0-release-evidence-bundle.ps1
 ```
 
+Standalone P0 closure go/no-go report (final readiness signal from bundled evidence):
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-p0-closure-report.ps1
+```
+
 Current result during implementation:
 
 ```text
@@ -665,7 +672,7 @@ GitHub Actions now runs `pytest` automatically for:
 Workflow file:
 [ci.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/ci.yml)
 
-Release Gate workflow artifact includes `p0-release-evidence-bundle` (manifest + copied evidence reports).
+Release Gate workflow artifact includes `p0-release-evidence-bundle` (manifest + copied evidence reports + closure report).
 
 Desktop workflow file:
 [desktop-build.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/desktop-build.yml)
@@ -913,5 +920,7 @@ If a value is rejected:
 - [run-p0-runbook-contract-check.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-p0-runbook-contract-check.ps1)
 - [p0-release-evidence-bundle.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/p0-release-evidence-bundle.py)
 - [run-p0-release-evidence-bundle.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-p0-release-evidence-bundle.ps1)
+- [p0-closure-report.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/p0-closure-report.py)
+- [run-p0-closure-report.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-p0-closure-report.ps1)
 - [test_goal_ops.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_goal_ops.py)
 - [test_desktop_launcher.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_desktop_launcher.py)

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -9,7 +9,7 @@ This runbook is optimized for reliability-first releases of the desktop app and 
 Run in repo root:
 
 ```powershell
-.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle
+.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 ```
 
 This gate covers:
@@ -50,6 +50,7 @@ This gate covers:
 - P0 burn-in consecutive-green monitor (latest CI history must satisfy N consecutive fully green runs)
 - P0 runbook contract check (release-gate/CI/runbook strict-flag and script-reference consistency)
 - P0 release evidence bundle (single artifact with required P0 report files and status summary)
+- P0 closure report (single go/no-go signal from burn-in + contract + evidence checks)
 
 Manual migration rehearsal invocation (same thresholds as gate defaults):
 
@@ -231,6 +232,12 @@ Manual P0 release evidence bundle invocation:
 .\scripts\run-p0-release-evidence-bundle.ps1
 ```
 
+Manual P0 closure report invocation:
+
+```powershell
+.\scripts\run-p0-closure-report.ps1
+```
+
 Verify before release:
 - CI checks green:
   - `Release Gate (Windows)`
@@ -240,6 +247,7 @@ Verify before release:
 - burn-in monitor report confirms threshold met (`metrics.consecutive_green >= metrics.required_consecutive`)
 - runbook contract report confirms zero missing flags/scripts (`success=true`)
 - release evidence bundle report confirms all required P0 reports present and successful (`success=true`)
+- closure report confirms all readiness criteria are green (`success=true`, `metrics.criteria_failed=0`)
 - `master` branch only receives PR merges (no direct pushes).
 - No unresolved high-severity bug tickets for release scope.
 

--- a/scripts/p0-closure-report.py
+++ b/scripts/p0-closure-report.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _resolve_path(project_root: Path, value: str) -> Path:
+    path = Path(str(value)).expanduser()
+    if not path.is_absolute():
+        path = project_root / path
+    return path.resolve()
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Expected JSON object in {path}")
+    return payload
+
+
+def _criterion(name: str, passed: bool, details: str) -> dict[str, Any]:
+    return {"name": name, "passed": bool(passed), "details": details}
+
+
+def build_closure_report(
+    *,
+    label: str,
+    required_consecutive: int,
+    evidence_bundle_file: Path,
+    burnin_file: Path,
+    runbook_contract_file: Path,
+    output_file: Path,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    criteria: list[dict[str, Any]] = []
+    missing_files: list[str] = []
+
+    def load_or_missing(path: Path) -> dict[str, Any] | None:
+        if not path.exists():
+            missing_files.append(str(path))
+            return None
+        return _read_json(path)
+
+    evidence_payload = load_or_missing(evidence_bundle_file)
+    burnin_payload = load_or_missing(burnin_file)
+    runbook_payload = load_or_missing(runbook_contract_file)
+
+    if evidence_payload is None:
+        criteria.append(_criterion("evidence_bundle_present", False, "Missing evidence bundle report file"))
+    else:
+        criteria.append(
+            _criterion(
+                "evidence_bundle_success",
+                bool(evidence_payload.get("success") is True),
+                f"success={evidence_payload.get('success')!r}",
+            )
+        )
+
+    if burnin_payload is None:
+        criteria.append(_criterion("burnin_report_present", False, "Missing burn-in report file"))
+    else:
+        burnin_success = bool(burnin_payload.get("success") is True)
+        metrics = burnin_payload.get("metrics") or {}
+        consecutive_green = int(metrics.get("consecutive_green") or 0)
+        criteria.append(_criterion("burnin_success", burnin_success, f"success={burnin_payload.get('success')!r}"))
+        criteria.append(
+            _criterion(
+                "burnin_consecutive_threshold",
+                consecutive_green >= required_consecutive,
+                f"consecutive_green={consecutive_green}, required={required_consecutive}",
+            )
+        )
+
+    if runbook_payload is None:
+        criteria.append(_criterion("runbook_contract_present", False, "Missing runbook contract report file"))
+    else:
+        criteria.append(
+            _criterion(
+                "runbook_contract_success",
+                bool(runbook_payload.get("success") is True),
+                f"success={runbook_payload.get('success')!r}",
+            )
+        )
+
+    failed_criteria = [item for item in criteria if not item["passed"]]
+    success = len(failed_criteria) == 0
+    report = {
+        "label": label,
+        "success": bool(success),
+        "config": {
+            "required_consecutive": int(required_consecutive),
+            "evidence_bundle_file": str(evidence_bundle_file),
+            "burnin_file": str(burnin_file),
+            "runbook_contract_file": str(runbook_contract_file),
+        },
+        "metrics": {
+            "criteria_total": len(criteria),
+            "criteria_passed": len(criteria) - len(failed_criteria),
+            "criteria_failed": len(failed_criteria),
+        },
+        "criteria": criteria,
+        "failed_criteria": failed_criteria,
+        "missing_files": missing_files,
+        "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "duration_ms": int((time.perf_counter() - started) * 1000),
+    }
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2), encoding="utf-8")
+    if not success:
+        raise RuntimeError(f"P0 closure report is not green: {json.dumps(report, sort_keys=True)}")
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build a P0 closure go/no-go report from release-gate evidence reports."
+    )
+    parser.add_argument("--label", default="p0-closure-report")
+    parser.add_argument("--project-root")
+    parser.add_argument("--required-consecutive", type=int, default=10)
+    parser.add_argument("--evidence-bundle-file", default="artifacts/p0-release-evidence-bundle-release-gate.json")
+    parser.add_argument("--burnin-file", default="artifacts/p0-burnin-consecutive-green-release-gate.json")
+    parser.add_argument("--runbook-contract-file", default="artifacts/p0-runbook-contract-check-release-gate.json")
+    parser.add_argument("--output-file", default="artifacts/p0-closure-report-release-gate.json")
+    parser.add_argument("--allow-not-ready", action="store_true")
+    args = parser.parse_args(argv)
+
+    if int(args.required_consecutive) <= 0:
+        print("[p0-closure-report] ERROR: --required-consecutive must be > 0.", file=sys.stderr)
+        return 2
+
+    inferred_project_root = Path(__file__).resolve().parents[1]
+    project_root = _resolve_path(inferred_project_root, args.project_root) if args.project_root else inferred_project_root
+    evidence_bundle_file = _resolve_path(project_root, args.evidence_bundle_file)
+    burnin_file = _resolve_path(project_root, args.burnin_file)
+    runbook_contract_file = _resolve_path(project_root, args.runbook_contract_file)
+    output_file = _resolve_path(project_root, args.output_file)
+
+    try:
+        report = build_closure_report(
+            label=str(args.label),
+            required_consecutive=int(args.required_consecutive),
+            evidence_bundle_file=evidence_bundle_file,
+            burnin_file=burnin_file,
+            runbook_contract_file=runbook_contract_file,
+            output_file=output_file,
+        )
+    except Exception as exc:
+        if args.allow_not_ready and output_file.exists():
+            report = _read_json(output_file)
+            print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+            return 0
+        print(f"[p0-closure-report] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/p0-runbook-contract-check.py
+++ b/scripts/p0-runbook-contract-check.py
@@ -17,6 +17,7 @@ DEFAULT_REQUIRED_RUNBOOK_SCRIPTS = [
     "run-release-gate-runtime-stability-drill.ps1",
     "run-p0-burnin-consecutive-green.ps1",
     "run-p0-release-evidence-bundle.ps1",
+    "run-p0-closure-report.ps1",
 ]
 
 

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -69,7 +69,9 @@ param(
     [switch]$SkipP0RunbookContractCheck,
     [switch]$StrictP0RunbookContractCheck,
     [switch]$SkipP0ReleaseEvidenceBundle,
-    [switch]$StrictP0ReleaseEvidenceBundle
+    [switch]$StrictP0ReleaseEvidenceBundle,
+    [switch]$SkipP0ClosureReport,
+    [switch]$StrictP0ClosureReport
 )
 
 $ErrorActionPreference = "Stop"
@@ -919,6 +921,31 @@ if (-not $SkipP0ReleaseEvidenceBundle) {
             }
             Write-Warning (
                 "P0 release evidence bundle failed but StrictP0ReleaseEvidenceBundle is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipP0ClosureReport) {
+    Invoke-GateStep -Name "P0 closure go/no-go report (consolidated readiness signal)" -Action {
+        $outputPath = Join-Path $ProjectRoot "artifacts\p0-closure-report-release-gate.json"
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\p0-closure-report.py",
+                "--label", "release-gate",
+                "--required-consecutive", "10",
+                "--evidence-bundle-file", "artifacts\p0-release-evidence-bundle-release-gate.json",
+                "--burnin-file", "artifacts\p0-burnin-consecutive-green-release-gate.json",
+                "--runbook-contract-file", "artifacts\p0-runbook-contract-check-release-gate.json",
+                "--output-file", $outputPath
+            )
+        } catch {
+            if ($StrictP0ClosureReport) {
+                throw
+            }
+            Write-Warning (
+                "P0 closure report failed but StrictP0ClosureReport is off. " +
                 "Continuing. Error: $($_.Exception.Message)"
             )
         }

--- a/scripts/run-p0-closure-report.ps1
+++ b/scripts/run-p0-closure-report.ps1
@@ -1,0 +1,34 @@
+param(
+    [string]$PythonExe = "python",
+    [int]$RequiredConsecutive = 10,
+    [string]$EvidenceBundleFile = "artifacts\\p0-release-evidence-bundle-release-gate.json",
+    [string]$BurnInFile = "artifacts\\p0-burnin-consecutive-green-release-gate.json",
+    [string]$RunbookContractFile = "artifacts\\p0-runbook-contract-check-release-gate.json",
+    [string]$OutputFile = "artifacts\\p0-closure-report-release-gate.json",
+    [switch]$AllowNotReady
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$arguments = @(
+    ".\\scripts\\p0-closure-report.py",
+    "--label", "manual",
+    "--required-consecutive", [string]$RequiredConsecutive,
+    "--evidence-bundle-file", $EvidenceBundleFile,
+    "--burnin-file", $BurnInFile,
+    "--runbook-contract-file", $RunbookContractFile,
+    "--output-file", $OutputFile
+)
+if ($AllowNotReady) {
+    $arguments += "--allow-not-ready"
+}
+
+& $PythonExe @arguments
+if ($LASTEXITCODE -ne 0) {
+    throw "P0 closure report failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "P0 closure report check passed." -ForegroundColor Green

--- a/scripts/run-p0-runbook-contract-check.ps1
+++ b/scripts/run-p0-runbook-contract-check.ps1
@@ -1,7 +1,7 @@
 param(
     [string]$PythonExe = "python",
     [string]$OutputFile = "artifacts\\p0-runbook-contract-check-report.json",
-    [string]$RequiredRunbookScripts = "run-power-loss-durability-drill.ps1,run-disk-pressure-fault-injection-drill.ps1,run-upgrade-downgrade-compatibility-drill.ps1,run-backup-restore-stress-drill.ps1,run-release-gate-runtime-stability-drill.ps1,run-p0-burnin-consecutive-green.ps1,run-p0-release-evidence-bundle.ps1",
+    [string]$RequiredRunbookScripts = "run-power-loss-durability-drill.ps1,run-disk-pressure-fault-injection-drill.ps1,run-upgrade-downgrade-compatibility-drill.ps1,run-backup-restore-stress-drill.ps1,run-release-gate-runtime-stability-drill.ps1,run-p0-burnin-consecutive-green.ps1,run-p0-release-evidence-bundle.ps1,run-p0-closure-report.ps1",
     [string]$RequiredStrictFlags = ""
 )
 

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -3408,3 +3408,126 @@ def test_114_p0_release_evidence_bundle_fails_when_required_file_missing():
     assert str(missing_report) in report["required_missing"]
 
     shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_115_p0_closure_report_reports_success_when_all_criteria_pass():
+    workspace = _local_test_dir("pytest-p0-closure-report-success").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    artifacts_dir = workspace / "artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    evidence_file = artifacts_dir / "p0-release-evidence-bundle-release-gate.json"
+    burnin_file = artifacts_dir / "p0-burnin-consecutive-green-release-gate.json"
+    runbook_file = artifacts_dir / "p0-runbook-contract-check-release-gate.json"
+    output_file = artifacts_dir / "p0-closure-report-release-gate.json"
+
+    evidence_file.write_text(
+        json.dumps({"label": "evidence", "success": True}, ensure_ascii=True, sort_keys=True),
+        encoding="utf-8",
+    )
+    burnin_file.write_text(
+        json.dumps(
+            {"label": "burnin", "success": True, "metrics": {"consecutive_green": 12}},
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    runbook_file.write_text(
+        json.dumps({"label": "runbook", "success": True}, ensure_ascii=True, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "p0-closure-report.py"),
+        "--label",
+        "pytest-drill",
+        "--project-root",
+        str(workspace.resolve()),
+        "--required-consecutive",
+        "10",
+        "--evidence-bundle-file",
+        str(evidence_file.resolve()),
+        "--burnin-file",
+        str(burnin_file.resolve()),
+        "--runbook-contract-file",
+        str(runbook_file.resolve()),
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["metrics"]["criteria_failed"] == 0
+    assert output_file.exists()
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_116_p0_closure_report_fails_when_burnin_threshold_not_met():
+    workspace = _local_test_dir("pytest-p0-closure-report-failure").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    artifacts_dir = workspace / "artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    evidence_file = artifacts_dir / "p0-release-evidence-bundle-release-gate.json"
+    burnin_file = artifacts_dir / "p0-burnin-consecutive-green-release-gate.json"
+    runbook_file = artifacts_dir / "p0-runbook-contract-check-release-gate.json"
+    output_file = artifacts_dir / "p0-closure-report-release-gate.json"
+
+    evidence_file.write_text(
+        json.dumps({"label": "evidence", "success": True}, ensure_ascii=True, sort_keys=True),
+        encoding="utf-8",
+    )
+    burnin_file.write_text(
+        json.dumps(
+            {"label": "burnin", "success": True, "metrics": {"consecutive_green": 3}},
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    runbook_file.write_text(
+        json.dumps({"label": "runbook", "success": True}, ensure_ascii=True, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "p0-closure-report.py"),
+        "--label",
+        "pytest-drill",
+        "--project-root",
+        str(workspace.resolve()),
+        "--required-consecutive",
+        "10",
+        "--evidence-bundle-file",
+        str(evidence_file.resolve()),
+        "--burnin-file",
+        str(burnin_file.resolve()),
+        "--runbook-contract-file",
+        str(runbook_file.resolve()),
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "P0 closure report is not green: "
+    assert marker in completed.stderr
+    payload = json.loads(completed.stderr.split(marker, 1)[1].strip())
+    assert payload["success"] is False
+    assert payload["metrics"]["criteria_failed"] >= 1
+
+    shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
﻿## Summary
- add `scripts/p0-closure-report.py` to compute a single go/no-go signal from P0 evidence artifacts
- add `scripts/run-p0-closure-report.ps1` wrapper for local operator execution
- integrate closure report into `release-gate.ps1` with strict/skip flags (`-StrictP0ClosureReport`, `-SkipP0ClosureReport`)
- include closure report in CI release-evidence artifact upload
- update runbook contract required script set and documentation references
- extend tests with closure report success/failure scenarios

## Why
This closes the loop for Stufe-A by producing one machine-readable readiness decision from burn-in, contract, and bundled evidence checks.

## Validation
- `python -m py_compile scripts/p0-closure-report.py scripts/p0-release-evidence-bundle.py scripts/p0-runbook-contract-check.py tests/test_goal_ops.py`
- `python -m pytest -q tests/test_goal_ops.py -k "test_110_p0_burnin_consecutive_green_reports_success_after_recovery_window or test_111_p0_burnin_consecutive_green_reports_failure_for_latest_non_green_run or test_112_p0_runbook_contract_check_reports_success or test_113_p0_release_evidence_bundle_reports_success_with_required_files or test_114_p0_release_evidence_bundle_fails_when_required_file_missing or test_115_p0_closure_report_reports_success_when_all_criteria_pass or test_116_p0_closure_report_fails_when_burnin_threshold_not_met"`
- `./scripts/run-p0-runbook-contract-check.ps1`
- `./scripts/run-p0-release-evidence-bundle.ps1 -AllowEmpty`
- `./scripts/run-p0-closure-report.ps1 -AllowNotReady`
- `./scripts/release-gate.ps1` skip-smoke including new `-SkipP0ClosureReport`
