### PR TITLE
[codex] Add stage-B security config hardening gate and operator auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          .\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+          .\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 
       - name: Upload release evidence artifacts
         uses: actions/upload-artifact@v4
@@ -51,6 +51,7 @@ jobs:
             artifacts/p0-release-evidence-bundle-release-gate.json
             artifacts/p0-release-evidence-files-release-gate/**
             artifacts/p0-closure-report-release-gate.json
+            artifacts/security-config-hardening-release-gate.json
           if-no-files-found: error
 
   test:

--- a/README.md
+++ b/README.md
@@ -410,11 +410,11 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle + P0 closure go/no-go report):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + security config hardening check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle + P0 closure go/no-go report):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 ```
 
 Standalone backup/restore drill:
@@ -464,6 +464,13 @@ Standalone auto-rollback policy check (live service):
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-auto-rollback-policy.ps1 -BaseUrl "http://127.0.0.1:8000" -ManifestPath ".\artifacts\desktop-rings.json" -CriticalWindowSeconds 300 -PollIntervalSeconds 30 -MaxObservationSeconds 900
+```
+
+Standalone security config hardening check (production profile policy):
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-security-config-hardening-check.ps1 -OperatorAuthRequired -OperatorAuthToken "replace-with-long-secret-token" -StartupCorruptionRecoveryEnabled
 ```
 
 Standalone release-freeze policy check (live service):
@@ -922,5 +929,7 @@ If a value is rejected:
 - [run-p0-release-evidence-bundle.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-p0-release-evidence-bundle.ps1)
 - [p0-closure-report.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/p0-closure-report.py)
 - [run-p0-closure-report.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-p0-closure-report.ps1)
+- [security-config-hardening-check.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/security-config-hardening-check.py)
+- [run-security-config-hardening-check.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-security-config-hardening-check.ps1)
 - [test_goal_ops.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_goal_ops.py)
 - [test_desktop_launcher.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_desktop_launcher.py)

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -9,7 +9,7 @@ This runbook is optimized for reliability-first releases of the desktop app and 
 Run in repo root:
 
 ```powershell
-.\scripts\release-gate.ps1 -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 ```
 
 This gate covers:
@@ -17,6 +17,7 @@ This gate covers:
 - desktop smoke boot path
 - `GET /system/readiness`
 - `GET /system/slo` (`status` must be `ok`)
+- security config hardening check (production profile must require operator auth, strong token, non-memory DB, and startup corruption recovery guard)
 - release-freeze policy drill (sustained non-ok window or burn-rate spike freezes ring promotion path)
 - auto-rollback-policy drill (`critical` sustained window triggers stable ring rollback path)
 - desktop-update-safety drill (hash validation + rollback-to-stable fallback path)
@@ -68,6 +69,12 @@ Manual auto-rollback policy invocation (live endpoint, stable ring):
 
 ```powershell
 .\scripts\run-auto-rollback-policy.ps1 -BaseUrl "http://127.0.0.1:8000" -ManifestPath ".\artifacts\desktop-rings.json" -CriticalWindowSeconds 300 -PollIntervalSeconds 30 -MaxObservationSeconds 900
+```
+
+Manual security config hardening check invocation:
+
+```powershell
+.\scripts\run-security-config-hardening-check.ps1 -OperatorAuthRequired -OperatorAuthToken "replace-with-long-secret-token" -StartupCorruptionRecoveryEnabled
 ```
 
 Manual release-freeze policy invocation (live endpoint, stable ring):
@@ -248,6 +255,7 @@ Verify before release:
 - runbook contract report confirms zero missing flags/scripts (`success=true`)
 - release evidence bundle report confirms all required P0 reports present and successful (`success=true`)
 - closure report confirms all readiness criteria are green (`success=true`, `metrics.criteria_failed=0`)
+- security hardening report confirms production policy criteria are green (`success=true`)
 - `master` branch only receives PR merges (no direct pushes).
 - No unresolved high-severity bug tickets for release scope.
 

--- a/goal_ops_console/config.py
+++ b/goal_ops_console/config.py
@@ -142,6 +142,15 @@ IDEMPOTENCY_RETENTION_DAYS = _env_int(
     "GOAL_OPS_IDEMPOTENCY_RETENTION_DAYS",
     14,
 )
+OPERATOR_AUTH_REQUIRED = _env_bool(
+    "GOAL_OPS_OPERATOR_AUTH_REQUIRED",
+    False,
+)
+OPERATOR_AUTH_TOKEN = os.getenv("GOAL_OPS_OPERATOR_AUTH_TOKEN", "")
+OPERATOR_AUTH_TOKEN_MIN_LENGTH = _env_int(
+    "GOAL_OPS_OPERATOR_AUTH_TOKEN_MIN_LENGTH",
+    16,
+)
 
 # The sandbox in this workspace rejects file-backed SQLite locks, so the
 # persistent `goal_ops.db` path should be supplied via GOAL_OPS_DATABASE_URL.
@@ -191,3 +200,6 @@ class Settings:
     safe_mode_io_error_window_seconds: int = SAFE_MODE_IO_ERROR_WINDOW_SECONDS
     safe_mode_auto_disable_after_seconds: int = SAFE_MODE_AUTO_DISABLE_AFTER_SECONDS
     idempotency_retention_days: int = IDEMPOTENCY_RETENTION_DAYS
+    operator_auth_required: bool = OPERATOR_AUTH_REQUIRED
+    operator_auth_token: str = OPERATOR_AUTH_TOKEN
+    operator_auth_token_min_length: int = OPERATOR_AUTH_TOKEN_MIN_LENGTH

--- a/goal_ops_console/main.py
+++ b/goal_ops_console/main.py
@@ -57,6 +57,33 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         method = request.method.upper()
         path = request.url.path
 
+        if (
+            bool(services.settings.operator_auth_required)
+            and method in {"POST", "PUT", "PATCH", "DELETE"}
+            and path.startswith("/system/")
+        ):
+            expected_token = str(services.settings.operator_auth_token or "").strip()
+            auth_header = str(request.headers.get("Authorization") or "")
+            operator_header = str(request.headers.get("X-Operator-Token") or "").strip()
+            provided_token = ""
+            if auth_header.lower().startswith("bearer "):
+                provided_token = auth_header[7:].strip()
+            elif operator_header:
+                provided_token = operator_header
+
+            if not provided_token or provided_token != expected_token:
+                services.observability.increment_metric("security.operator_auth.denied")
+                return JSONResponse(
+                    status_code=401,
+                    content={
+                        "detail": (
+                            "Operator authentication required for mutating /system endpoints."
+                        )
+                    },
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+            services.observability.increment_metric("security.operator_auth.allowed")
+
         if services.runtime_guard.should_block_mutation(method=method, path=path):
             safe_mode = services.runtime_guard.safe_mode_snapshot()
             return JSONResponse(

--- a/goal_ops_console/routers/system.py
+++ b/goal_ops_console/routers/system.py
@@ -59,6 +59,15 @@ def _build_health_payload(services: AppServices) -> dict[str, Any]:
         "invariant_monitor": services.invariant_monitor.status(),
         "safe_mode": services.runtime_guard.safe_mode_snapshot(),
         "database_startup_recovery": services.db.startup_recovery_status(),
+        "security": {
+            "operator_auth_required": bool(services.settings.operator_auth_required),
+            "operator_auth_token_configured": bool(
+                str(services.settings.operator_auth_token or "").strip()
+            ),
+            "operator_auth_token_min_length": int(
+                services.settings.operator_auth_token_min_length
+            ),
+        },
     }
 
 
@@ -152,8 +161,19 @@ def _build_readiness_payload(services: AppServices) -> dict[str, Any]:
         and not invariant_monitor.get("last_error")
     )
 
+    operator_token = str(services.settings.operator_auth_token or "").strip()
+    operator_token_min_length = max(1, int(services.settings.operator_auth_token_min_length))
+    operator_auth_required = bool(services.settings.operator_auth_required)
+    operator_auth_ok = (not operator_auth_required) or (len(operator_token) >= operator_token_min_length)
+
     return {
-        "ready": bool(db_ok and worker_ok and safe_mode_ok and invariant_monitor_ok),
+        "ready": bool(
+            db_ok
+            and worker_ok
+            and safe_mode_ok
+            and invariant_monitor_ok
+            and operator_auth_ok
+        ),
         "spec_version": SPEC_VERSION,
         "timestamp_utc": _utc_iso(),
         "checks": {
@@ -178,6 +198,13 @@ def _build_readiness_payload(services: AppServices) -> dict[str, Any]:
                 **invariant_monitor,
                 "ok": invariant_monitor_ok,
                 "error": invariant_monitor_error,
+            },
+            "operator_auth": {
+                "ok": operator_auth_ok,
+                "required": operator_auth_required,
+                "token_configured": bool(operator_token),
+                "token_length": len(operator_token),
+                "token_min_length": operator_token_min_length,
             },
         },
     }

--- a/goal_ops_console/services.py
+++ b/goal_ops_console/services.py
@@ -36,6 +36,14 @@ class AppServices:
 
 def build_services(settings: Settings | None = None) -> AppServices:
     app_settings = settings or Settings()
+    if app_settings.operator_auth_required:
+        token = str(app_settings.operator_auth_token or "").strip()
+        minimum = max(1, int(app_settings.operator_auth_token_min_length))
+        if len(token) < minimum:
+            raise ValueError(
+                "Operator auth is required but GOAL_OPS_OPERATOR_AUTH_TOKEN is missing or too short "
+                f"(minimum length: {minimum})."
+            )
     db = Database(
         app_settings.database_url,
         migration_backup_dir=app_settings.db_migration_backup_dir,

--- a/scripts/p0-runbook-contract-check.py
+++ b/scripts/p0-runbook-contract-check.py
@@ -10,6 +10,7 @@ from typing import Any
 
 
 DEFAULT_REQUIRED_RUNBOOK_SCRIPTS = [
+    "run-security-config-hardening-check.ps1",
     "run-power-loss-durability-drill.ps1",
     "run-disk-pressure-fault-injection-drill.ps1",
     "run-upgrade-downgrade-compatibility-drill.ps1",

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -4,6 +4,8 @@ param(
     [switch]$SkipDesktopSmoke,
     [switch]$SkipApiProbe,
     [switch]$SkipSloAlertCheck,
+    [switch]$SkipSecurityConfigHardeningCheck,
+    [switch]$StrictSecurityConfigHardeningCheck,
     [switch]$SkipReleaseFreezePolicyDrill,
     [switch]$StrictReleaseFreezePolicyDrill,
     [switch]$SkipFileDatabaseProbe,
@@ -138,6 +140,33 @@ if (-not $SkipSloAlertCheck) {
             "--database-url", ":memory:",
             "--allowed-status", "ok"
         )
+    }
+}
+
+if (-not $SkipSecurityConfigHardeningCheck) {
+    Invoke-GateStep -Name "Security config hardening check (production profile)" -Action {
+        $reportPath = Join-Path $ProjectRoot "artifacts\security-config-hardening-release-gate.json"
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\security-config-hardening-check.py",
+                "--label", "release-gate",
+                "--deployment-profile", "production",
+                "--operator-auth-required",
+                "--operator-auth-token", "release-gate-operator-token-0001",
+                "--min-operator-token-length", "16",
+                "--database-url", "goal_ops.db",
+                "--startup-corruption-recovery-enabled",
+                "--output-file", $reportPath
+            )
+        } catch {
+            if ($StrictSecurityConfigHardeningCheck) {
+                throw
+            }
+            Write-Warning (
+                "Security config hardening check failed but StrictSecurityConfigHardeningCheck is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
     }
 }
 

--- a/scripts/run-p0-runbook-contract-check.ps1
+++ b/scripts/run-p0-runbook-contract-check.ps1
@@ -1,7 +1,7 @@
 param(
     [string]$PythonExe = "python",
     [string]$OutputFile = "artifacts\\p0-runbook-contract-check-report.json",
-    [string]$RequiredRunbookScripts = "run-power-loss-durability-drill.ps1,run-disk-pressure-fault-injection-drill.ps1,run-upgrade-downgrade-compatibility-drill.ps1,run-backup-restore-stress-drill.ps1,run-release-gate-runtime-stability-drill.ps1,run-p0-burnin-consecutive-green.ps1,run-p0-release-evidence-bundle.ps1,run-p0-closure-report.ps1",
+    [string]$RequiredRunbookScripts = "run-security-config-hardening-check.ps1,run-power-loss-durability-drill.ps1,run-disk-pressure-fault-injection-drill.ps1,run-upgrade-downgrade-compatibility-drill.ps1,run-backup-restore-stress-drill.ps1,run-release-gate-runtime-stability-drill.ps1,run-p0-burnin-consecutive-green.ps1,run-p0-release-evidence-bundle.ps1,run-p0-closure-report.ps1",
     [string]$RequiredStrictFlags = ""
 )
 

--- a/scripts/run-security-config-hardening-check.ps1
+++ b/scripts/run-security-config-hardening-check.ps1
@@ -1,0 +1,46 @@
+param(
+    [string]$PythonExe = "python",
+    [string]$DeploymentProfile = "production",
+    [switch]$OperatorAuthRequired,
+    [string]$OperatorAuthToken = "",
+    [int]$MinOperatorTokenLength = 16,
+    [string]$DatabaseUrl = "goal_ops.db",
+    [switch]$StartupCorruptionRecoveryEnabled,
+    [switch]$AllowMemoryDatabase,
+    [string]$OutputFile = "artifacts\\security-config-hardening-check-report.json",
+    [switch]$AllowFailure
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$arguments = @(
+    ".\\scripts\\security-config-hardening-check.py",
+    "--label", "manual",
+    "--deployment-profile", $DeploymentProfile,
+    "--operator-auth-token", $OperatorAuthToken,
+    "--min-operator-token-length", [string]$MinOperatorTokenLength,
+    "--database-url", $DatabaseUrl,
+    "--output-file", $OutputFile
+)
+if ($OperatorAuthRequired) {
+    $arguments += "--operator-auth-required"
+}
+if ($StartupCorruptionRecoveryEnabled) {
+    $arguments += "--startup-corruption-recovery-enabled"
+}
+if ($AllowMemoryDatabase) {
+    $arguments += "--allow-memory-database"
+}
+if ($AllowFailure) {
+    $arguments += "--allow-failure"
+}
+
+& $PythonExe @arguments
+if ($LASTEXITCODE -ne 0) {
+    throw "Security config hardening check failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Security config hardening check passed." -ForegroundColor Green

--- a/scripts/security-config-hardening-check.py
+++ b/scripts/security-config-hardening-check.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _is_memory_database(url: str) -> bool:
+    normalized = str(url or "").strip().lower()
+    if normalized in {"", ":memory:", "sqlite:///:memory:"}:
+        return True
+    return normalized.endswith("/:memory:")
+
+
+def run_check(
+    *,
+    label: str,
+    deployment_profile: str,
+    operator_auth_required: bool,
+    operator_auth_token: str,
+    min_operator_token_length: int,
+    database_url: str,
+    startup_corruption_recovery_enabled: bool,
+    allow_memory_database: bool,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    profile = str(deployment_profile).strip().lower() or "production"
+    minimum = max(1, int(min_operator_token_length))
+    token = str(operator_auth_token or "").strip()
+    criteria: list[dict[str, Any]] = []
+
+    def add(name: str, passed: bool, details: str) -> None:
+        criteria.append({"name": name, "passed": bool(passed), "details": details})
+
+    if profile == "production":
+        add(
+            "operator_auth_required",
+            bool(operator_auth_required),
+            f"operator_auth_required={operator_auth_required!r}",
+        )
+        add(
+            "operator_auth_token_length",
+            len(token) >= minimum,
+            f"token_length={len(token)}, minimum={minimum}",
+        )
+        memory_db = _is_memory_database(database_url)
+        add(
+            "database_not_in_memory",
+            (not memory_db) or allow_memory_database,
+            f"database_url={database_url!r}, is_memory={memory_db}, allow_memory_database={allow_memory_database!r}",
+        )
+        add(
+            "startup_corruption_recovery_enabled",
+            bool(startup_corruption_recovery_enabled),
+            f"startup_corruption_recovery_enabled={startup_corruption_recovery_enabled!r}",
+        )
+    else:
+        # For non-production profiles, report values but do not fail by default.
+        add(
+            "non_production_profile",
+            True,
+            f"deployment_profile={profile!r} (hard requirements skipped)",
+        )
+
+    failed = [item for item in criteria if not item["passed"]]
+    success = len(failed) == 0
+    report = {
+        "label": label,
+        "success": bool(success),
+        "config": {
+            "deployment_profile": profile,
+            "operator_auth_required": bool(operator_auth_required),
+            "min_operator_token_length": int(minimum),
+            "database_url": str(database_url),
+            "startup_corruption_recovery_enabled": bool(startup_corruption_recovery_enabled),
+            "allow_memory_database": bool(allow_memory_database),
+        },
+        "metrics": {
+            "criteria_total": len(criteria),
+            "criteria_failed": len(failed),
+            "criteria_passed": len(criteria) - len(failed),
+        },
+        "criteria": criteria,
+        "failed_criteria": failed,
+        "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "duration_ms": int((time.perf_counter() - started) * 1000),
+    }
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Security/config hardening preflight for production profile. "
+            "Checks operator auth, token strength, DB mode, and startup recovery guard."
+        )
+    )
+    parser.add_argument("--label", default="security-config-hardening")
+    parser.add_argument("--deployment-profile", default="production")
+    parser.add_argument("--operator-auth-required", action="store_true")
+    parser.add_argument("--operator-auth-token", default="")
+    parser.add_argument("--min-operator-token-length", type=int, default=16)
+    parser.add_argument("--database-url", default="goal_ops.db")
+    parser.add_argument("--startup-corruption-recovery-enabled", action="store_true")
+    parser.add_argument("--allow-memory-database", action="store_true")
+    parser.add_argument("--output-file")
+    parser.add_argument("--allow-failure", action="store_true")
+    args = parser.parse_args(argv)
+
+    report = run_check(
+        label=str(args.label),
+        deployment_profile=str(args.deployment_profile),
+        operator_auth_required=bool(args.operator_auth_required),
+        operator_auth_token=str(args.operator_auth_token),
+        min_operator_token_length=int(args.min_operator_token_length),
+        database_url=str(args.database_url),
+        startup_corruption_recovery_enabled=bool(args.startup_corruption_recovery_enabled),
+        allow_memory_database=bool(args.allow_memory_database),
+    )
+
+    output_file = None
+    if args.output_file:
+        output_file = Path(str(args.output_file)).expanduser()
+        if not output_file.is_absolute():
+            output_file = (Path(__file__).resolve().parents[1] / output_file).resolve()
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2), encoding="utf-8")
+
+    if report["success"] is False and not bool(args.allow_failure):
+        print(f"[security-config-hardening-check] ERROR: {json.dumps(report, sort_keys=True)}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -3531,3 +3531,106 @@ def test_116_p0_closure_report_fails_when_burnin_threshold_not_met():
     assert payload["metrics"]["criteria_failed"] >= 1
 
     shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_117_operator_auth_blocks_system_mutations_without_valid_token():
+    app = create_app(
+        Settings(
+            database_url=":memory:",
+            operator_auth_required=True,
+            operator_auth_token="operator-token-0123456789",
+            operator_auth_token_min_length=16,
+        )
+    )
+    with TestClient(app) as local_client:
+        health = local_client.get("/system/health")
+        blocked = local_client.post("/system/scheduler/age")
+        wrong = local_client.post(
+            "/system/scheduler/age",
+            headers={"Authorization": "Bearer wrong-token"},
+        )
+        allowed = local_client.post(
+            "/system/scheduler/age",
+            headers={"Authorization": "Bearer operator-token-0123456789"},
+        )
+
+    assert health.status_code == 200
+    assert blocked.status_code == 401
+    assert blocked.headers.get("WWW-Authenticate") == "Bearer"
+    assert "Operator authentication required" in blocked.json()["detail"]
+    assert wrong.status_code == 401
+    assert allowed.status_code == 200
+
+
+def test_118_create_app_rejects_weak_operator_token_when_auth_required():
+    with pytest.raises(ValueError) as exc_info:
+        create_app(
+            Settings(
+                database_url=":memory:",
+                operator_auth_required=True,
+                operator_auth_token="short",
+                operator_auth_token_min_length=16,
+            )
+        )
+    assert "Operator auth is required" in str(exc_info.value)
+
+
+def test_119_security_config_hardening_check_reports_success():
+    project_root = Path(__file__).resolve().parents[1]
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "security-config-hardening-check.py"),
+        "--label",
+        "pytest-drill",
+        "--deployment-profile",
+        "production",
+        "--operator-auth-required",
+        "--operator-auth-token",
+        "security-token-0123456789",
+        "--min-operator-token-length",
+        "16",
+        "--database-url",
+        "goal_ops.db",
+        "--startup-corruption-recovery-enabled",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["metrics"]["criteria_failed"] == 0
+
+
+def test_120_security_config_hardening_check_reports_failure_without_auth_requirement():
+    project_root = Path(__file__).resolve().parents[1]
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "security-config-hardening-check.py"),
+        "--label",
+        "pytest-drill",
+        "--deployment-profile",
+        "production",
+        "--operator-auth-token",
+        "security-token-0123456789",
+        "--min-operator-token-length",
+        "16",
+        "--database-url",
+        "goal_ops.db",
+        "--startup-corruption-recovery-enabled",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "[security-config-hardening-check] ERROR: "
+    assert marker in completed.stderr
+    payload = json.loads(completed.stderr.split(marker, 1)[1].strip())
+    assert payload["success"] is False
+    assert payload["metrics"]["criteria_failed"] >= 1


### PR DESCRIPTION
﻿## Summary
- add Stage-B security config hardening check script (`security-config-hardening-check.py`) plus PowerShell wrapper
- integrate security hardening into release gate with `-StrictSecurityConfigHardeningCheck` / `-SkipSecurityConfigHardeningCheck`
- wire CI release gate to run the strict security check and upload its report artifact
- add operator authentication settings (`GOAL_OPS_OPERATOR_AUTH_REQUIRED`, `GOAL_OPS_OPERATOR_AUTH_TOKEN`, min length) with startup validation
- enforce auth for mutating `/system/*` endpoints when operator auth is enabled (Bearer or `X-Operator-Token`)
- surface operator auth state in health/readiness payloads
- update runbook contract defaults, README, and production runbook docs
- add automated tests for auth enforcement, weak-token startup rejection, and security hardening script success/failure

## Why
This starts Stage B (Security & Ops Foundation) with a concrete guardrail: production profile config hardening and authenticated operator mutations.

## Validation
- `python -m py_compile goal_ops_console/config.py goal_ops_console/services.py goal_ops_console/main.py goal_ops_console/routers/system.py scripts/security-config-hardening-check.py tests/test_goal_ops.py`
- `python -m pytest -q tests/test_goal_ops.py -k "test_21_scheduler_age_endpoint_increments_wait_cycles or test_117_operator_auth_blocks_system_mutations_without_valid_token or test_118_create_app_rejects_weak_operator_token_when_auth_required or test_119_security_config_hardening_check_reports_success or test_120_security_config_hardening_check_reports_failure_without_auth_requirement or test_112_p0_runbook_contract_check_reports_success"`
- `./scripts/run-p0-runbook-contract-check.ps1`
- `./scripts/run-security-config-hardening-check.ps1 -OperatorAuthRequired -OperatorAuthToken "security-token-0123456789" -StartupCorruptionRecoveryEnabled`
- `./scripts/release-gate.ps1` skip-smoke including new `-SkipSecurityConfigHardeningCheck`
