### PR TITLE
[codex] Add stage-B audit trail hardening gate and integrity chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          .\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+          .\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 
       - name: Upload release evidence artifacts
         uses: actions/upload-artifact@v4
@@ -52,6 +52,7 @@ jobs:
             artifacts/p0-release-evidence-files-release-gate/**
             artifacts/p0-closure-report-release-gate.json
             artifacts/security-config-hardening-release-gate.json
+            artifacts/audit-trail-hardening-release-gate.json
           if-no-files-found: error
 
   test:

--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ Observability endpoints:
 
 - `GET /system/metrics`
 - `GET /system/audit`
+- `GET /system/audit/integrity`
 - `GET /system/slo`
 - `GET /system/safe-mode`
 - `POST /system/safe-mode/enable`
@@ -410,11 +411,11 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + security config hardening check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle + P0 closure go/no-go report):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + security config hardening check + audit trail hardening check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle + P0 closure go/no-go report):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 ```
 
 Standalone backup/restore drill:
@@ -471,6 +472,13 @@ Standalone security config hardening check (production profile policy):
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-security-config-hardening-check.ps1 -OperatorAuthRequired -OperatorAuthToken "replace-with-long-secret-token" -StartupCorruptionRecoveryEnabled
+```
+
+Standalone audit trail hardening check (hash-chain integrity + tamper detection + retention policy):
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-audit-trail-hardening-check.ps1 -AuditRetentionDays 365 -MinAuditRetentionDays 90 -SeedEntries 8
 ```
 
 Standalone release-freeze policy check (live service):
@@ -931,5 +939,7 @@ If a value is rejected:
 - [run-p0-closure-report.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-p0-closure-report.ps1)
 - [security-config-hardening-check.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/security-config-hardening-check.py)
 - [run-security-config-hardening-check.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-security-config-hardening-check.ps1)
+- [audit-trail-hardening-check.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/audit-trail-hardening-check.py)
+- [run-audit-trail-hardening-check.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-audit-trail-hardening-check.ps1)
 - [test_goal_ops.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_goal_ops.py)
 - [test_desktop_launcher.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_desktop_launcher.py)

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -9,7 +9,7 @@ This runbook is optimized for reliability-first releases of the desktop app and 
 Run in repo root:
 
 ```powershell
-.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 ```
 
 This gate covers:
@@ -18,6 +18,7 @@ This gate covers:
 - `GET /system/readiness`
 - `GET /system/slo` (`status` must be `ok`)
 - security config hardening check (production profile must require operator auth, strong token, non-memory DB, and startup corruption recovery guard)
+- audit trail hardening check (audit hash-chain integrity verification, tamper detection, and retention policy floor)
 - release-freeze policy drill (sustained non-ok window or burn-rate spike freezes ring promotion path)
 - auto-rollback-policy drill (`critical` sustained window triggers stable ring rollback path)
 - desktop-update-safety drill (hash validation + rollback-to-stable fallback path)
@@ -75,6 +76,12 @@ Manual security config hardening check invocation:
 
 ```powershell
 .\scripts\run-security-config-hardening-check.ps1 -OperatorAuthRequired -OperatorAuthToken "replace-with-long-secret-token" -StartupCorruptionRecoveryEnabled
+```
+
+Manual audit trail hardening check invocation:
+
+```powershell
+.\scripts\run-audit-trail-hardening-check.ps1 -AuditRetentionDays 365 -MinAuditRetentionDays 90 -SeedEntries 8
 ```
 
 Manual release-freeze policy invocation (live endpoint, stable ring):

--- a/goal_ops_console/config.py
+++ b/goal_ops_console/config.py
@@ -82,6 +82,7 @@ EPHEMERAL_MAX_ROWS = 10_000
 EVENTS_RETENTION_DAYS = 30
 EVENT_PROCESSING_RETENTION_DAYS = 30
 FAILURE_LOG_RETENTION_DAYS = 90
+AUDIT_LOG_RETENTION_DAYS = _env_int("GOAL_OPS_AUDIT_LOG_RETENTION_DAYS", 365)
 WORKFLOW_RUN_TIMEOUT_SECONDS = 300
 WORKFLOW_REAPER_BATCH_SIZE = 200
 WORKFLOW_WORKER_POLL_INTERVAL_SECONDS = 0.5
@@ -177,6 +178,7 @@ class Settings:
     events_retention_days: int = EVENTS_RETENTION_DAYS
     event_processing_retention_days: int = EVENT_PROCESSING_RETENTION_DAYS
     failure_log_retention_days: int = FAILURE_LOG_RETENTION_DAYS
+    audit_log_retention_days: int = AUDIT_LOG_RETENTION_DAYS
     workflow_run_timeout_seconds: int = WORKFLOW_RUN_TIMEOUT_SECONDS
     workflow_reaper_batch_size: int = WORKFLOW_REAPER_BATCH_SIZE
     workflow_worker_poll_interval_seconds: float = WORKFLOW_WORKER_POLL_INTERVAL_SECONDS

--- a/goal_ops_console/database.py
+++ b/goal_ops_console/database.py
@@ -236,6 +236,20 @@ CREATE TABLE IF NOT EXISTS audit_log (
 CREATE INDEX IF NOT EXISTS idx_audit_log_created_at ON audit_log(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_audit_log_action_created_at ON audit_log(action, created_at DESC);
 
+CREATE TABLE IF NOT EXISTS audit_log_integrity (
+  chain_index      INTEGER PRIMARY KEY AUTOINCREMENT,
+  audit_id         TEXT NOT NULL UNIQUE,
+  previous_hash    TEXT,
+  entry_hash       TEXT NOT NULL,
+  canonical_payload TEXT NOT NULL,
+  created_at       TEXT NOT NULL,
+  FOREIGN KEY(audit_id) REFERENCES audit_log(audit_id)
+);
+CREATE INDEX IF NOT EXISTS idx_audit_log_integrity_created_at
+ON audit_log_integrity(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_log_integrity_audit_id
+ON audit_log_integrity(audit_id);
+
 CREATE TABLE IF NOT EXISTS metrics_counters (
   metric_name TEXT PRIMARY KEY,
   value       INTEGER NOT NULL DEFAULT 0,

--- a/goal_ops_console/event_bus.py
+++ b/goal_ops_console/event_bus.py
@@ -27,6 +27,7 @@ class EventBus:
         events_retention_days: int,
         event_processing_retention_days: int,
         failure_log_retention_days: int,
+        audit_log_retention_days: int,
         idempotency_retention_days: int,
         observability: "ObservabilityService | None" = None,
     ):
@@ -38,6 +39,7 @@ class EventBus:
         self.events_retention_days = events_retention_days
         self.event_processing_retention_days = event_processing_retention_days
         self.failure_log_retention_days = failure_log_retention_days
+        self.audit_log_retention_days = audit_log_retention_days
         self.idempotency_retention_days = idempotency_retention_days
         self.observability = observability
 
@@ -141,6 +143,22 @@ class EventBus:
                    WHERE created_at < datetime('now', ? || ' days')""",
                 f"-{self.failure_log_retention_days}",
             )
+            audit_integrity_deleted = tx.execute(
+                """DELETE FROM audit_log_integrity
+                   WHERE created_at < datetime('now', ? || ' days')
+                      OR audit_id IN (
+                          SELECT audit_id
+                          FROM audit_log
+                          WHERE created_at < datetime('now', ? || ' days')
+                      )""",
+                f"-{self.audit_log_retention_days}",
+                f"-{self.audit_log_retention_days}",
+            )
+            audit_log_deleted = tx.execute(
+                """DELETE FROM audit_log
+                   WHERE created_at < datetime('now', ? || ' days')""",
+                f"-{self.audit_log_retention_days}",
+            )
             idempotency_deleted = tx.execute(
                 """DELETE FROM idempotency_keys
                    WHERE updated_at < datetime('now', ? || ' days')""",
@@ -156,12 +174,22 @@ class EventBus:
                 )
             if failures_deleted:
                 self._metric("maintenance.retention.failure_log_deleted", failures_deleted, tx=tx)
+            if audit_integrity_deleted:
+                self._metric(
+                    "maintenance.retention.audit_integrity_deleted",
+                    audit_integrity_deleted,
+                    tx=tx,
+                )
+            if audit_log_deleted:
+                self._metric("maintenance.retention.audit_log_deleted", audit_log_deleted, tx=tx)
             if idempotency_deleted:
                 self._metric("maintenance.retention.idempotency_deleted", idempotency_deleted, tx=tx)
         return {
             "events_deleted": events_deleted,
             "event_processing_deleted": event_processing_deleted,
             "failure_log_deleted": failures_deleted,
+            "audit_integrity_deleted": audit_integrity_deleted,
+            "audit_log_deleted": audit_log_deleted,
             "idempotency_deleted": idempotency_deleted,
         }
 

--- a/goal_ops_console/observability.py
+++ b/goal_ops_console/observability.py
@@ -1,4 +1,5 @@
 import json
+import hashlib
 from typing import Any
 
 from goal_ops_console.database import Database, Transaction, new_id, now_utc
@@ -7,6 +8,101 @@ from goal_ops_console.database import Database, Transaction, new_id, now_utc
 class ObservabilityService:
     def __init__(self, db: Database):
         self.db = db
+
+    @staticmethod
+    def _normalize_details(details: dict[str, Any] | None) -> str:
+        if not details:
+            return ""
+        return json.dumps(details, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+    @staticmethod
+    def _compute_hash(payload: str) -> str:
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _canonical_audit_payload(
+        *,
+        audit_id: str,
+        action: str,
+        actor: str,
+        status: str,
+        entity_type: str | None,
+        entity_id: str | None,
+        correlation_id: str | None,
+        details_json: str,
+        created_at: str,
+        previous_hash: str | None,
+    ) -> str:
+        payload = {
+            "audit_id": audit_id,
+            "action": action,
+            "actor": actor,
+            "status": status,
+            "entity_type": entity_type,
+            "entity_id": entity_id,
+            "correlation_id": correlation_id,
+            "details": details_json,
+            "created_at": created_at,
+            "previous_hash": previous_hash,
+        }
+        return json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+    def _insert_audit_with_integrity(
+        self,
+        *,
+        tx: Transaction,
+        audit_id: str,
+        action: str,
+        actor: str,
+        status: str,
+        entity_type: str | None,
+        entity_id: str | None,
+        correlation_id: str | None,
+        details_json: str,
+        created_at: str,
+    ) -> None:
+        tx.execute(
+            """INSERT INTO audit_log
+               (audit_id, action, actor, status, entity_type, entity_id,
+                correlation_id, details, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            audit_id,
+            action,
+            actor,
+            status,
+            entity_type,
+            entity_id,
+            correlation_id,
+            details_json if details_json else None,
+            created_at,
+        )
+        previous_hash_value = tx.fetch_scalar(
+            "SELECT entry_hash FROM audit_log_integrity ORDER BY chain_index DESC LIMIT 1"
+        )
+        previous_hash = str(previous_hash_value) if previous_hash_value is not None else None
+        canonical_payload = self._canonical_audit_payload(
+            audit_id=audit_id,
+            action=action,
+            actor=actor,
+            status=status,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            correlation_id=correlation_id,
+            details_json=details_json,
+            created_at=created_at,
+            previous_hash=previous_hash,
+        )
+        entry_hash = self._compute_hash(canonical_payload)
+        tx.execute(
+            """INSERT INTO audit_log_integrity
+               (audit_id, previous_hash, entry_hash, canonical_payload, created_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            audit_id,
+            previous_hash,
+            entry_hash,
+            canonical_payload,
+            created_at,
+        )
 
     def increment_metric(
         self,
@@ -87,23 +183,257 @@ class ObservabilityService:
         tx: Transaction | None = None,
     ) -> str:
         audit_id = new_id()
-        runner = tx or self.db
-        runner.execute(
-            """INSERT INTO audit_log
-               (audit_id, action, actor, status, entity_type, entity_id,
-                correlation_id, details, created_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            audit_id,
-            action,
-            actor,
-            status,
-            entity_type,
-            entity_id,
-            correlation_id,
-            json.dumps(details) if details else None,
-            now_utc(),
-        )
+        created_at = now_utc()
+        details_json = self._normalize_details(details)
+        if tx is not None:
+            self._insert_audit_with_integrity(
+                tx=tx,
+                audit_id=audit_id,
+                action=action,
+                actor=actor,
+                status=status,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                correlation_id=correlation_id,
+                details_json=details_json,
+                created_at=created_at,
+            )
+            return audit_id
+
+        with self.db.transaction() as nested_tx:
+            self._insert_audit_with_integrity(
+                tx=nested_tx,
+                audit_id=audit_id,
+                action=action,
+                actor=actor,
+                status=status,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                correlation_id=correlation_id,
+                details_json=details_json,
+                created_at=created_at,
+            )
         return audit_id
+
+    def ensure_audit_integrity_backfill(self, *, batch_size: int = 1000) -> dict[str, int]:
+        normalized_batch_size = max(1, int(batch_size))
+        inserted_total = 0
+        remaining = 0
+
+        while True:
+            with self.db.transaction() as tx:
+                previous_hash_value = tx.fetch_scalar(
+                    "SELECT entry_hash FROM audit_log_integrity ORDER BY chain_index DESC LIMIT 1"
+                )
+                previous_hash = str(previous_hash_value) if previous_hash_value is not None else None
+                rows = tx.fetch_all(
+                    """SELECT a.audit_id,
+                              a.action,
+                              a.actor,
+                              a.status,
+                              a.entity_type,
+                              a.entity_id,
+                              a.correlation_id,
+                              a.details,
+                              a.created_at
+                       FROM audit_log a
+                       LEFT JOIN audit_log_integrity ai ON ai.audit_id = a.audit_id
+                       WHERE ai.audit_id IS NULL
+                       ORDER BY a.created_at ASC, a.audit_id ASC
+                       LIMIT ?""",
+                    normalized_batch_size,
+                )
+                inserted_batch = 0
+                for row in rows:
+                    details_json = str(row["details"]) if row["details"] else ""
+                    canonical_payload = self._canonical_audit_payload(
+                        audit_id=str(row["audit_id"]),
+                        action=str(row["action"]),
+                        actor=str(row["actor"]),
+                        status=str(row["status"]),
+                        entity_type=str(row["entity_type"]) if row["entity_type"] is not None else None,
+                        entity_id=str(row["entity_id"]) if row["entity_id"] is not None else None,
+                        correlation_id=(
+                            str(row["correlation_id"])
+                            if row["correlation_id"] is not None
+                            else None
+                        ),
+                        details_json=details_json,
+                        created_at=str(row["created_at"]),
+                        previous_hash=previous_hash,
+                    )
+                    entry_hash = self._compute_hash(canonical_payload)
+                    tx.execute(
+                        """INSERT INTO audit_log_integrity
+                           (audit_id, previous_hash, entry_hash, canonical_payload, created_at)
+                           VALUES (?, ?, ?, ?, ?)""",
+                        str(row["audit_id"]),
+                        previous_hash,
+                        entry_hash,
+                        canonical_payload,
+                        str(row["created_at"]),
+                    )
+                    previous_hash = entry_hash
+                    inserted_batch += 1
+
+                remaining_value = tx.fetch_scalar(
+                    """SELECT COUNT(*)
+                       FROM audit_log a
+                       LEFT JOIN audit_log_integrity ai ON ai.audit_id = a.audit_id
+                       WHERE ai.audit_id IS NULL"""
+                )
+                remaining = int(remaining_value or 0)
+                inserted_total += inserted_batch
+                if inserted_batch:
+                    self.increment_metric(
+                        "audit.integrity.backfilled",
+                        delta=inserted_batch,
+                        tx=tx,
+                    )
+            if remaining == 0 or inserted_batch == 0:
+                break
+
+        return {"inserted": inserted_total, "remaining": remaining}
+
+    def audit_integrity_status(self, *, verify_limit: int = 200) -> dict[str, Any]:
+        normalized_limit = max(1, int(verify_limit))
+        total_entries = int(self.db.fetch_scalar("SELECT COUNT(*) FROM audit_log") or 0)
+        chain_entries = int(self.db.fetch_scalar("SELECT COUNT(*) FROM audit_log_integrity") or 0)
+        missing_rows = int(
+            self.db.fetch_scalar(
+                """SELECT COUNT(*)
+                   FROM audit_log a
+                   LEFT JOIN audit_log_integrity ai ON ai.audit_id = a.audit_id
+                   WHERE ai.audit_id IS NULL"""
+            )
+            or 0
+        )
+
+        if chain_entries == 0:
+            coverage = 100.0 if total_entries == 0 else 0.0
+            return {
+                "ok": bool(total_entries == 0),
+                "metrics": {
+                    "total_audit_entries": total_entries,
+                    "chain_entries": chain_entries,
+                    "missing_integrity_rows": missing_rows,
+                    "coverage_percent": coverage,
+                    "sampled_rows": 0,
+                    "hash_mismatch_count": 0,
+                    "previous_link_mismatch_count": 0,
+                    "chain_gap_count": 0,
+                    "verify_limit": normalized_limit,
+                },
+                "violations": (
+                    []
+                    if total_entries == 0
+                    else [
+                        {
+                            "type": "missing_integrity_rows",
+                            "message": "Audit rows exist without matching integrity chain rows.",
+                            "count": missing_rows,
+                        }
+                    ]
+                ),
+            }
+
+        max_chain_index = int(
+            self.db.fetch_scalar("SELECT COALESCE(MAX(chain_index), 0) FROM audit_log_integrity") or 0
+        )
+        start_index = max(1, max_chain_index - normalized_limit + 1)
+        predecessor_hash: str | None = None
+        if start_index > 1:
+            predecessor_value = self.db.fetch_scalar(
+                "SELECT entry_hash FROM audit_log_integrity WHERE chain_index = ?",
+                start_index - 1,
+            )
+            predecessor_hash = str(predecessor_value) if predecessor_value is not None else None
+
+        rows = self.db.fetch_all(
+            """SELECT chain_index, previous_hash, entry_hash, canonical_payload
+               FROM audit_log_integrity
+               WHERE chain_index >= ?
+               ORDER BY chain_index ASC""",
+            start_index,
+        )
+
+        hash_mismatch_count = 0
+        previous_link_mismatch_count = 0
+        chain_gap_count = 0
+        expected_previous = predecessor_hash
+        last_index = start_index - 1
+
+        for row in rows:
+            current_index = int(row["chain_index"])
+            if current_index != last_index + 1:
+                chain_gap_count += max(1, current_index - (last_index + 1))
+            previous_hash = str(row["previous_hash"]) if row["previous_hash"] is not None else None
+            entry_hash = str(row["entry_hash"])
+            canonical_payload = str(row["canonical_payload"])
+            if previous_hash != expected_previous:
+                previous_link_mismatch_count += 1
+            if self._compute_hash(canonical_payload) != entry_hash:
+                hash_mismatch_count += 1
+            expected_previous = entry_hash
+            last_index = current_index
+
+        coverage_percent = 100.0 if total_entries == 0 else (chain_entries / max(1, total_entries)) * 100.0
+        violations: list[dict[str, Any]] = []
+        if missing_rows:
+            violations.append(
+                {
+                    "type": "missing_integrity_rows",
+                    "message": "Audit rows exist without matching integrity chain rows.",
+                    "count": missing_rows,
+                }
+            )
+        if hash_mismatch_count:
+            violations.append(
+                {
+                    "type": "hash_mismatch",
+                    "message": "Stored entry hash does not match canonical payload hash.",
+                    "count": hash_mismatch_count,
+                }
+            )
+        if previous_link_mismatch_count:
+            violations.append(
+                {
+                    "type": "link_mismatch",
+                    "message": "Integrity chain previous_hash links do not match preceding entry hash.",
+                    "count": previous_link_mismatch_count,
+                }
+            )
+        if chain_gap_count:
+            violations.append(
+                {
+                    "type": "chain_gap",
+                    "message": "Detected non-contiguous chain_index gaps in audit integrity rows.",
+                    "count": chain_gap_count,
+                }
+            )
+
+        return {
+            "ok": (
+                missing_rows == 0
+                and hash_mismatch_count == 0
+                and previous_link_mismatch_count == 0
+                and chain_gap_count == 0
+            ),
+            "metrics": {
+                "total_audit_entries": total_entries,
+                "chain_entries": chain_entries,
+                "missing_integrity_rows": missing_rows,
+                "coverage_percent": coverage_percent,
+                "sampled_rows": len(rows),
+                "hash_mismatch_count": hash_mismatch_count,
+                "previous_link_mismatch_count": previous_link_mismatch_count,
+                "chain_gap_count": chain_gap_count,
+                "verify_limit": normalized_limit,
+                "sample_start_chain_index": start_index,
+                "sample_end_chain_index": max_chain_index,
+            },
+            "violations": violations,
+        }
 
     def list_audit(
         self,

--- a/goal_ops_console/routers/system.py
+++ b/goal_ops_console/routers/system.py
@@ -32,6 +32,7 @@ def _build_health_payload(services: AppServices) -> dict[str, Any]:
     faults["systemic_external_failures_last_window"] = (
         services.failure_intelligence.systemic_external_failure_count()
     )
+    audit_integrity = services.observability.audit_integrity_status(verify_limit=200)
     return {
         "spec_version": SPEC_VERSION,
         "default_consumer_id": services.settings.consumer_id,
@@ -45,11 +46,13 @@ def _build_health_payload(services: AppServices) -> dict[str, Any]:
             "events_days": services.settings.events_retention_days,
             "event_processing_days": services.settings.event_processing_retention_days,
             "failure_log_days": services.settings.failure_log_retention_days,
+            "audit_log_days": services.settings.audit_log_retention_days,
             "idempotency_keys_days": services.settings.idempotency_retention_days,
         },
         "metrics": services.observability.metrics_summary(),
         "audit": {
             "entries_last_24h": services.observability.recent_audit_count(hours=24),
+            "integrity": audit_integrity,
         },
         "faults": faults,
         "retry_budget_per_cycle": MAX_TOTAL_RETRIES_PER_CYCLE,
@@ -140,6 +143,28 @@ def _build_readiness_payload(services: AppServices) -> dict[str, Any]:
         safe_mode_error = str(exc)
     safe_mode_ok = safe_mode_error is None and not bool(safe_mode.get("active"))
 
+    audit_integrity_error: str | None = None
+    audit_integrity: dict[str, Any] = {
+        "ok": False,
+        "metrics": {
+            "total_audit_entries": 0,
+            "chain_entries": 0,
+            "missing_integrity_rows": 0,
+            "coverage_percent": 100.0,
+            "sampled_rows": 0,
+            "hash_mismatch_count": 0,
+            "previous_link_mismatch_count": 0,
+            "chain_gap_count": 0,
+            "verify_limit": 500,
+        },
+        "violations": [],
+    }
+    try:
+        audit_integrity = services.observability.audit_integrity_status(verify_limit=500)
+    except Exception as exc:
+        audit_integrity_error = str(exc)
+    audit_integrity_ok = audit_integrity_error is None and bool(audit_integrity.get("ok"))
+
     invariant_monitor_error: str | None = None
     invariant_monitor: dict[str, Any] = {
         "is_running": False,
@@ -171,6 +196,7 @@ def _build_readiness_payload(services: AppServices) -> dict[str, Any]:
             db_ok
             and worker_ok
             and safe_mode_ok
+            and audit_integrity_ok
             and invariant_monitor_ok
             and operator_auth_ok
         ),
@@ -193,6 +219,11 @@ def _build_readiness_payload(services: AppServices) -> dict[str, Any]:
                 **safe_mode,
                 "ok": safe_mode_ok,
                 "error": safe_mode_error,
+            },
+            "audit_integrity": {
+                **audit_integrity,
+                "ok": audit_integrity_ok,
+                "error": audit_integrity_error,
             },
             "invariant_monitor": {
                 **invariant_monitor,
@@ -673,6 +704,17 @@ def audit_log(
     }
 
 
+@router.get("/system/audit/integrity")
+def audit_integrity(
+    verify_limit: int = 500,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return {
+        "timestamp_utc": _utc_iso(),
+        **services.observability.audit_integrity_status(verify_limit=verify_limit),
+    }
+
+
 @router.get("/system/faults")
 def fault_explorer(
     limit: int = 200,
@@ -789,6 +831,7 @@ def run_retention_cleanup(services: AppServices = Depends(get_services)) -> dict
             "events": services.settings.events_retention_days,
             "event_processing": services.settings.event_processing_retention_days,
             "failure_log": services.settings.failure_log_retention_days,
+            "audit_log": services.settings.audit_log_retention_days,
             "idempotency_keys": services.settings.idempotency_retention_days,
         },
     }

--- a/goal_ops_console/services.py
+++ b/goal_ops_console/services.py
@@ -52,6 +52,7 @@ def build_services(settings: Settings | None = None) -> AppServices:
     )
     db.initialize()
     observability = ObservabilityService(db)
+    observability.ensure_audit_integrity_backfill()
     runtime_guard = RuntimeGuard(
         lock_error_threshold=app_settings.safe_mode_lock_error_threshold,
         lock_error_window_seconds=app_settings.safe_mode_lock_error_window_seconds,
@@ -81,6 +82,7 @@ def build_services(settings: Settings | None = None) -> AppServices:
         events_retention_days=app_settings.events_retention_days,
         event_processing_retention_days=app_settings.event_processing_retention_days,
         failure_log_retention_days=app_settings.failure_log_retention_days,
+        audit_log_retention_days=app_settings.audit_log_retention_days,
         idempotency_retention_days=app_settings.idempotency_retention_days,
         observability=observability,
     )

--- a/scripts/audit-trail-hardening-check.py
+++ b/scripts/audit-trail-hardening-check.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from goal_ops_console.config import Settings
+from goal_ops_console.services import build_services
+
+
+def run_check(
+    *,
+    label: str,
+    deployment_profile: str,
+    audit_retention_days: int,
+    min_audit_retention_days: int,
+    seed_entries: int,
+    workspace: Path,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    profile = str(deployment_profile).strip().lower() or "production"
+    retention_days = max(1, int(audit_retention_days))
+    min_retention_days = max(1, int(min_audit_retention_days))
+    seed_count = max(1, int(seed_entries))
+
+    workspace.mkdir(parents=True, exist_ok=True)
+    db_file = workspace / (
+        f"audit-trail-hardening-{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}"
+        f"-{uuid.uuid4().hex[:8]}.db"
+    )
+
+    services = build_services(
+        Settings(
+            database_url=str(db_file),
+            audit_log_retention_days=retention_days,
+        )
+    )
+    for index in range(seed_count):
+        services.observability.record_audit(
+            action="audit_trail.hardening.seed",
+            actor="release-gate",
+            status="success",
+            entity_type="seed",
+            entity_id=str(index),
+            details={"index": index, "label": label},
+        )
+    baseline = services.observability.audit_integrity_status(
+        verify_limit=max(200, seed_count * 4),
+    )
+    services.db.execute(
+        """UPDATE audit_log_integrity
+           SET entry_hash = ?
+           WHERE chain_index = (SELECT MAX(chain_index) FROM audit_log_integrity)""",
+        "0" * 64,
+    )
+    tampered = services.observability.audit_integrity_status(
+        verify_limit=max(200, seed_count * 4),
+    )
+
+    criteria: list[dict[str, Any]] = []
+
+    def add(name: str, passed: bool, details: str) -> None:
+        criteria.append({"name": name, "passed": bool(passed), "details": details})
+
+    if profile == "production":
+        add(
+            "audit_retention_days_minimum",
+            retention_days >= min_retention_days,
+            f"audit_retention_days={retention_days}, minimum={min_retention_days}",
+        )
+    else:
+        add(
+            "non_production_profile",
+            True,
+            f"deployment_profile={profile!r} (retention hard requirement skipped)",
+        )
+
+    add(
+        "baseline_integrity_ok",
+        bool(baseline.get("ok")),
+        f"baseline_ok={baseline.get('ok')!r}",
+    )
+    baseline_metrics = baseline.get("metrics", {})
+    add(
+        "baseline_coverage_full",
+        int(baseline_metrics.get("missing_integrity_rows") or 0) == 0
+        and float(baseline_metrics.get("coverage_percent") or 0.0) >= 100.0,
+        (
+            "missing_integrity_rows="
+            f"{baseline_metrics.get('missing_integrity_rows')}, "
+            f"coverage_percent={baseline_metrics.get('coverage_percent')}"
+        ),
+    )
+    add(
+        "seeded_entries_recorded",
+        int(baseline_metrics.get("total_audit_entries") or 0) >= seed_count,
+        f"total_audit_entries={baseline_metrics.get('total_audit_entries')}, seeded={seed_count}",
+    )
+    tampered_metrics = tampered.get("metrics", {})
+    add(
+        "tamper_detection_triggered",
+        (not bool(tampered.get("ok")))
+        and (
+            int(tampered_metrics.get("hash_mismatch_count") or 0) > 0
+            or int(tampered_metrics.get("previous_link_mismatch_count") or 0) > 0
+        ),
+        (
+            f"tampered_ok={tampered.get('ok')!r}, "
+            f"hash_mismatch_count={tampered_metrics.get('hash_mismatch_count')}, "
+            "previous_link_mismatch_count="
+            f"{tampered_metrics.get('previous_link_mismatch_count')}"
+        ),
+    )
+
+    failed = [item for item in criteria if not item["passed"]]
+    success = len(failed) == 0
+    report = {
+        "label": label,
+        "success": bool(success),
+        "config": {
+            "deployment_profile": profile,
+            "audit_retention_days": retention_days,
+            "min_audit_retention_days": min_retention_days,
+            "seed_entries": seed_count,
+            "workspace": str(workspace),
+            "database_file": str(db_file),
+        },
+        "metrics": {
+            "criteria_total": len(criteria),
+            "criteria_failed": len(failed),
+            "criteria_passed": len(criteria) - len(failed),
+            "baseline_total_audit_entries": int(baseline_metrics.get("total_audit_entries") or 0),
+            "baseline_chain_entries": int(baseline_metrics.get("chain_entries") or 0),
+            "tampered_hash_mismatch_count": int(tampered_metrics.get("hash_mismatch_count") or 0),
+            "tampered_link_mismatch_count": int(
+                tampered_metrics.get("previous_link_mismatch_count") or 0
+            ),
+        },
+        "criteria": criteria,
+        "failed_criteria": failed,
+        "baseline_integrity": baseline,
+        "tampered_integrity": tampered,
+        "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "duration_ms": int((time.perf_counter() - started) * 1000),
+    }
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Audit trail hardening check. Seeds audit events, verifies hash-chain integrity, "
+            "then injects tampering and asserts the detector catches it."
+        )
+    )
+    parser.add_argument("--label", default="audit-trail-hardening")
+    parser.add_argument("--deployment-profile", default="production")
+    parser.add_argument("--audit-retention-days", type=int, default=365)
+    parser.add_argument("--min-audit-retention-days", type=int, default=90)
+    parser.add_argument("--seed-entries", type=int, default=8)
+    parser.add_argument("--workspace", default=".tmp/audit-trail-hardening-check")
+    parser.add_argument("--output-file")
+    parser.add_argument("--allow-failure", action="store_true")
+    args = parser.parse_args(argv)
+
+    project_root = Path(__file__).resolve().parents[1]
+    workspace = Path(str(args.workspace)).expanduser()
+    if not workspace.is_absolute():
+        workspace = (project_root / workspace).resolve()
+
+    report = run_check(
+        label=str(args.label),
+        deployment_profile=str(args.deployment_profile),
+        audit_retention_days=int(args.audit_retention_days),
+        min_audit_retention_days=int(args.min_audit_retention_days),
+        seed_entries=int(args.seed_entries),
+        workspace=workspace,
+    )
+
+    output_file = None
+    if args.output_file:
+        output_file = Path(str(args.output_file)).expanduser()
+        if not output_file.is_absolute():
+            output_file = (project_root / output_file).resolve()
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(
+            json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2),
+            encoding="utf-8",
+        )
+
+    if report["success"] is False and not bool(args.allow_failure):
+        print(
+            f"[audit-trail-hardening-check] ERROR: {json.dumps(report, sort_keys=True)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/p0-runbook-contract-check.py
+++ b/scripts/p0-runbook-contract-check.py
@@ -11,6 +11,7 @@ from typing import Any
 
 DEFAULT_REQUIRED_RUNBOOK_SCRIPTS = [
     "run-security-config-hardening-check.ps1",
+    "run-audit-trail-hardening-check.ps1",
     "run-power-loss-durability-drill.ps1",
     "run-disk-pressure-fault-injection-drill.ps1",
     "run-upgrade-downgrade-compatibility-drill.ps1",

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -6,6 +6,8 @@ param(
     [switch]$SkipSloAlertCheck,
     [switch]$SkipSecurityConfigHardeningCheck,
     [switch]$StrictSecurityConfigHardeningCheck,
+    [switch]$SkipAuditTrailHardeningCheck,
+    [switch]$StrictAuditTrailHardeningCheck,
     [switch]$SkipReleaseFreezePolicyDrill,
     [switch]$StrictReleaseFreezePolicyDrill,
     [switch]$SkipFileDatabaseProbe,
@@ -164,6 +166,33 @@ if (-not $SkipSecurityConfigHardeningCheck) {
             }
             Write-Warning (
                 "Security config hardening check failed but StrictSecurityConfigHardeningCheck is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipAuditTrailHardeningCheck) {
+    Invoke-GateStep -Name "Audit trail hardening check (immutable hash-chain + tamper detection + retention policy)" -Action {
+        $reportPath = Join-Path $ProjectRoot "artifacts\audit-trail-hardening-release-gate.json"
+        $workspace = Join-Path $ProjectRoot ".tmp\audit-trail-hardening-release-gate"
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\audit-trail-hardening-check.py",
+                "--label", "release-gate",
+                "--deployment-profile", "production",
+                "--audit-retention-days", "365",
+                "--min-audit-retention-days", "90",
+                "--seed-entries", "8",
+                "--workspace", $workspace,
+                "--output-file", $reportPath
+            )
+        } catch {
+            if ($StrictAuditTrailHardeningCheck) {
+                throw
+            }
+            Write-Warning (
+                "Audit trail hardening check failed but StrictAuditTrailHardeningCheck is off. " +
                 "Continuing. Error: $($_.Exception.Message)"
             )
         }

--- a/scripts/run-audit-trail-hardening-check.ps1
+++ b/scripts/run-audit-trail-hardening-check.ps1
@@ -1,0 +1,36 @@
+param(
+    [string]$PythonExe = "python",
+    [string]$DeploymentProfile = "production",
+    [int]$AuditRetentionDays = 365,
+    [int]$MinAuditRetentionDays = 90,
+    [int]$SeedEntries = 8,
+    [string]$Workspace = ".tmp\\audit-trail-hardening-check-manual",
+    [string]$OutputFile = "artifacts\\audit-trail-hardening-check-report.json",
+    [switch]$AllowFailure
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$arguments = @(
+    ".\\scripts\\audit-trail-hardening-check.py",
+    "--label", "manual",
+    "--deployment-profile", $DeploymentProfile,
+    "--audit-retention-days", [string]$AuditRetentionDays,
+    "--min-audit-retention-days", [string]$MinAuditRetentionDays,
+    "--seed-entries", [string]$SeedEntries,
+    "--workspace", $Workspace,
+    "--output-file", $OutputFile
+)
+if ($AllowFailure) {
+    $arguments += "--allow-failure"
+}
+
+& $PythonExe @arguments
+if ($LASTEXITCODE -ne 0) {
+    throw "Audit trail hardening check failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Audit trail hardening check passed." -ForegroundColor Green

--- a/scripts/run-p0-runbook-contract-check.ps1
+++ b/scripts/run-p0-runbook-contract-check.ps1
@@ -1,7 +1,7 @@
 param(
     [string]$PythonExe = "python",
     [string]$OutputFile = "artifacts\\p0-runbook-contract-check-report.json",
-    [string]$RequiredRunbookScripts = "run-security-config-hardening-check.ps1,run-power-loss-durability-drill.ps1,run-disk-pressure-fault-injection-drill.ps1,run-upgrade-downgrade-compatibility-drill.ps1,run-backup-restore-stress-drill.ps1,run-release-gate-runtime-stability-drill.ps1,run-p0-burnin-consecutive-green.ps1,run-p0-release-evidence-bundle.ps1,run-p0-closure-report.ps1",
+    [string]$RequiredRunbookScripts = "run-security-config-hardening-check.ps1,run-audit-trail-hardening-check.ps1,run-power-loss-durability-drill.ps1,run-disk-pressure-fault-injection-drill.ps1,run-upgrade-downgrade-compatibility-drill.ps1,run-backup-restore-stress-drill.ps1,run-release-gate-runtime-stability-drill.ps1,run-p0-burnin-consecutive-green.ps1,run-p0-release-evidence-bundle.ps1,run-p0-closure-report.ps1",
     [string]$RequiredStrictFlags = ""
 )
 

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -531,18 +531,38 @@ def test_29_retention_cleanup_deletes_old_records(client):
         " 'old-fingerprint', 1, 'old', 'recorded', 1, datetime('now', '-120 days'), datetime('now', '-120 days'))",
         old_failure_id,
     )
+    old_audit_id = services.observability.record_audit(
+        action="retention.old.audit",
+        actor="test",
+        status="success",
+        entity_type="retention",
+        entity_id="old-audit-entry",
+    )
+    services.db.execute(
+        "UPDATE audit_log SET created_at = datetime('now', '-400 days') WHERE audit_id = ?",
+        old_audit_id,
+    )
+    services.db.execute(
+        "UPDATE audit_log_integrity SET created_at = datetime('now', '-400 days') WHERE audit_id = ?",
+        old_audit_id,
+    )
     response = client.post("/system/maintenance/retention")
     assert response.status_code == 200
     payload = response.json()
     assert payload["event_processing_deleted"] == 1
     assert payload["events_deleted"] == 1
     assert payload["failure_log_deleted"] == 1
+    assert payload["audit_log_deleted"] == 1
+    assert payload["audit_integrity_deleted"] == 1
+    assert payload["retention_days"]["audit_log"] == services.settings.audit_log_retention_days
     assert services.db.fetch_scalar("SELECT COUNT(*) FROM events WHERE event_id = ?", old_event_id) == 0
     assert (
         services.db.fetch_scalar("SELECT COUNT(*) FROM event_processing WHERE event_id = ?", old_event_id)
         == 0
     )
     assert services.db.fetch_scalar("SELECT COUNT(*) FROM failure_log WHERE id = ?", old_failure_id) == 0
+    assert services.db.fetch_scalar("SELECT COUNT(*) FROM audit_log WHERE audit_id = ?", old_audit_id) == 0
+    assert services.db.fetch_scalar("SELECT COUNT(*) FROM audit_log_integrity WHERE audit_id = ?", old_audit_id) == 0
 
 
 def test_30_backpressure_endpoint_and_health_include_limits(client):
@@ -3634,3 +3654,177 @@ def test_120_security_config_hardening_check_reports_failure_without_auth_requir
     payload = json.loads(completed.stderr.split(marker, 1)[1].strip())
     assert payload["success"] is False
     assert payload["metrics"]["criteria_failed"] >= 1
+
+
+def test_121_audit_integrity_endpoint_detects_tampering(client):
+    created = client.post(
+        "/goals",
+        json={
+            "title": "Audit integrity goal",
+            "description": "tamper detection",
+            "urgency": 0.6,
+            "value": 0.7,
+            "deadline_score": 0.1,
+        },
+    )
+    assert created.status_code == 201
+
+    baseline = client.get("/system/audit/integrity?verify_limit=500")
+    assert baseline.status_code == 200
+    baseline_payload = baseline.json()
+    assert baseline_payload["ok"] is True
+    assert baseline_payload["metrics"]["missing_integrity_rows"] == 0
+
+    services = client.app.state.services
+    latest_audit_id = services.db.fetch_scalar(
+        "SELECT audit_id FROM audit_log ORDER BY created_at DESC, audit_id DESC LIMIT 1"
+    )
+    assert latest_audit_id is not None
+    services.db.execute(
+        "UPDATE audit_log_integrity SET entry_hash = ? WHERE audit_id = ?",
+        "0" * 64,
+        latest_audit_id,
+    )
+
+    tampered = client.get("/system/audit/integrity?verify_limit=500")
+    assert tampered.status_code == 200
+    tampered_payload = tampered.json()
+    assert tampered_payload["ok"] is False
+    assert tampered_payload["metrics"]["hash_mismatch_count"] >= 1
+
+
+def test_122_readiness_reports_not_ready_when_audit_integrity_is_tampered():
+    app = create_app(Settings(database_url=":memory:"))
+    with TestClient(app) as local_client:
+        created = local_client.post(
+            "/goals",
+            json={
+                "title": "Readiness tamper goal",
+                "description": "check",
+                "urgency": 0.5,
+                "value": 0.4,
+                "deadline_score": 0.1,
+            },
+        )
+        assert created.status_code == 201
+
+        services = local_client.app.state.services
+        latest_audit_id = services.db.fetch_scalar(
+            "SELECT audit_id FROM audit_log ORDER BY created_at DESC, audit_id DESC LIMIT 1"
+        )
+        assert latest_audit_id is not None
+        services.db.execute(
+            "UPDATE audit_log_integrity SET entry_hash = ? WHERE audit_id = ?",
+            "0" * 64,
+            latest_audit_id,
+        )
+
+        readiness = local_client.get("/system/readiness")
+        assert readiness.status_code == 200
+        payload = readiness.json()
+        assert payload["ready"] is False
+        assert payload["checks"]["audit_integrity"]["ok"] is False
+        assert payload["checks"]["audit_integrity"]["metrics"]["hash_mismatch_count"] >= 1
+
+
+def test_123_audit_trail_hardening_check_reports_success():
+    workspace = _local_test_dir("pytest-audit-trail-hardening-check-success").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    output_file = workspace / "audit-trail-hardening-check-report.json"
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "audit-trail-hardening-check.py"),
+        "--label",
+        "pytest-drill",
+        "--deployment-profile",
+        "production",
+        "--audit-retention-days",
+        "365",
+        "--min-audit-retention-days",
+        "90",
+        "--seed-entries",
+        "8",
+        "--workspace",
+        str(workspace),
+        "--output-file",
+        str(output_file),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["metrics"]["criteria_failed"] == 0
+    assert output_file.exists()
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_124_audit_trail_hardening_check_fails_with_low_retention_policy():
+    workspace = _local_test_dir("pytest-audit-trail-hardening-check-failure").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    output_file = workspace / "audit-trail-hardening-check-report.json"
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "audit-trail-hardening-check.py"),
+        "--label",
+        "pytest-drill",
+        "--deployment-profile",
+        "production",
+        "--audit-retention-days",
+        "14",
+        "--min-audit-retention-days",
+        "90",
+        "--seed-entries",
+        "8",
+        "--workspace",
+        str(workspace),
+        "--output-file",
+        str(output_file),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "[audit-trail-hardening-check] ERROR: "
+    assert marker in completed.stderr
+    payload = json.loads(completed.stderr.split(marker, 1)[1].strip())
+    assert payload["success"] is False
+    assert payload["metrics"]["criteria_failed"] >= 1
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_125_service_startup_backfills_legacy_audit_integrity_rows():
+    workspace = _local_test_dir("pytest-audit-integrity-backfill")
+    db_path = workspace / "legacy-audit.db"
+    db = Database(str(db_path))
+    db.initialize()
+
+    legacy_audit_id = new_id()
+    db.execute(
+        """INSERT INTO audit_log
+           (audit_id, action, actor, status, entity_type, entity_id, correlation_id, details, created_at)
+           VALUES (?, 'legacy.audit', 'test', 'success', 'legacy', 'entry-1', NULL, NULL, ?)""",
+        legacy_audit_id,
+        now_utc(),
+    )
+
+    app = create_app(Settings(database_url=str(db_path)))
+    with TestClient(app) as local_client:
+        integrity = local_client.get("/system/audit/integrity?verify_limit=500")
+        assert integrity.status_code == 200
+        payload = integrity.json()
+        assert payload["ok"] is True
+        assert payload["metrics"]["missing_integrity_rows"] == 0
+        assert payload["metrics"]["chain_entries"] >= 1
+        assert payload["metrics"]["total_audit_entries"] >= 1
+
+    shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
﻿## Summary
- add tamper-evident audit hash-chain persistence (`audit_log_integrity`) and integrity verification in `ObservabilityService`
- backfill legacy audit rows into the integrity chain during service startup
- add `/system/audit/integrity` endpoint and wire audit integrity into health/readiness checks
- extend retention cleanup with `audit_log_retention_days` plus audit/audit-integrity cleanup metrics
- add Stage-B `audit-trail-hardening-check.py` drill + PowerShell wrapper
- integrate audit trail hardening into release gate, CI strict flags, artifacts, and runbook-contract requirements
- update README and production runbook for new strict flag and manual drill command
- add automated tests for tamper detection, readiness behavior, script success/failure, and backfill

## Validation
- `python -m py_compile goal_ops_console\config.py goal_ops_console\database.py goal_ops_console\event_bus.py goal_ops_console\observability.py goal_ops_console\services.py goal_ops_console\routers\system.py scripts\audit-trail-hardening-check.py scripts\p0-runbook-contract-check.py tests\test_goal_ops.py`
- `python -m pytest -q tests\test_goal_ops.py -k "test_29_retention_cleanup_deletes_old_records or test_61_system_readiness_reports_ready or test_62_system_readiness_reports_not_ready_when_worker_stopped or test_84_system_readiness_reports_not_ready_on_startup_recovery_error or test_112_p0_runbook_contract_check_reports_success or test_117_operator_auth_blocks_system_mutations_without_valid_token or test_118_create_app_rejects_weak_operator_token_when_auth_required or test_119_security_config_hardening_check_reports_success or test_120_security_config_hardening_check_reports_failure_without_auth_requirement or test_121_audit_integrity_endpoint_detects_tampering or test_122_readiness_reports_not_ready_when_audit_integrity_is_tampered or test_123_audit_trail_hardening_check_reports_success or test_124_audit_trail_hardening_check_fails_with_low_retention_policy or test_125_service_startup_backfills_legacy_audit_integrity_rows"`
- `python -m pytest -q tests\test_goal_ops.py -k "test_30_backpressure_endpoint_and_health_include_limits or test_32_audit_endpoint_lists_mutating_requests or test_34_health_includes_metrics_and_audit_summaries or test_63_system_diagnostics_exports_snapshot"`
- `./scripts/run-audit-trail-hardening-check.ps1 -AuditRetentionDays 365 -MinAuditRetentionDays 90 -SeedEntries 8`
- `./scripts/run-p0-runbook-contract-check.ps1`
- `./scripts/release-gate.ps1` smoke with all skip flags (including `-SkipAuditTrailHardeningCheck`)
