### PR TITLE
[codex] Add stage-B security CI lane checks and policy gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,14 @@ jobs:
         shell: pwsh
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[test]"
+          python -m pip install -e ".[test,security]"
 
       - name: Run release gate
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          .\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+          .\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 
       - name: Upload release evidence artifacts
         uses: actions/upload-artifact@v4
@@ -53,6 +53,40 @@ jobs:
             artifacts/p0-closure-report-release-gate.json
             artifacts/security-config-hardening-release-gate.json
             artifacts/audit-trail-hardening-release-gate.json
+            artifacts/security-ci-lane-release-gate.json
+            artifacts/security-sbom-release-gate.json
+          if-no-files-found: error
+
+  security-ci-lane:
+    name: Security CI Lane
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test,security]"
+
+      - name: Run security lane check
+        run: |
+          python ./scripts/security-ci-lane-check.py --label ci --deployment-profile production --scan-path goal_ops_console --max-dependency-vulnerabilities 0 --max-sast-high 0 --max-sast-medium 200 --sbom-output-file artifacts/security-sbom-ci.json --output-file artifacts/security-ci-lane-ci.json
+
+      - name: Upload security lane artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-ci-lane
+          path: |
+            artifacts/security-ci-lane-ci.json
+            artifacts/security-sbom-ci.json
           if-no-files-found: error
 
   test:

--- a/README.md
+++ b/README.md
@@ -411,11 +411,11 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + security config hardening check + audit trail hardening check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle + P0 closure go/no-go report):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + security config hardening check + audit trail hardening check + security CI lane check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle + P0 closure go/no-go report):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 ```
 
 Standalone backup/restore drill:
@@ -479,6 +479,13 @@ Standalone audit trail hardening check (hash-chain integrity + tamper detection 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-audit-trail-hardening-check.ps1 -AuditRetentionDays 365 -MinAuditRetentionDays 90 -SeedEntries 8
+```
+
+Standalone security CI lane check (pip-audit + bandit + SBOM + fail policy):
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-security-ci-lane-check.ps1 -MaxDependencyVulnerabilities 0 -MaxSastHigh 0 -MaxSastMedium 200
 ```
 
 Standalone release-freeze policy check (live service):
@@ -941,5 +948,7 @@ If a value is rejected:
 - [run-security-config-hardening-check.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-security-config-hardening-check.ps1)
 - [audit-trail-hardening-check.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/audit-trail-hardening-check.py)
 - [run-audit-trail-hardening-check.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-audit-trail-hardening-check.ps1)
+- [security-ci-lane-check.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/security-ci-lane-check.py)
+- [run-security-ci-lane-check.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-security-ci-lane-check.ps1)
 - [test_goal_ops.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_goal_ops.py)
 - [test_desktop_launcher.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_desktop_launcher.py)

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -9,7 +9,7 @@ This runbook is optimized for reliability-first releases of the desktop app and 
 Run in repo root:
 
 ```powershell
-.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 ```
 
 This gate covers:
@@ -19,6 +19,7 @@ This gate covers:
 - `GET /system/slo` (`status` must be `ok`)
 - security config hardening check (production profile must require operator auth, strong token, non-memory DB, and startup corruption recovery guard)
 - audit trail hardening check (audit hash-chain integrity verification, tamper detection, and retention policy floor)
+- security CI lane check (`pip-audit` + `bandit` + SBOM export with explicit fail policy thresholds)
 - release-freeze policy drill (sustained non-ok window or burn-rate spike freezes ring promotion path)
 - auto-rollback-policy drill (`critical` sustained window triggers stable ring rollback path)
 - desktop-update-safety drill (hash validation + rollback-to-stable fallback path)
@@ -82,6 +83,12 @@ Manual audit trail hardening check invocation:
 
 ```powershell
 .\scripts\run-audit-trail-hardening-check.ps1 -AuditRetentionDays 365 -MinAuditRetentionDays 90 -SeedEntries 8
+```
+
+Manual security CI lane check invocation:
+
+```powershell
+.\scripts\run-security-ci-lane-check.ps1 -MaxDependencyVulnerabilities 0 -MaxSastHigh 0 -MaxSastMedium 200
 ```
 
 Manual release-freeze policy invocation (live endpoint, stable ring):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,10 @@ desktop = [
 desktop-build = [
   "pyinstaller>=6.6",
 ]
+security = [
+  "bandit>=1.7.9",
+  "pip-audit>=2.7.3",
+]
 test = [
   "httpx>=0.27",
   "pytest>=8.0",

--- a/scripts/p0-runbook-contract-check.py
+++ b/scripts/p0-runbook-contract-check.py
@@ -12,6 +12,7 @@ from typing import Any
 DEFAULT_REQUIRED_RUNBOOK_SCRIPTS = [
     "run-security-config-hardening-check.ps1",
     "run-audit-trail-hardening-check.ps1",
+    "run-security-ci-lane-check.ps1",
     "run-power-loss-durability-drill.ps1",
     "run-disk-pressure-fault-injection-drill.ps1",
     "run-upgrade-downgrade-compatibility-drill.ps1",

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -8,6 +8,8 @@ param(
     [switch]$StrictSecurityConfigHardeningCheck,
     [switch]$SkipAuditTrailHardeningCheck,
     [switch]$StrictAuditTrailHardeningCheck,
+    [switch]$SkipSecurityCiLaneCheck,
+    [switch]$StrictSecurityCiLaneCheck,
     [switch]$SkipReleaseFreezePolicyDrill,
     [switch]$StrictReleaseFreezePolicyDrill,
     [switch]$SkipFileDatabaseProbe,
@@ -193,6 +195,36 @@ if (-not $SkipAuditTrailHardeningCheck) {
             }
             Write-Warning (
                 "Audit trail hardening check failed but StrictAuditTrailHardeningCheck is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipSecurityCiLaneCheck) {
+    Invoke-GateStep -Name "Security CI lane check (dependency audit + SAST + SBOM + fail policy)" -Action {
+        $reportPath = Join-Path $ProjectRoot "artifacts\security-ci-lane-release-gate.json"
+        $sbomPath = Join-Path $ProjectRoot "artifacts\security-sbom-release-gate.json"
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\security-ci-lane-check.py",
+                "--label", "release-gate",
+                "--python-exe", $PythonExe,
+                "--deployment-profile", "production",
+                "--scan-path", "goal_ops_console",
+                "--max-dependency-vulnerabilities", "0",
+                "--max-sast-high", "0",
+                "--max-sast-medium", "200",
+                "--timeout-seconds", "300",
+                "--sbom-output-file", $sbomPath,
+                "--output-file", $reportPath
+            )
+        } catch {
+            if ($StrictSecurityCiLaneCheck) {
+                throw
+            }
+            Write-Warning (
+                "Security CI lane check failed but StrictSecurityCiLaneCheck is off. " +
                 "Continuing. Error: $($_.Exception.Message)"
             )
         }

--- a/scripts/run-p0-runbook-contract-check.ps1
+++ b/scripts/run-p0-runbook-contract-check.ps1
@@ -1,7 +1,7 @@
 param(
     [string]$PythonExe = "python",
     [string]$OutputFile = "artifacts\\p0-runbook-contract-check-report.json",
-    [string]$RequiredRunbookScripts = "run-security-config-hardening-check.ps1,run-audit-trail-hardening-check.ps1,run-power-loss-durability-drill.ps1,run-disk-pressure-fault-injection-drill.ps1,run-upgrade-downgrade-compatibility-drill.ps1,run-backup-restore-stress-drill.ps1,run-release-gate-runtime-stability-drill.ps1,run-p0-burnin-consecutive-green.ps1,run-p0-release-evidence-bundle.ps1,run-p0-closure-report.ps1",
+    [string]$RequiredRunbookScripts = "run-security-config-hardening-check.ps1,run-audit-trail-hardening-check.ps1,run-security-ci-lane-check.ps1,run-power-loss-durability-drill.ps1,run-disk-pressure-fault-injection-drill.ps1,run-upgrade-downgrade-compatibility-drill.ps1,run-backup-restore-stress-drill.ps1,run-release-gate-runtime-stability-drill.ps1,run-p0-burnin-consecutive-green.ps1,run-p0-release-evidence-bundle.ps1,run-p0-closure-report.ps1",
     [string]$RequiredStrictFlags = ""
 )
 

--- a/scripts/run-security-ci-lane-check.ps1
+++ b/scripts/run-security-ci-lane-check.ps1
@@ -1,0 +1,65 @@
+param(
+    [string]$PythonExe = "python",
+    [string]$DeploymentProfile = "production",
+    [string]$ScanPath = "goal_ops_console",
+    [int]$MaxDependencyVulnerabilities = 0,
+    [int]$MaxSastHigh = 0,
+    [int]$MaxSastMedium = 200,
+    [int]$TimeoutSeconds = 180,
+    [switch]$SkipDependencyAudit,
+    [switch]$SkipSast,
+    [switch]$SkipSbom,
+    [switch]$AllowMissingTools,
+    [string]$DependencyAuditJsonFile = "",
+    [string]$SastJsonFile = "",
+    [string]$SbomOutputFile = "artifacts\\security-sbom-check.json",
+    [string]$OutputFile = "artifacts\\security-ci-lane-check-report.json",
+    [switch]$AllowFailure
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$arguments = @(
+    ".\\scripts\\security-ci-lane-check.py",
+    "--label", "manual",
+    "--python-exe", $PythonExe,
+    "--deployment-profile", $DeploymentProfile,
+    "--scan-path", $ScanPath,
+    "--max-dependency-vulnerabilities", [string]$MaxDependencyVulnerabilities,
+    "--max-sast-high", [string]$MaxSastHigh,
+    "--max-sast-medium", [string]$MaxSastMedium,
+    "--timeout-seconds", [string]$TimeoutSeconds,
+    "--sbom-output-file", $SbomOutputFile,
+    "--output-file", $OutputFile
+)
+if ($SkipDependencyAudit) {
+    $arguments += "--skip-dependency-audit"
+}
+if ($SkipSast) {
+    $arguments += "--skip-sast"
+}
+if ($SkipSbom) {
+    $arguments += "--skip-sbom"
+}
+if ($AllowMissingTools) {
+    $arguments += "--allow-missing-tools"
+}
+if (-not [string]::IsNullOrWhiteSpace($DependencyAuditJsonFile)) {
+    $arguments += @("--dependency-audit-json-file", $DependencyAuditJsonFile)
+}
+if (-not [string]::IsNullOrWhiteSpace($SastJsonFile)) {
+    $arguments += @("--sast-json-file", $SastJsonFile)
+}
+if ($AllowFailure) {
+    $arguments += "--allow-failure"
+}
+
+& $PythonExe @arguments
+if ($LASTEXITCODE -ne 0) {
+    throw "Security CI lane check failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Security CI lane check passed." -ForegroundColor Green

--- a/scripts/security-ci-lane-check.py
+++ b/scripts/security-ci-lane-check.py
@@ -1,0 +1,485 @@
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _read_json_file(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _extract_dependency_vulnerability_count(payload: Any) -> int:
+    dependencies: list[dict[str, Any]] = []
+    if isinstance(payload, list):
+        dependencies = [item for item in payload if isinstance(item, dict)]
+    elif isinstance(payload, dict):
+        maybe_dependencies = payload.get("dependencies")
+        if isinstance(maybe_dependencies, list):
+            dependencies = [item for item in maybe_dependencies if isinstance(item, dict)]
+
+    vulnerability_count = 0
+    for dependency in dependencies:
+        vulns = dependency.get("vulns")
+        if not isinstance(vulns, list):
+            vulns = dependency.get("vulnerabilities")
+        if isinstance(vulns, list):
+            vulnerability_count += len(vulns)
+    return vulnerability_count
+
+
+def _extract_bandit_counts(payload: Any) -> dict[str, int]:
+    results = payload.get("results") if isinstance(payload, dict) else None
+    if not isinstance(results, list):
+        return {"high": 0, "medium": 0, "low": 0, "total": 0}
+
+    counts = {"high": 0, "medium": 0, "low": 0, "total": 0}
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        severity = str(item.get("issue_severity") or "").strip().lower()
+        if severity not in {"high", "medium", "low"}:
+            continue
+        counts[severity] += 1
+        counts["total"] += 1
+    return counts
+
+
+def _extract_requirement_name(requirement: str) -> str:
+    token = str(requirement or "").strip()
+    if not token:
+        return ""
+    for marker in (";", "[", " ", "<", ">", "=", "!", "~"):
+        index = token.find(marker)
+        if index > 0:
+            token = token[:index]
+            break
+    return token.strip()
+
+
+def _load_project_metadata(project_root: Path) -> dict[str, Any]:
+    pyproject_path = project_root / "pyproject.toml"
+    if not pyproject_path.exists():
+        raise RuntimeError(f"Missing pyproject.toml: {pyproject_path}")
+    if sys.version_info < (3, 11):
+        raise RuntimeError("Python 3.11+ is required for tomllib support.")
+
+    import tomllib  # pylint: disable=import-outside-toplevel
+
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    project = data.get("project")
+    if not isinstance(project, dict):
+        raise RuntimeError("pyproject.toml is missing [project] metadata.")
+    dependencies = project.get("dependencies")
+    if not isinstance(dependencies, list):
+        dependencies = []
+    return {
+        "name": str(project.get("name") or "unknown-project"),
+        "version": str(project.get("version") or "0.0.0"),
+        "dependencies": [str(item) for item in dependencies if str(item).strip()],
+    }
+
+
+def _build_sbom(project_root: Path, output_file: Path) -> dict[str, Any]:
+    metadata = _load_project_metadata(project_root)
+    installed_versions: dict[str, str] = {}
+    for distribution in importlib.metadata.distributions():
+        name = str(distribution.metadata.get("Name") or "").strip()
+        version = str(distribution.version or "").strip()
+        if name and version:
+            installed_versions[name.lower()] = version
+
+    components: list[dict[str, Any]] = []
+    for raw_requirement in metadata["dependencies"]:
+        package_name = _extract_requirement_name(raw_requirement)
+        if not package_name:
+            continue
+        components.append(
+            {
+                "name": package_name,
+                "version": installed_versions.get(package_name.lower(), "unknown"),
+                "requirement": raw_requirement,
+                "scope": "runtime",
+            }
+        )
+
+    sbom = {
+        "format": "goal-ops-sbom-v1",
+        "generated_at_utc": _utc_now(),
+        "project": {
+            "name": metadata["name"],
+            "version": metadata["version"],
+        },
+        "components": components,
+        "component_count": len(components),
+    }
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(json.dumps(sbom, ensure_ascii=True, sort_keys=True, indent=2), encoding="utf-8")
+    return sbom
+
+
+def _run_json_command(
+    command: list[str],
+    *,
+    cwd: Path,
+    timeout_seconds: int,
+) -> tuple[subprocess.CompletedProcess[str], Any | None, str | None]:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=max(1, int(timeout_seconds)),
+    )
+    stdout = str(completed.stdout or "").strip()
+    if not stdout:
+        return completed, None, "No JSON output produced."
+    try:
+        return completed, json.loads(stdout), None
+    except json.JSONDecodeError as exc:
+        return completed, None, f"Invalid JSON output: {exc}"
+
+
+def run_check(
+    *,
+    label: str,
+    project_root: Path,
+    python_exe: str,
+    deployment_profile: str,
+    scan_path: str,
+    max_dependency_vulnerabilities: int,
+    max_sast_high: int,
+    max_sast_medium: int,
+    skip_dependency_audit: bool,
+    skip_sast: bool,
+    skip_sbom: bool,
+    allow_missing_tools: bool,
+    timeout_seconds: int,
+    dependency_audit_json_file: Path | None,
+    sast_json_file: Path | None,
+    sbom_output_file: Path,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    profile = str(deployment_profile).strip().lower() or "production"
+
+    dependency_report: dict[str, Any] = {
+        "enabled": not skip_dependency_audit,
+        "tool": "pip-audit",
+        "tool_available": True,
+        "executed": False,
+        "source": "command",
+        "return_code": None,
+        "vulnerability_count": 0,
+        "error": None,
+    }
+    sast_report: dict[str, Any] = {
+        "enabled": not skip_sast,
+        "tool": "bandit",
+        "tool_available": True,
+        "executed": False,
+        "source": "command",
+        "return_code": None,
+        "high_count": 0,
+        "medium_count": 0,
+        "low_count": 0,
+        "total_count": 0,
+        "error": None,
+    }
+    sbom_report: dict[str, Any] = {
+        "enabled": not skip_sbom,
+        "generated": False,
+        "output_file": str(sbom_output_file),
+        "component_count": 0,
+        "error": None,
+    }
+
+    if not skip_dependency_audit:
+        if dependency_audit_json_file is not None:
+            dependency_report["source"] = "file"
+            payload = _read_json_file(dependency_audit_json_file)
+            dependency_report["vulnerability_count"] = _extract_dependency_vulnerability_count(payload)
+        else:
+            command = [python_exe, "-m", "pip_audit", "-f", "json"]
+            try:
+                completed, payload, error = _run_json_command(
+                    command,
+                    cwd=project_root,
+                    timeout_seconds=timeout_seconds,
+                )
+                dependency_report["executed"] = True
+                dependency_report["return_code"] = int(completed.returncode)
+                if error is None and payload is not None:
+                    dependency_report["vulnerability_count"] = _extract_dependency_vulnerability_count(payload)
+                else:
+                    stderr = str(completed.stderr or "").strip()
+                    if "No module named pip_audit" in stderr:
+                        dependency_report["tool_available"] = False
+                    dependency_report["error"] = error or stderr or "Unknown pip-audit error."
+                if int(completed.returncode) not in {0, 1}:
+                    if dependency_report["error"] is None:
+                        dependency_report["error"] = (
+                            f"pip-audit failed with unexpected return code {completed.returncode}."
+                        )
+            except Exception as exc:  # pragma: no cover - defensive
+                dependency_report["tool_available"] = False
+                dependency_report["error"] = str(exc)
+
+    if not skip_sast:
+        if sast_json_file is not None:
+            sast_report["source"] = "file"
+            payload = _read_json_file(sast_json_file)
+            counts = _extract_bandit_counts(payload)
+            sast_report["high_count"] = counts["high"]
+            sast_report["medium_count"] = counts["medium"]
+            sast_report["low_count"] = counts["low"]
+            sast_report["total_count"] = counts["total"]
+        else:
+            command = [python_exe, "-m", "bandit", "-r", scan_path, "-f", "json", "-q"]
+            try:
+                completed, payload, error = _run_json_command(
+                    command,
+                    cwd=project_root,
+                    timeout_seconds=timeout_seconds,
+                )
+                sast_report["executed"] = True
+                sast_report["return_code"] = int(completed.returncode)
+                if error is None and payload is not None:
+                    counts = _extract_bandit_counts(payload)
+                    sast_report["high_count"] = counts["high"]
+                    sast_report["medium_count"] = counts["medium"]
+                    sast_report["low_count"] = counts["low"]
+                    sast_report["total_count"] = counts["total"]
+                else:
+                    stderr = str(completed.stderr or "").strip()
+                    if "No module named bandit" in stderr:
+                        sast_report["tool_available"] = False
+                    sast_report["error"] = error or stderr or "Unknown bandit error."
+                if int(completed.returncode) not in {0, 1}:
+                    if sast_report["error"] is None:
+                        sast_report["error"] = (
+                            f"bandit failed with unexpected return code {completed.returncode}."
+                        )
+            except Exception as exc:  # pragma: no cover - defensive
+                sast_report["tool_available"] = False
+                sast_report["error"] = str(exc)
+
+    if not skip_sbom:
+        try:
+            sbom_payload = _build_sbom(project_root, sbom_output_file)
+            sbom_report["generated"] = True
+            sbom_report["component_count"] = int(sbom_payload.get("component_count") or 0)
+        except Exception as exc:  # pragma: no cover - defensive
+            sbom_report["error"] = str(exc)
+
+    criteria: list[dict[str, Any]] = []
+
+    def add(name: str, passed: bool, details: str) -> None:
+        criteria.append({"name": name, "passed": bool(passed), "details": details})
+
+    if profile == "production":
+        if not skip_dependency_audit:
+            add(
+                "dependency_audit_tool_available",
+                bool(dependency_report["tool_available"]) or allow_missing_tools,
+                (
+                    f"tool_available={dependency_report['tool_available']}, "
+                    f"allow_missing_tools={allow_missing_tools}"
+                ),
+            )
+            add(
+                "dependency_vulnerability_budget",
+                int(dependency_report["vulnerability_count"]) <= max(0, int(max_dependency_vulnerabilities)),
+                (
+                    f"vulnerability_count={dependency_report['vulnerability_count']}, "
+                    f"max={max_dependency_vulnerabilities}"
+                ),
+            )
+            add(
+                "dependency_audit_execution_error",
+                dependency_report["error"] is None
+                or (allow_missing_tools and dependency_report["tool_available"] is False),
+                f"error={dependency_report['error']!r}",
+            )
+
+        if not skip_sast:
+            add(
+                "sast_tool_available",
+                bool(sast_report["tool_available"]) or allow_missing_tools,
+                (
+                    f"tool_available={sast_report['tool_available']}, "
+                    f"allow_missing_tools={allow_missing_tools}"
+                ),
+            )
+            add(
+                "sast_high_budget",
+                int(sast_report["high_count"]) <= max(0, int(max_sast_high)),
+                f"high_count={sast_report['high_count']}, max={max_sast_high}",
+            )
+            add(
+                "sast_medium_budget",
+                int(sast_report["medium_count"]) <= max(0, int(max_sast_medium)),
+                f"medium_count={sast_report['medium_count']}, max={max_sast_medium}",
+            )
+            add(
+                "sast_execution_error",
+                sast_report["error"] is None
+                or (allow_missing_tools and sast_report["tool_available"] is False),
+                f"error={sast_report['error']!r}",
+            )
+
+        if not skip_sbom:
+            add(
+                "sbom_generated",
+                bool(sbom_report["generated"]),
+                f"generated={sbom_report['generated']}, error={sbom_report['error']!r}",
+            )
+            add(
+                "sbom_component_count",
+                int(sbom_report["component_count"]) > 0,
+                f"component_count={sbom_report['component_count']}",
+            )
+    else:
+        add(
+            "non_production_profile",
+            True,
+            f"deployment_profile={profile!r} (hard requirements skipped)",
+        )
+
+    failed = [item for item in criteria if not item["passed"]]
+    success = len(failed) == 0
+    report = {
+        "label": label,
+        "success": bool(success),
+        "config": {
+            "project_root": str(project_root),
+            "deployment_profile": profile,
+            "python_exe": str(python_exe),
+            "scan_path": str(scan_path),
+            "max_dependency_vulnerabilities": int(max_dependency_vulnerabilities),
+            "max_sast_high": int(max_sast_high),
+            "max_sast_medium": int(max_sast_medium),
+            "skip_dependency_audit": bool(skip_dependency_audit),
+            "skip_sast": bool(skip_sast),
+            "skip_sbom": bool(skip_sbom),
+            "allow_missing_tools": bool(allow_missing_tools),
+            "timeout_seconds": int(timeout_seconds),
+            "dependency_audit_json_file": (
+                str(dependency_audit_json_file) if dependency_audit_json_file is not None else None
+            ),
+            "sast_json_file": str(sast_json_file) if sast_json_file is not None else None,
+            "sbom_output_file": str(sbom_output_file),
+        },
+        "metrics": {
+            "criteria_total": len(criteria),
+            "criteria_failed": len(failed),
+            "criteria_passed": len(criteria) - len(failed),
+            "dependency_vulnerability_count": int(dependency_report["vulnerability_count"]),
+            "sast_high_count": int(sast_report["high_count"]),
+            "sast_medium_count": int(sast_report["medium_count"]),
+            "sast_low_count": int(sast_report["low_count"]),
+            "sbom_component_count": int(sbom_report["component_count"]),
+        },
+        "criteria": criteria,
+        "failed_criteria": failed,
+        "dependency_audit": dependency_report,
+        "sast": sast_report,
+        "sbom": sbom_report,
+        "generated_at_utc": _utc_now(),
+        "duration_ms": int((time.perf_counter() - started) * 1000),
+    }
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Security CI lane check for dependency scanning, SAST, and SBOM export with "
+            "deterministic pass/fail policy."
+        )
+    )
+    parser.add_argument("--label", default="security-ci-lane")
+    parser.add_argument("--project-root")
+    parser.add_argument("--python-exe", default=sys.executable)
+    parser.add_argument("--deployment-profile", default="production")
+    parser.add_argument("--scan-path", default="goal_ops_console")
+    parser.add_argument("--max-dependency-vulnerabilities", type=int, default=0)
+    parser.add_argument("--max-sast-high", type=int, default=0)
+    parser.add_argument("--max-sast-medium", type=int, default=200)
+    parser.add_argument("--timeout-seconds", type=int, default=180)
+    parser.add_argument("--skip-dependency-audit", action="store_true")
+    parser.add_argument("--skip-sast", action="store_true")
+    parser.add_argument("--skip-sbom", action="store_true")
+    parser.add_argument("--allow-missing-tools", action="store_true")
+    parser.add_argument("--dependency-audit-json-file")
+    parser.add_argument("--sast-json-file")
+    parser.add_argument("--sbom-output-file", default="artifacts/security-sbom-check.json")
+    parser.add_argument("--output-file")
+    parser.add_argument("--allow-failure", action="store_true")
+    args = parser.parse_args(argv)
+
+    inferred_project_root = Path(__file__).resolve().parents[1]
+    project_root = Path(str(args.project_root)).expanduser() if args.project_root else inferred_project_root
+    if not project_root.is_absolute():
+        project_root = (inferred_project_root / project_root).resolve()
+
+    dependency_audit_json_file = (
+        Path(str(args.dependency_audit_json_file)).expanduser()
+        if args.dependency_audit_json_file
+        else None
+    )
+    if dependency_audit_json_file is not None and not dependency_audit_json_file.is_absolute():
+        dependency_audit_json_file = (project_root / dependency_audit_json_file).resolve()
+
+    sast_json_file = Path(str(args.sast_json_file)).expanduser() if args.sast_json_file else None
+    if sast_json_file is not None and not sast_json_file.is_absolute():
+        sast_json_file = (project_root / sast_json_file).resolve()
+
+    sbom_output_file = Path(str(args.sbom_output_file)).expanduser()
+    if not sbom_output_file.is_absolute():
+        sbom_output_file = (project_root / sbom_output_file).resolve()
+
+    report = run_check(
+        label=str(args.label),
+        project_root=project_root,
+        python_exe=str(args.python_exe),
+        deployment_profile=str(args.deployment_profile),
+        scan_path=str(args.scan_path),
+        max_dependency_vulnerabilities=int(args.max_dependency_vulnerabilities),
+        max_sast_high=int(args.max_sast_high),
+        max_sast_medium=int(args.max_sast_medium),
+        skip_dependency_audit=bool(args.skip_dependency_audit),
+        skip_sast=bool(args.skip_sast),
+        skip_sbom=bool(args.skip_sbom),
+        allow_missing_tools=bool(args.allow_missing_tools),
+        timeout_seconds=int(args.timeout_seconds),
+        dependency_audit_json_file=dependency_audit_json_file,
+        sast_json_file=sast_json_file,
+        sbom_output_file=sbom_output_file,
+    )
+
+    if args.output_file:
+        output_file = Path(str(args.output_file)).expanduser()
+        if not output_file.is_absolute():
+            output_file = (project_root / output_file).resolve()
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2), encoding="utf-8")
+
+    if report["success"] is False and not bool(args.allow_failure):
+        print(f"[security-ci-lane-check] ERROR: {json.dumps(report, sort_keys=True)}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -3828,3 +3828,133 @@ def test_125_service_startup_backfills_legacy_audit_integrity_rows():
         assert payload["metrics"]["total_audit_entries"] >= 1
 
     shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_126_security_ci_lane_check_reports_success_with_fixture_inputs():
+    workspace = _local_test_dir("pytest-security-ci-lane-check-success").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    artifacts_dir = workspace / "artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    dependency_file = artifacts_dir / "dependency-audit.json"
+    sast_file = artifacts_dir / "sast-bandit.json"
+    sbom_file = artifacts_dir / "security-sbom.json"
+    output_file = artifacts_dir / "security-ci-lane-report.json"
+
+    dependency_file.write_text(json.dumps([], ensure_ascii=True), encoding="utf-8")
+    sast_file.write_text(
+        json.dumps({"results": [], "metrics": {}}, ensure_ascii=True, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "security-ci-lane-check.py"),
+        "--label",
+        "pytest-drill",
+        "--deployment-profile",
+        "production",
+        "--scan-path",
+        "goal_ops_console",
+        "--max-dependency-vulnerabilities",
+        "0",
+        "--max-sast-high",
+        "0",
+        "--max-sast-medium",
+        "0",
+        "--dependency-audit-json-file",
+        str(dependency_file.resolve()),
+        "--sast-json-file",
+        str(sast_file.resolve()),
+        "--sbom-output-file",
+        str(sbom_file.resolve()),
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["metrics"]["criteria_failed"] == 0
+    assert sbom_file.exists()
+    assert output_file.exists()
+
+    sbom_payload = json.loads(sbom_file.read_text(encoding="utf-8"))
+    assert sbom_payload["component_count"] >= 1
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_127_security_ci_lane_check_fails_when_dependency_budget_exceeded():
+    workspace = _local_test_dir("pytest-security-ci-lane-check-failure").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    artifacts_dir = workspace / "artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    dependency_file = artifacts_dir / "dependency-audit.json"
+    sast_file = artifacts_dir / "sast-bandit.json"
+    output_file = artifacts_dir / "security-ci-lane-report.json"
+
+    dependency_file.write_text(
+        json.dumps(
+            [
+                {
+                    "name": "example-package",
+                    "version": "1.2.3",
+                    "vulns": [{"id": "PYSEC-2026-0001", "fix_versions": ["1.2.4"]}],
+                }
+            ],
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    sast_file.write_text(
+        json.dumps({"results": [], "metrics": {}}, ensure_ascii=True, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "security-ci-lane-check.py"),
+        "--label",
+        "pytest-drill",
+        "--deployment-profile",
+        "production",
+        "--scan-path",
+        "goal_ops_console",
+        "--max-dependency-vulnerabilities",
+        "0",
+        "--max-sast-high",
+        "0",
+        "--max-sast-medium",
+        "0",
+        "--dependency-audit-json-file",
+        str(dependency_file.resolve()),
+        "--sast-json-file",
+        str(sast_file.resolve()),
+        "--sbom-output-file",
+        str((artifacts_dir / "security-sbom.json").resolve()),
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "[security-ci-lane-check] ERROR: "
+    assert marker in completed.stderr
+    payload = json.loads(completed.stderr.split(marker, 1)[1].strip())
+    assert payload["success"] is False
+    assert payload["metrics"]["criteria_failed"] >= 1
+    assert payload["metrics"]["dependency_vulnerability_count"] >= 1
+
+    shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
﻿## Summary
- add `security-ci-lane-check.py` for dependency scan (`pip-audit`), SAST (`bandit`), and deterministic SBOM export with policy-based pass/fail criteria
- add `run-security-ci-lane-check.ps1` wrapper for local/ops invocation
- add release-gate integration with new flags: `-SkipSecurityCiLaneCheck` and `-StrictSecurityCiLaneCheck`
- add CI integration:
  - release-gate Windows job installs `.[test,security]`, runs `-StrictSecurityCiLaneCheck`, and uploads security lane artifacts
  - new dedicated `Security CI Lane` GitHub Actions job on Ubuntu
- add optional `security` dependency extra (`pip-audit`, `bandit`) in `pyproject.toml`
- extend runbook-contract requirements with `run-security-ci-lane-check.ps1`
- update README + production runbook commands and security lane documentation
- add automated tests for security-lane script success/failure using fixture-driven JSON inputs (tool-independent)

## Validation
- `python -m py_compile scripts\security-ci-lane-check.py scripts\p0-runbook-contract-check.py tests\test_goal_ops.py goal_ops_console\config.py`
- `python -m pytest -q tests\test_goal_ops.py -k "test_112_p0_runbook_contract_check_reports_success or test_119_security_config_hardening_check_reports_success or test_120_security_config_hardening_check_reports_failure_without_auth_requirement or test_123_audit_trail_hardening_check_reports_success or test_124_audit_trail_hardening_check_fails_with_low_retention_policy or test_126_security_ci_lane_check_reports_success_with_fixture_inputs or test_127_security_ci_lane_check_fails_when_dependency_budget_exceeded"`
- `./scripts/run-security-ci-lane-check.ps1 -AllowMissingTools -MaxDependencyVulnerabilities 0 -MaxSastHigh 0 -MaxSastMedium 200`
- `./scripts/run-p0-runbook-contract-check.ps1`
- `./scripts/release-gate.ps1` smoke with all skip flags (including `-SkipSecurityCiLaneCheck`)
