### PR TITLE
[codex] Add stage-B alert routing and on-call automation gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          .\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+          .\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 
       - name: Upload release evidence artifacts
         uses: actions/upload-artifact@v4
@@ -55,6 +55,7 @@ jobs:
             artifacts/audit-trail-hardening-release-gate.json
             artifacts/security-ci-lane-release-gate.json
             artifacts/security-sbom-release-gate.json
+            artifacts/alert-routing-oncall-release-gate.json
           if-no-files-found: error
 
   security-ci-lane:

--- a/README.md
+++ b/README.md
@@ -411,11 +411,11 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + security config hardening check + audit trail hardening check + security CI lane check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle + P0 closure go/no-go report):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + security config hardening check + audit trail hardening check + security CI lane check + alert-routing/on-call runbook automation check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle + P0 closure go/no-go report):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 ```
 
 Standalone backup/restore drill:
@@ -486,6 +486,13 @@ Standalone security CI lane check (pip-audit + bandit + SBOM + fail policy):
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-security-ci-lane-check.ps1 -MaxDependencyVulnerabilities 0 -MaxSastHigh 0 -MaxSastMedium 200
+```
+
+Standalone alert-routing/on-call runbook automation check:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-alert-routing-oncall-check.ps1 -MockSloStatus critical -MockAlertCount 2 -RoutingPolicyFile "docs\oncall-alert-routing-policy.json"
 ```
 
 Standalone release-freeze policy check (live service):
@@ -950,5 +957,8 @@ If a value is rejected:
 - [run-audit-trail-hardening-check.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-audit-trail-hardening-check.ps1)
 - [security-ci-lane-check.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/security-ci-lane-check.py)
 - [run-security-ci-lane-check.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-security-ci-lane-check.ps1)
+- [alert-routing-oncall-check.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/alert-routing-oncall-check.py)
+- [run-alert-routing-oncall-check.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-alert-routing-oncall-check.ps1)
+- [oncall-alert-routing-policy.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/oncall-alert-routing-policy.json)
 - [test_goal_ops.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_goal_ops.py)
 - [test_desktop_launcher.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_desktop_launcher.py)

--- a/docs/oncall-alert-routing-policy.json
+++ b/docs/oncall-alert-routing-policy.json
@@ -1,0 +1,24 @@
+{
+  "routes": {
+    "critical": {
+      "channel": "ops-pager-critical",
+      "primary": "primary-oncall",
+      "backup": "secondary-oncall",
+      "max_ack_minutes": 15,
+      "runbook_section": "### 3.27 On-call critical alert routing"
+    },
+    "warning": {
+      "channel": "ops-slack-warning",
+      "primary": "ops-duty-manager",
+      "backup": "ops-secondary",
+      "max_ack_minutes": 60,
+      "runbook_section": "### 3.28 On-call warning alert routing"
+    }
+  },
+  "escalation": {
+    "critical_page_within_minutes": 5,
+    "critical_backup_after_minutes": 10,
+    "warning_notify_within_minutes": 15,
+    "warning_ticket_within_minutes": 30
+  }
+}

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -9,7 +9,7 @@ This runbook is optimized for reliability-first releases of the desktop app and 
 Run in repo root:
 
 ```powershell
-.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 ```
 
 This gate covers:
@@ -20,6 +20,7 @@ This gate covers:
 - security config hardening check (production profile must require operator auth, strong token, non-memory DB, and startup corruption recovery guard)
 - audit trail hardening check (audit hash-chain integrity verification, tamper detection, and retention policy floor)
 - security CI lane check (`pip-audit` + `bandit` + SBOM export with explicit fail policy thresholds)
+- alert-routing/on-call check (severity route policy, escalation SLA budgets, and runbook-section references)
 - release-freeze policy drill (sustained non-ok window or burn-rate spike freezes ring promotion path)
 - auto-rollback-policy drill (`critical` sustained window triggers stable ring rollback path)
 - desktop-update-safety drill (hash validation + rollback-to-stable fallback path)
@@ -89,6 +90,12 @@ Manual security CI lane check invocation:
 
 ```powershell
 .\scripts\run-security-ci-lane-check.ps1 -MaxDependencyVulnerabilities 0 -MaxSastHigh 0 -MaxSastMedium 200
+```
+
+Manual alert-routing/on-call runbook automation invocation:
+
+```powershell
+.\scripts\run-alert-routing-oncall-check.ps1 -MockSloStatus critical -MockAlertCount 2 -RoutingPolicyFile "docs\oncall-alert-routing-policy.json"
 ```
 
 Manual release-freeze policy invocation (live endpoint, stable ring):
@@ -827,6 +834,44 @@ Actions:
    - `readiness.after_recovery = true`
    - `slo.after_recovery = ok`
 3. If recovery or integrity checks fail, hold release and escalate with drill JSON + diagnostics snapshot before retrying rollout.
+
+### 3.27 On-call critical alert routing
+
+Symptoms:
+- `/system/slo` returns `status=critical` or one/more critical alert objects in `alerts[]`
+- customer-impacting error budget burn or safe-mode incidents require immediate human response
+
+Actions:
+1. Trigger on-call routing automation:
+   ```powershell
+   .\scripts\run-alert-routing-oncall-check.ps1 -MockSloStatus critical -MockAlertCount 2 -RoutingPolicyFile "docs\oncall-alert-routing-policy.json"
+   ```
+2. Ensure policy output includes for every critical alert:
+   - `page_primary_oncall` action to `primary-oncall`
+   - `page_backup_oncall` action to `secondary-oncall`
+   - due windows within policy (`critical_page_within_minutes`, `critical_backup_after_minutes`)
+3. Follow escalation order:
+   - page primary immediately
+   - page backup if ack/mitigation is not confirmed within escalation SLA
+   - open incident bridge and attach diagnostics bundle
+4. Keep release frozen until `status` returns to `ok` and post-incident checklist is complete.
+
+### 3.28 On-call warning alert routing
+
+Symptoms:
+- `/system/slo` returns `status=degraded` or warning-level alerts
+- no immediate outage, but error budget and stability trends indicate heightened risk
+
+Actions:
+1. Run warning-route verification:
+   ```powershell
+   .\scripts\run-alert-routing-oncall-check.ps1 -MockSloStatus degraded -MockAlertCount 1 -RoutingPolicyFile "docs\oncall-alert-routing-policy.json"
+   ```
+2. Ensure policy output includes for every warning alert:
+   - `notify_warning_channel` action to `ops-slack-warning`
+   - `create_warning_ticket` action with owner + due window
+3. Assign mitigation owner and ETA in incident tracker.
+4. Escalate to critical routing immediately if warning turns into `status=critical` or burn-rate spikes.
 
 ## 4. Operational Defaults
 

--- a/scripts/alert-routing-oncall-check.py
+++ b/scripts/alert-routing-oncall-check.py
@@ -1,0 +1,434 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.request
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from goal_ops_console.config import Settings
+from goal_ops_console.main import create_app
+
+SEVERITY_ORDER = {"warning": 1, "critical": 2}
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _read_json_file(path: Path) -> dict[str, Any]:
+    _expect(path.exists(), f"Required file not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    _expect(isinstance(payload, dict), f"Expected JSON object in {path}")
+    return payload
+
+
+def _fetch_slo_from_local_app(database_url: str) -> dict[str, Any]:
+    app = create_app(Settings(database_url=database_url))
+    with TestClient(app) as client:
+        response = client.get("/system/slo")
+        _expect(response.status_code == 200, "Local /system/slo returned non-200 status")
+        payload = response.json()
+    _expect(isinstance(payload, dict), "Local /system/slo payload is not a JSON object")
+    return payload
+
+
+def _fetch_slo_from_url(base_url: str) -> dict[str, Any]:
+    normalized = base_url.strip().rstrip("/")
+    parsed = urlparse(normalized)
+    _expect(bool(parsed.scheme and parsed.netloc), f"Invalid base URL: {base_url}")
+    target = f"{normalized}/system/slo"
+    with urllib.request.urlopen(target, timeout=10) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    _expect(isinstance(payload, dict), "Remote /system/slo payload is not a JSON object")
+    return payload
+
+
+def _build_mock_slo_payload(status: str, alert_count: int) -> dict[str, Any]:
+    normalized_status = str(status).strip().lower()
+    _expect(normalized_status in {"ok", "degraded", "critical"}, f"Invalid mock status: {status!r}")
+    count = max(0, int(alert_count))
+    severity = "critical" if normalized_status == "critical" else "warning"
+    alerts = []
+    for index in range(count):
+        alerts.append(
+            {
+                "code": f"mock.{normalized_status}.{index + 1}",
+                "severity": severity,
+                "message": f"Mock {normalized_status} alert {index + 1}.",
+            }
+        )
+    return {
+        "timestamp_utc": _utc_now(),
+        "status": normalized_status,
+        "alert_count": len(alerts),
+        "alerts": alerts,
+        "indicators": {
+            "http_success_rate_percent": 95.0 if normalized_status != "ok" else 100.0,
+            "event_failure_rate_percent": 2.0 if normalized_status == "degraded" else 6.0 if normalized_status == "critical" else 0.0,
+        },
+    }
+
+
+def _normalize_alerts(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    raw_alerts = payload.get("alerts")
+    if isinstance(raw_alerts, list):
+        for index, item in enumerate(raw_alerts):
+            if not isinstance(item, dict):
+                continue
+            severity = str(item.get("severity") or "").strip().lower()
+            if severity not in {"warning", "critical"}:
+                continue
+            normalized.append(
+                {
+                    "code": str(item.get("code") or f"alert.{index + 1}"),
+                    "severity": severity,
+                    "message": str(item.get("message") or ""),
+                }
+            )
+
+    if normalized:
+        return normalized
+
+    status = str(payload.get("status") or "").strip().lower()
+    if status == "critical":
+        return [{"code": "synthetic.status.critical", "severity": "critical", "message": "Derived critical alert from SLO status."}]
+    if status == "degraded":
+        return [{"code": "synthetic.status.degraded", "severity": "warning", "message": "Derived warning alert from SLO status."}]
+    return []
+
+
+def _route_for_severity(policy: dict[str, Any], severity: str) -> dict[str, Any] | None:
+    routes = policy.get("routes")
+    if not isinstance(routes, dict):
+        return None
+    route = routes.get(severity)
+    if not isinstance(route, dict):
+        return None
+    return route
+
+
+def _build_action_plan(policy: dict[str, Any], alerts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    escalation = policy.get("escalation")
+    if not isinstance(escalation, dict):
+        escalation = {}
+
+    critical_page_within = max(0, int(escalation.get("critical_page_within_minutes", 5)))
+    critical_backup_after = max(0, int(escalation.get("critical_backup_after_minutes", 10)))
+    warning_notify_within = max(0, int(escalation.get("warning_notify_within_minutes", 15)))
+    warning_ticket_within = max(0, int(escalation.get("warning_ticket_within_minutes", 30)))
+
+    actions: list[dict[str, Any]] = []
+    for alert in alerts:
+        severity = str(alert["severity"])
+        route = _route_for_severity(policy, severity)
+        if route is None:
+            continue
+        channel = str(route.get("channel") or "")
+        primary = str(route.get("primary") or "")
+        backup = str(route.get("backup") or "")
+        runbook_section = str(route.get("runbook_section") or "")
+        code = str(alert["code"])
+
+        if severity == "critical":
+            actions.append(
+                {
+                    "alert_code": code,
+                    "severity": severity,
+                    "step": "page_primary_oncall",
+                    "target": primary,
+                    "channel": channel,
+                    "due_within_minutes": critical_page_within,
+                    "runbook_section": runbook_section,
+                }
+            )
+            actions.append(
+                {
+                    "alert_code": code,
+                    "severity": severity,
+                    "step": "page_backup_oncall",
+                    "target": backup,
+                    "channel": channel,
+                    "due_within_minutes": critical_backup_after,
+                    "runbook_section": runbook_section,
+                }
+            )
+        else:
+            actions.append(
+                {
+                    "alert_code": code,
+                    "severity": severity,
+                    "step": "notify_warning_channel",
+                    "target": channel,
+                    "channel": channel,
+                    "due_within_minutes": warning_notify_within,
+                    "runbook_section": runbook_section,
+                }
+            )
+            actions.append(
+                {
+                    "alert_code": code,
+                    "severity": severity,
+                    "step": "create_warning_ticket",
+                    "target": primary,
+                    "channel": channel,
+                    "due_within_minutes": warning_ticket_within,
+                    "runbook_section": runbook_section,
+                }
+            )
+    return actions
+
+
+def run_check(
+    *,
+    label: str,
+    deployment_profile: str,
+    policy_file: Path,
+    runbook_file: Path,
+    database_url: str,
+    base_url: str,
+    slo_json_file: Path | None,
+    mock_slo_status: str,
+    mock_alert_count: int,
+    max_critical_ack_minutes: int,
+    max_warning_ack_minutes: int,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    profile = str(deployment_profile).strip().lower() or "production"
+    policy = _read_json_file(policy_file)
+    runbook_text = runbook_file.read_text(encoding="utf-8")
+
+    source: dict[str, Any]
+    if mock_slo_status.strip():
+        payload = _build_mock_slo_payload(mock_slo_status, mock_alert_count)
+        source = {
+            "type": "mock",
+            "mock_slo_status": str(mock_slo_status).strip().lower(),
+            "mock_alert_count": int(mock_alert_count),
+        }
+    elif slo_json_file is not None:
+        payload = _read_json_file(slo_json_file)
+        source = {"type": "slo_json_file", "path": str(slo_json_file)}
+    elif base_url.strip():
+        payload = _fetch_slo_from_url(base_url.strip())
+        source = {"type": "http", "base_url": base_url.strip()}
+    else:
+        payload = _fetch_slo_from_local_app(database_url.strip())
+        source = {"type": "local", "database_url": database_url.strip()}
+
+    alerts = _normalize_alerts(payload)
+    action_plan = _build_action_plan(policy, alerts)
+
+    critical_alerts = [item for item in alerts if item["severity"] == "critical"]
+    warning_alerts = [item for item in alerts if item["severity"] == "warning"]
+    critical_actions_primary = [
+        item for item in action_plan if item["severity"] == "critical" and item["step"] == "page_primary_oncall"
+    ]
+    critical_actions_backup = [
+        item for item in action_plan if item["severity"] == "critical" and item["step"] == "page_backup_oncall"
+    ]
+    warning_actions_notify = [
+        item for item in action_plan if item["severity"] == "warning" and item["step"] == "notify_warning_channel"
+    ]
+    warning_actions_ticket = [
+        item for item in action_plan if item["severity"] == "warning" and item["step"] == "create_warning_ticket"
+    ]
+
+    warning_route = _route_for_severity(policy, "warning")
+    critical_route = _route_for_severity(policy, "critical")
+    critical_ack = int(critical_route.get("max_ack_minutes", 9999)) if critical_route else 9999
+    warning_ack = int(warning_route.get("max_ack_minutes", 9999)) if warning_route else 9999
+    critical_runbook_section = str(critical_route.get("runbook_section") or "") if critical_route else ""
+    warning_runbook_section = str(warning_route.get("runbook_section") or "") if warning_route else ""
+
+    criteria: list[dict[str, Any]] = []
+
+    def add(name: str, passed: bool, details: str) -> None:
+        criteria.append({"name": name, "passed": bool(passed), "details": details})
+
+    if profile == "production":
+        add(
+            "warning_and_critical_routes_present",
+            warning_route is not None and critical_route is not None,
+            f"warning_route={warning_route is not None}, critical_route={critical_route is not None}",
+        )
+        add(
+            "critical_ack_budget",
+            critical_ack <= max(1, int(max_critical_ack_minutes)),
+            f"critical_ack_minutes={critical_ack}, max={max_critical_ack_minutes}",
+        )
+        add(
+            "warning_ack_budget",
+            warning_ack <= max(1, int(max_warning_ack_minutes)),
+            f"warning_ack_minutes={warning_ack}, max={max_warning_ack_minutes}",
+        )
+        add(
+            "critical_runbook_section_present",
+            bool(critical_runbook_section) and critical_runbook_section in runbook_text,
+            f"critical_runbook_section={critical_runbook_section!r}",
+        )
+        add(
+            "warning_runbook_section_present",
+            bool(warning_runbook_section) and warning_runbook_section in runbook_text,
+            f"warning_runbook_section={warning_runbook_section!r}",
+        )
+        add(
+            "critical_alerts_routed",
+            len(critical_actions_primary) >= len(critical_alerts)
+            and len(critical_actions_backup) >= len(critical_alerts),
+            (
+                f"critical_alerts={len(critical_alerts)}, "
+                f"primary_actions={len(critical_actions_primary)}, "
+                f"backup_actions={len(critical_actions_backup)}"
+            ),
+        )
+        add(
+            "warning_alerts_routed",
+            len(warning_actions_notify) >= len(warning_alerts)
+            and len(warning_actions_ticket) >= len(warning_alerts),
+            (
+                f"warning_alerts={len(warning_alerts)}, "
+                f"notify_actions={len(warning_actions_notify)}, "
+                f"ticket_actions={len(warning_actions_ticket)}"
+            ),
+        )
+    else:
+        add(
+            "non_production_profile",
+            True,
+            f"deployment_profile={profile!r} (hard requirements skipped)",
+        )
+
+    failed = [item for item in criteria if not item["passed"]]
+    success = len(failed) == 0
+
+    report = {
+        "label": label,
+        "success": bool(success),
+        "config": {
+            "deployment_profile": profile,
+            "policy_file": str(policy_file),
+            "runbook_file": str(runbook_file),
+            "database_url": str(database_url),
+            "base_url": str(base_url),
+            "slo_json_file": str(slo_json_file) if slo_json_file else None,
+            "mock_slo_status": str(mock_slo_status).strip().lower() or None,
+            "mock_alert_count": int(mock_alert_count),
+            "max_critical_ack_minutes": int(max_critical_ack_minutes),
+            "max_warning_ack_minutes": int(max_warning_ack_minutes),
+        },
+        "metrics": {
+            "criteria_total": len(criteria),
+            "criteria_failed": len(failed),
+            "criteria_passed": len(criteria) - len(failed),
+            "alert_count": len(alerts),
+            "critical_alert_count": len(critical_alerts),
+            "warning_alert_count": len(warning_alerts),
+            "action_count": len(action_plan),
+            "max_observed_severity_rank": max([SEVERITY_ORDER.get(item["severity"], 0) for item in alerts], default=0),
+        },
+        "criteria": criteria,
+        "failed_criteria": failed,
+        "source": source,
+        "slo": payload,
+        "alerts": alerts,
+        "action_plan": action_plan,
+        "generated_at_utc": _utc_now(),
+        "duration_ms": int((time.perf_counter() - started) * 1000),
+    }
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate alert routing and on-call runbook automation policy against observed SLO alerts."
+        )
+    )
+    parser.add_argument("--label", default="alert-routing-oncall-check")
+    parser.add_argument("--deployment-profile", default="production")
+    parser.add_argument("--database-url", default=":memory:")
+    parser.add_argument("--base-url", default="")
+    parser.add_argument("--slo-json-file", default="")
+    parser.add_argument("--mock-slo-status", default="")
+    parser.add_argument("--mock-alert-count", type=int, default=1)
+    parser.add_argument("--routing-policy-file", default="docs/oncall-alert-routing-policy.json")
+    parser.add_argument("--runbook-file", default="docs/production-runbook.md")
+    parser.add_argument("--max-critical-ack-minutes", type=int, default=15)
+    parser.add_argument("--max-warning-ack-minutes", type=int, default=120)
+    parser.add_argument("--output-file")
+    parser.add_argument("--allow-failure", action="store_true")
+    args = parser.parse_args(argv)
+
+    project_root = Path(__file__).resolve().parents[1]
+    policy_file = Path(str(args.routing_policy_file)).expanduser()
+    if not policy_file.is_absolute():
+        policy_file = (project_root / policy_file).resolve()
+    runbook_file = Path(str(args.runbook_file)).expanduser()
+    if not runbook_file.is_absolute():
+        runbook_file = (project_root / runbook_file).resolve()
+
+    slo_json_file = None
+    if str(args.slo_json_file).strip():
+        slo_json_file = Path(str(args.slo_json_file)).expanduser()
+        if not slo_json_file.is_absolute():
+            slo_json_file = (project_root / slo_json_file).resolve()
+
+    custom_sources = int(bool(str(args.base_url).strip())) + int(slo_json_file is not None) + int(bool(str(args.mock_slo_status).strip()))
+    if custom_sources > 1:
+        print(
+            "[alert-routing-oncall-check] ERROR: Provide only one custom source: --base-url, --slo-json-file, or --mock-slo-status.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        report = run_check(
+            label=str(args.label),
+            deployment_profile=str(args.deployment_profile),
+            policy_file=policy_file,
+            runbook_file=runbook_file,
+            database_url=str(args.database_url),
+            base_url=str(args.base_url),
+            slo_json_file=slo_json_file,
+            mock_slo_status=str(args.mock_slo_status),
+            mock_alert_count=max(0, int(args.mock_alert_count)),
+            max_critical_ack_minutes=max(1, int(args.max_critical_ack_minutes)),
+            max_warning_ack_minutes=max(1, int(args.max_warning_ack_minutes)),
+        )
+    except Exception as exc:
+        print(f"[alert-routing-oncall-check] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output_file:
+        output_file = Path(str(args.output_file)).expanduser()
+        if not output_file.is_absolute():
+            output_file = (project_root / output_file).resolve()
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2), encoding="utf-8")
+
+    if report["success"] is False and not bool(args.allow_failure):
+        print(f"[alert-routing-oncall-check] ERROR: {json.dumps(report, sort_keys=True)}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/p0-runbook-contract-check.py
+++ b/scripts/p0-runbook-contract-check.py
@@ -13,6 +13,7 @@ DEFAULT_REQUIRED_RUNBOOK_SCRIPTS = [
     "run-security-config-hardening-check.ps1",
     "run-audit-trail-hardening-check.ps1",
     "run-security-ci-lane-check.ps1",
+    "run-alert-routing-oncall-check.ps1",
     "run-power-loss-durability-drill.ps1",
     "run-disk-pressure-fault-injection-drill.ps1",
     "run-upgrade-downgrade-compatibility-drill.ps1",

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -10,6 +10,8 @@ param(
     [switch]$StrictAuditTrailHardeningCheck,
     [switch]$SkipSecurityCiLaneCheck,
     [switch]$StrictSecurityCiLaneCheck,
+    [switch]$SkipAlertRoutingOnCallCheck,
+    [switch]$StrictAlertRoutingOnCallCheck,
     [switch]$SkipReleaseFreezePolicyDrill,
     [switch]$StrictReleaseFreezePolicyDrill,
     [switch]$SkipFileDatabaseProbe,
@@ -225,6 +227,34 @@ if (-not $SkipSecurityCiLaneCheck) {
             }
             Write-Warning (
                 "Security CI lane check failed but StrictSecurityCiLaneCheck is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipAlertRoutingOnCallCheck) {
+    Invoke-GateStep -Name "Alert routing + on-call runbook automation check (severity routing + escalation plan)" -Action {
+        $reportPath = Join-Path $ProjectRoot "artifacts\alert-routing-oncall-release-gate.json"
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\alert-routing-oncall-check.py",
+                "--label", "release-gate",
+                "--deployment-profile", "production",
+                "--mock-slo-status", "critical",
+                "--mock-alert-count", "2",
+                "--routing-policy-file", "docs/oncall-alert-routing-policy.json",
+                "--runbook-file", "docs/production-runbook.md",
+                "--max-critical-ack-minutes", "15",
+                "--max-warning-ack-minutes", "120",
+                "--output-file", $reportPath
+            )
+        } catch {
+            if ($StrictAlertRoutingOnCallCheck) {
+                throw
+            }
+            Write-Warning (
+                "Alert routing on-call check failed but StrictAlertRoutingOnCallCheck is off. " +
                 "Continuing. Error: $($_.Exception.Message)"
             )
         }

--- a/scripts/run-alert-routing-oncall-check.ps1
+++ b/scripts/run-alert-routing-oncall-check.ps1
@@ -1,0 +1,52 @@
+param(
+    [string]$PythonExe = "python",
+    [string]$DeploymentProfile = "production",
+    [string]$DatabaseUrl = ":memory:",
+    [string]$BaseUrl = "",
+    [string]$SloJsonFile = "",
+    [string]$MockSloStatus = "",
+    [int]$MockAlertCount = 1,
+    [string]$RoutingPolicyFile = "docs\\oncall-alert-routing-policy.json",
+    [string]$RunbookFile = "docs\\production-runbook.md",
+    [int]$MaxCriticalAckMinutes = 15,
+    [int]$MaxWarningAckMinutes = 120,
+    [string]$OutputFile = "artifacts\\alert-routing-oncall-check-report.json",
+    [switch]$AllowFailure
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$arguments = @(
+    ".\\scripts\\alert-routing-oncall-check.py",
+    "--label", "manual",
+    "--deployment-profile", $DeploymentProfile,
+    "--database-url", $DatabaseUrl,
+    "--routing-policy-file", $RoutingPolicyFile,
+    "--runbook-file", $RunbookFile,
+    "--max-critical-ack-minutes", [string]$MaxCriticalAckMinutes,
+    "--max-warning-ack-minutes", [string]$MaxWarningAckMinutes,
+    "--output-file", $OutputFile
+)
+if (-not [string]::IsNullOrWhiteSpace($BaseUrl)) {
+    $arguments += @("--base-url", $BaseUrl)
+}
+if (-not [string]::IsNullOrWhiteSpace($SloJsonFile)) {
+    $arguments += @("--slo-json-file", $SloJsonFile)
+}
+if (-not [string]::IsNullOrWhiteSpace($MockSloStatus)) {
+    $arguments += @("--mock-slo-status", $MockSloStatus)
+    $arguments += @("--mock-alert-count", [string]$MockAlertCount)
+}
+if ($AllowFailure) {
+    $arguments += "--allow-failure"
+}
+
+& $PythonExe @arguments
+if ($LASTEXITCODE -ne 0) {
+    throw "Alert routing on-call check failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Alert routing on-call check passed." -ForegroundColor Green

--- a/scripts/run-p0-runbook-contract-check.ps1
+++ b/scripts/run-p0-runbook-contract-check.ps1
@@ -1,7 +1,7 @@
 param(
     [string]$PythonExe = "python",
     [string]$OutputFile = "artifacts\\p0-runbook-contract-check-report.json",
-    [string]$RequiredRunbookScripts = "run-security-config-hardening-check.ps1,run-audit-trail-hardening-check.ps1,run-security-ci-lane-check.ps1,run-power-loss-durability-drill.ps1,run-disk-pressure-fault-injection-drill.ps1,run-upgrade-downgrade-compatibility-drill.ps1,run-backup-restore-stress-drill.ps1,run-release-gate-runtime-stability-drill.ps1,run-p0-burnin-consecutive-green.ps1,run-p0-release-evidence-bundle.ps1,run-p0-closure-report.ps1",
+    [string]$RequiredRunbookScripts = "run-security-config-hardening-check.ps1,run-audit-trail-hardening-check.ps1,run-security-ci-lane-check.ps1,run-alert-routing-oncall-check.ps1,run-power-loss-durability-drill.ps1,run-disk-pressure-fault-injection-drill.ps1,run-upgrade-downgrade-compatibility-drill.ps1,run-backup-restore-stress-drill.ps1,run-release-gate-runtime-stability-drill.ps1,run-p0-burnin-consecutive-green.ps1,run-p0-release-evidence-bundle.ps1,run-p0-closure-report.ps1",
     [string]$RequiredStrictFlags = ""
 )
 

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -3958,3 +3958,107 @@ def test_127_security_ci_lane_check_fails_when_dependency_budget_exceeded():
     assert payload["metrics"]["dependency_vulnerability_count"] >= 1
 
     shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_128_alert_routing_oncall_check_reports_success_with_mock_critical():
+    workspace = _local_test_dir("pytest-alert-routing-oncall-check-success").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    output_file = workspace / "alert-routing-oncall-report.json"
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "alert-routing-oncall-check.py"),
+        "--label",
+        "pytest-drill",
+        "--deployment-profile",
+        "production",
+        "--mock-slo-status",
+        "critical",
+        "--mock-alert-count",
+        "2",
+        "--routing-policy-file",
+        str((project_root / "docs" / "oncall-alert-routing-policy.json").resolve()),
+        "--runbook-file",
+        str((project_root / "docs" / "production-runbook.md").resolve()),
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["metrics"]["criteria_failed"] == 0
+    assert payload["metrics"]["critical_alert_count"] >= 2
+    assert payload["metrics"]["action_count"] >= 4
+    assert output_file.exists()
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_129_alert_routing_oncall_check_fails_when_critical_route_missing():
+    workspace = _local_test_dir("pytest-alert-routing-oncall-check-failure").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    policy_file = workspace / "broken-policy.json"
+    output_file = workspace / "alert-routing-oncall-report.json"
+
+    policy_file.write_text(
+        json.dumps(
+            {
+                "routes": {
+                    "warning": {
+                        "channel": "ops-slack-warning",
+                        "primary": "ops-duty-manager",
+                        "backup": "ops-secondary",
+                        "max_ack_minutes": 60,
+                        "runbook_section": "### 3.28 On-call warning alert routing",
+                    }
+                },
+                "escalation": {
+                    "critical_page_within_minutes": 5,
+                    "critical_backup_after_minutes": 10,
+                    "warning_notify_within_minutes": 15,
+                    "warning_ticket_within_minutes": 30,
+                },
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "alert-routing-oncall-check.py"),
+        "--label",
+        "pytest-drill",
+        "--deployment-profile",
+        "production",
+        "--mock-slo-status",
+        "critical",
+        "--mock-alert-count",
+        "1",
+        "--routing-policy-file",
+        str(policy_file.resolve()),
+        "--runbook-file",
+        str((project_root / "docs" / "production-runbook.md").resolve()),
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "[alert-routing-oncall-check] ERROR: "
+    assert marker in completed.stderr
+    payload = json.loads(completed.stderr.split(marker, 1)[1].strip())
+    assert payload["success"] is False
+    assert payload["metrics"]["criteria_failed"] >= 1
+
+    shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
## Summary
- add Stage-B alert routing + on-call check script and PS1 wrapper
- validate routing policy + runbook anchors and generate actionable incident routing report
- integrate strict/skip flags into release gate and CI artifact export
- add failure/recovery tests and runbook contract coverage

## Testing
- python -m py_compile scripts/alert-routing-oncall-check.py scripts/security-ci-lane-check.py scripts/p0-runbook-contract-check.py tests/test_goal_ops.py
- python -m pytest -q tests/test_goal_ops.py -k "test_112_p0_runbook_contract_check_reports_success or test_126_security_ci_lane_check_reports_success_with_fixture_inputs or test_127_security_ci_lane_check_fails_when_dependency_budget_exceeded or test_128_alert_routing_oncall_check_reports_success_with_mock_critical or test_129_alert_routing_oncall_check_fails_when_critical_route_missing"
- ./scripts/run-alert-routing-oncall-check.ps1 -MockSloStatus critical -MockAlertCount 2 -RoutingPolicyFile docs/oncall-alert-routing-policy.json
- ./scripts/run-p0-runbook-contract-check.ps1
- ./scripts/release-gate.ps1 -SkipPowerLossDurabilityDrill -SkipSecurityConfigHardeningCheck -SkipAuditTrailHardeningCheck -SkipSecurityCiLaneCheck -SkipAlertRoutingOnCallCheck -SkipDesktopFaultInjectionDrill -SkipReleaseEvidenceBundle -SkipP0ClosureReport -SkipCanaryGuardrailCheck -SkipScaleProfileBudgetCheck -SkipRtoRpoAssertionCheck -SkipAutoRollbackTriggerCheck -SkipOpsChaosDrillCheck -SkipP95LatencySloCheck -SkipStorageQuotaCheck -SkipBackupRestoreDrill -SkipSecretRotationDrill -SkipUpgradeDowngradeCompatibilityDrill -SkipDiskFaultInjectionDrill -SkipRunbookContractCheck -SkipBurnInConsecutiveGreenCheck
