### PR TITLE
[codex] Add stage-C load profile framework gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          .\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictIncidentDrillAutomationCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+          .\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictIncidentDrillAutomationCheck -StrictLoadProfileFrameworkCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 
       - name: Upload release evidence artifacts
         uses: actions/upload-artifact@v4
@@ -57,6 +57,7 @@ jobs:
             artifacts/security-sbom-release-gate.json
             artifacts/alert-routing-oncall-release-gate.json
             artifacts/incident-drill-automation-release-gate.json
+            artifacts/load-profile-framework-release-gate.json
           if-no-files-found: error
 
   security-ci-lane:

--- a/README.md
+++ b/README.md
@@ -411,11 +411,11 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + security config hardening check + audit trail hardening check + security CI lane check + alert-routing/on-call runbook automation check + incident drill automation check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle + P0 closure go/no-go report):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + security config hardening check + audit trail hardening check + security CI lane check + alert-routing/on-call runbook automation check + incident drill automation check + load profile framework check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle + P0 closure go/no-go report):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictIncidentDrillAutomationCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictIncidentDrillAutomationCheck -StrictLoadProfileFrameworkCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 ```
 
 Standalone backup/restore drill:
@@ -500,6 +500,13 @@ Standalone incident drill automation check:
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-incident-drill-automation-check.ps1 -MockReport -MockDaysSinceTabletop 7 -MockDaysSinceTechnical 3 -PolicyFile "docs\incident-drill-automation-policy.json"
+```
+
+Standalone load profile framework check:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-load-profile-framework-check.ps1 -ProfileFile "docs\load-profile-catalog.json" -ProfileName "prod_like_ci_smoke" -ProfileVersion "1.0.0"
 ```
 
 Standalone release-freeze policy check (live service):
@@ -970,5 +977,8 @@ If a value is rejected:
 - [incident-drill-automation-check.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/incident-drill-automation-check.py)
 - [run-incident-drill-automation-check.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-incident-drill-automation-check.ps1)
 - [incident-drill-automation-policy.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/incident-drill-automation-policy.json)
+- [load-profile-framework-check.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/load-profile-framework-check.py)
+- [run-load-profile-framework-check.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-load-profile-framework-check.ps1)
+- [load-profile-catalog.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/load-profile-catalog.json)
 - [test_goal_ops.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_goal_ops.py)
 - [test_desktop_launcher.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_desktop_launcher.py)

--- a/docs/load-profile-catalog.json
+++ b/docs/load-profile-catalog.json
@@ -1,0 +1,78 @@
+{
+  "catalog_version": "2026-04-16.stage-c.1",
+  "profiles": [
+    {
+      "name": "prod_like_ci_smoke",
+      "version": "1.0.0",
+      "description": "Fast production-like CI smoke profile with steady plus burst phases.",
+      "metadata": {
+        "traffic_shape": "steady_plus_burst",
+        "target_environment": "production_like_ci"
+      },
+      "stages": [
+        {
+          "name": "steady_warmup",
+          "cycles": 8,
+          "workflow_start_every_cycles": 0,
+          "drain_batch_size": 80,
+          "readiness_check_every_cycles": 4
+        },
+        {
+          "name": "mixed_burst",
+          "cycles": 16,
+          "workflow_start_every_cycles": 4,
+          "drain_batch_size": 120,
+          "readiness_check_every_cycles": 4
+        }
+      ],
+      "budgets": {
+        "max_p95_latency_ms": 400.0,
+        "max_p99_latency_ms": 900.0,
+        "max_max_latency_ms": 6000.0,
+        "max_http_429_rate_percent": 5.0,
+        "max_error_rate_percent": 1.0,
+        "min_total_requests": 120
+      }
+    },
+    {
+      "name": "prod_like_release_baseline",
+      "version": "1.0.0",
+      "description": "Longer production-like baseline profile for release rehearsal windows.",
+      "metadata": {
+        "traffic_shape": "steady_burst_recovery",
+        "target_environment": "production_like_release"
+      },
+      "stages": [
+        {
+          "name": "steady",
+          "cycles": 20,
+          "workflow_start_every_cycles": 0,
+          "drain_batch_size": 120,
+          "readiness_check_every_cycles": 5
+        },
+        {
+          "name": "burst",
+          "cycles": 30,
+          "workflow_start_every_cycles": 3,
+          "drain_batch_size": 180,
+          "readiness_check_every_cycles": 5
+        },
+        {
+          "name": "recovery",
+          "cycles": 10,
+          "workflow_start_every_cycles": 5,
+          "drain_batch_size": 150,
+          "readiness_check_every_cycles": 5
+        }
+      ],
+      "budgets": {
+        "max_p95_latency_ms": 450.0,
+        "max_p99_latency_ms": 1200.0,
+        "max_max_latency_ms": 8000.0,
+        "max_http_429_rate_percent": 3.0,
+        "max_error_rate_percent": 1.0,
+        "min_total_requests": 280
+      }
+    }
+  ]
+}

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -9,7 +9,7 @@ This runbook is optimized for reliability-first releases of the desktop app and 
 Run in repo root:
 
 ```powershell
-.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictIncidentDrillAutomationCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictIncidentDrillAutomationCheck -StrictLoadProfileFrameworkCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 ```
 
 This gate covers:
@@ -22,6 +22,7 @@ This gate covers:
 - security CI lane check (`pip-audit` + `bandit` + SBOM export with explicit fail policy thresholds)
 - alert-routing/on-call check (severity route policy, escalation SLA budgets, and runbook-section references)
 - incident drill automation check (tabletop + technical drill cadence, evidence completeness, and follow-up budget)
+- load profile framework check (versioned production-like traffic profile with deterministic latency/error budgets)
 - release-freeze policy drill (sustained non-ok window or burn-rate spike freezes ring promotion path)
 - auto-rollback-policy drill (`critical` sustained window triggers stable ring rollback path)
 - desktop-update-safety drill (hash validation + rollback-to-stable fallback path)
@@ -103,6 +104,12 @@ Manual incident drill automation invocation:
 
 ```powershell
 .\scripts\run-incident-drill-automation-check.ps1 -MockReport -MockDaysSinceTabletop 7 -MockDaysSinceTechnical 3 -PolicyFile "docs\incident-drill-automation-policy.json"
+```
+
+Manual load profile framework invocation:
+
+```powershell
+.\scripts\run-load-profile-framework-check.ps1 -ProfileFile "docs\load-profile-catalog.json" -ProfileName "prod_like_ci_smoke" -ProfileVersion "1.0.0"
 ```
 
 Manual release-freeze policy invocation (live endpoint, stable ring):
@@ -915,6 +922,39 @@ Actions:
    - `recency_budget` within `technical_drill_max_age_days`
 3. Keep open follow-ups within policy budget (`max_open_followup_actions`) before approving release.
 4. If check fails, hold release and run a fresh end-to-end incident/rollback drill, then re-run automation check.
+
+### 3.31 Prod-like load profile execution
+
+Symptoms:
+- release candidate has no recent evidence under versioned production-like load profiles
+- latency/error behavior is unknown for current build in steady-plus-burst traffic shape
+
+Actions:
+1. Run load-profile framework check:
+   ```powershell
+   .\scripts\run-load-profile-framework-check.ps1 -ProfileFile "docs\load-profile-catalog.json" -ProfileName "prod_like_ci_smoke" -ProfileVersion "1.0.0"
+   ```
+2. Verify reported budgets are all green:
+   - `min_total_requests`
+   - `p95_latency_budget`, `p99_latency_budget`, `max_latency_budget`
+   - `http_429_budget`, `error_rate_budget`
+3. Confirm final health gates after profile run:
+   - `final_readiness_true = true`
+   - `final_slo_ok = true`
+   - `workflow_queue_drained = true`
+4. If a budget fails, hold release and attach JSON report to incident/change ticket for remediation.
+
+### 3.32 Load profile catalog version management
+
+Symptoms:
+- profile definitions change over time and previous evidence cannot be compared reproducibly
+- operators need deterministic mapping between release decision and exact profile revision
+
+Actions:
+1. Keep `docs/load-profile-catalog.json` under version control and bump `catalog_version` when profile semantics change.
+2. Add/retain explicit `name` + `version` for each profile and run checks with pinned values (`--profile-name`, `--profile-version`).
+3. For major profile updates, run both old and new versions once in rehearsal, compare deltas, then switch release gate default.
+4. Record selected profile/version in release notes for auditability and rollback analysis.
 
 ## 4. Operational Defaults
 

--- a/scripts/load-profile-framework-check.py
+++ b/scripts/load-profile-framework-check.py
@@ -1,0 +1,566 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from goal_ops_console.config import Settings
+from goal_ops_console.main import create_app
+
+TERMINAL_RUN_STATES = {"succeeded", "failed", "timed_out", "cancelled"}
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _percentile(values: list[float], p: float) -> float:
+    _expect(values, "Cannot compute percentile for empty sequence.")
+    sorted_values = sorted(values)
+    if len(sorted_values) == 1:
+        return float(sorted_values[0])
+    rank = (len(sorted_values) - 1) * max(0.0, min(100.0, float(p))) / 100.0
+    lower = math.floor(rank)
+    upper = math.ceil(rank)
+    if lower == upper:
+        return float(sorted_values[lower])
+    weight = rank - lower
+    return float(sorted_values[lower] * (1.0 - weight) + sorted_values[upper] * weight)
+
+
+def _read_json_file(path: Path) -> dict[str, Any]:
+    _expect(path.exists(), f"Required file not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    _expect(isinstance(payload, dict), f"Expected JSON object in {path}")
+    return payload
+
+
+def _find_profile(catalog: dict[str, Any], *, profile_name: str, profile_version: str) -> dict[str, Any]:
+    profiles = catalog.get("profiles")
+    _expect(isinstance(profiles, list) and profiles, "Profile catalog has no profiles.")
+
+    normalized_name = str(profile_name).strip()
+    normalized_version = str(profile_version).strip()
+    _expect(bool(normalized_name), "Profile name must not be empty.")
+    _expect(bool(normalized_version), "Profile version must not be empty.")
+
+    for item in profiles:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("name") or "") == normalized_name and str(item.get("version") or "") == normalized_version:
+            return item
+
+    raise RuntimeError(
+        f"Profile not found in catalog: name={normalized_name!r} version={normalized_version!r}"
+    )
+
+
+def _validate_profile_shape(profile: dict[str, Any]) -> None:
+    _expect(bool(str(profile.get("name") or "").strip()), "Profile field 'name' is required.")
+    _expect(bool(str(profile.get("version") or "").strip()), "Profile field 'version' is required.")
+
+    stages = profile.get("stages")
+    _expect(isinstance(stages, list) and stages, "Profile field 'stages' must be a non-empty list.")
+
+    for index, stage in enumerate(stages):
+        _expect(isinstance(stage, dict), f"Stage #{index + 1} is not an object.")
+        _expect(bool(str(stage.get("name") or "").strip()), f"Stage #{index + 1} missing 'name'.")
+        cycles = int(stage.get("cycles") or 0)
+        _expect(cycles > 0, f"Stage '{stage.get('name')}' has invalid cycles={cycles}.")
+
+        workflow_every = int(stage.get("workflow_start_every_cycles") or 0)
+        _expect(workflow_every >= 0, f"Stage '{stage.get('name')}' has invalid workflow_start_every_cycles={workflow_every}.")
+
+        drain_batch_size = int(stage.get("drain_batch_size") or 0)
+        _expect(drain_batch_size > 0, f"Stage '{stage.get('name')}' has invalid drain_batch_size={drain_batch_size}.")
+
+        readiness_every = int(stage.get("readiness_check_every_cycles") or 0)
+        _expect(readiness_every >= 0, f"Stage '{stage.get('name')}' has invalid readiness_check_every_cycles={readiness_every}.")
+
+    budgets = profile.get("budgets")
+    _expect(isinstance(budgets, dict), "Profile field 'budgets' must be an object.")
+    _expect(float(budgets.get("max_p95_latency_ms") or 0) > 0, "Budget 'max_p95_latency_ms' must be > 0.")
+    _expect(float(budgets.get("max_p99_latency_ms") or 0) > 0, "Budget 'max_p99_latency_ms' must be > 0.")
+    _expect(float(budgets.get("max_max_latency_ms") or 0) > 0, "Budget 'max_max_latency_ms' must be > 0.")
+    _expect(
+        float(budgets.get("max_http_429_rate_percent") or -1) >= 0,
+        "Budget 'max_http_429_rate_percent' must be >= 0.",
+    )
+    _expect(float(budgets.get("max_error_rate_percent") or -1) >= 0, "Budget 'max_error_rate_percent' must be >= 0.")
+    _expect(int(budgets.get("min_total_requests") or 0) > 0, "Budget 'min_total_requests' must be > 0.")
+
+
+def _wait_for_runs_terminal(client: TestClient, run_ids: list[str], timeout_seconds: float) -> None:
+    if not run_ids:
+        return
+    deadline = time.time() + max(1.0, float(timeout_seconds))
+    pending = set(run_ids)
+    while time.time() < deadline and pending:
+        finished: list[str] = []
+        for run_id in list(pending):
+            response = client.get(f"/workflows/runs/{run_id}")
+            if response.status_code != 200:
+                continue
+            status = str(response.json().get("run", {}).get("status") or "")
+            if status in TERMINAL_RUN_STATES:
+                finished.append(run_id)
+        for run_id in finished:
+            pending.discard(run_id)
+        if pending:
+            time.sleep(0.05)
+    _expect(not pending, f"Workflow runs did not reach terminal state: {sorted(pending)}")
+
+
+def _drain_consumer_until_empty(
+    client: TestClient,
+    *,
+    consumer_id: str,
+    drain_batch_size: int,
+    timeout_seconds: float,
+) -> int:
+    processed_total = 0
+    deadline = time.time() + max(1.0, float(timeout_seconds))
+    while time.time() < deadline:
+        snapshot = client.get("/system/backpressure")
+        _expect(snapshot.status_code == 200, f"/system/backpressure failed: {snapshot.text}")
+        pending = int(snapshot.json().get("pending_events") or 0)
+        if pending == 0:
+            return processed_total
+        drained = client.post(
+            f"/system/consumers/{consumer_id}/drain",
+            params={"batch_size": int(drain_batch_size)},
+        )
+        _expect(drained.status_code == 200, f"Consumer drain failed: {drained.text}")
+        processed_total += int(drained.json().get("processed_count") or 0)
+        time.sleep(0.02)
+    raise RuntimeError("Timed out while draining event backlog to zero.")
+
+
+def _compute_rate_percent(*, count: int, total: int) -> float:
+    if total <= 0:
+        return 0.0
+    return (float(count) / float(total)) * 100.0
+
+
+def run_check(
+    *,
+    label: str,
+    deployment_profile: str,
+    profile_file: Path,
+    profile_name: str,
+    profile_version: str,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    profile_mode = str(deployment_profile).strip().lower() or "production"
+
+    catalog = _read_json_file(profile_file)
+    catalog_version = str(catalog.get("catalog_version") or "")
+    _expect(bool(catalog_version.strip()), "Catalog field 'catalog_version' is required.")
+
+    selected_profile = _find_profile(
+        catalog,
+        profile_name=profile_name,
+        profile_version=profile_version,
+    )
+    _validate_profile_shape(selected_profile)
+
+    stages = list(selected_profile["stages"])
+    budgets = dict(selected_profile["budgets"])
+
+    app = create_app(
+        Settings(
+            database_url=":memory:",
+            workflow_worker_poll_interval_seconds=0.02,
+            workflow_run_timeout_seconds=120,
+        )
+    )
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        consumer_id = str(client.app.state.services.settings.consumer_id)
+        latencies_ms: list[float] = []
+        statuses = Counter()
+        run_ids: list[str] = []
+        transient_retry_count = 0
+        stage_summaries: list[dict[str, Any]] = []
+        cycle_counter = 0
+
+        def _request(method: str, url: str, **kwargs):
+            started_at = time.perf_counter()
+            response = client.request(method, url, **kwargs)
+            latencies_ms.append((time.perf_counter() - started_at) * 1000.0)
+            statuses[response.status_code] += 1
+            return response
+
+        def _request_expect(
+            method: str,
+            url: str,
+            expected_status: int,
+            *,
+            max_retries: int = 8,
+            **kwargs,
+        ):
+            nonlocal transient_retry_count
+            attempt = 0
+            last_response = None
+            while attempt <= max_retries:
+                response = _request(method, url, **kwargs)
+                last_response = response
+                if response.status_code == expected_status:
+                    return response
+                if response.status_code >= 500:
+                    transient_retry_count += 1
+                    attempt += 1
+                    time.sleep(min(0.2, 0.02 * attempt))
+                    continue
+                break
+            _expect(
+                False,
+                (
+                    f"Request failed for {method} {url}. "
+                    f"expected={expected_status} observed={last_response.status_code if last_response else 'none'} "
+                    f"body={last_response.text if last_response is not None else '<none>'}"
+                ),
+            )
+            return last_response
+
+        for stage in stages:
+            stage_name = str(stage.get("name") or "").strip()
+            stage_cycles = int(stage.get("cycles") or 0)
+            stage_workflow_every = int(stage.get("workflow_start_every_cycles") or 0)
+            stage_drain_batch_size = int(stage.get("drain_batch_size") or 0)
+            stage_readiness_every = int(stage.get("readiness_check_every_cycles") or 0)
+
+            stage_statuses = Counter()
+            stage_latencies: list[float] = []
+            stage_start = time.perf_counter()
+
+            def _request_stage(method: str, url: str, **kwargs):
+                response = _request(method, url, **kwargs)
+                stage_statuses[response.status_code] += 1
+                if latencies_ms:
+                    stage_latencies.append(latencies_ms[-1])
+                return response
+
+            def _request_expect_stage(
+                method: str,
+                url: str,
+                expected_status: int,
+                *,
+                max_retries: int = 8,
+                **kwargs,
+            ):
+                nonlocal transient_retry_count
+                attempt = 0
+                last_response = None
+                while attempt <= max_retries:
+                    response = _request_stage(method, url, **kwargs)
+                    last_response = response
+                    if response.status_code == expected_status:
+                        return response
+                    if response.status_code >= 500:
+                        transient_retry_count += 1
+                        attempt += 1
+                        time.sleep(min(0.2, 0.02 * attempt))
+                        continue
+                    break
+                _expect(
+                    False,
+                    (
+                        f"Stage request failed ({stage_name}) for {method} {url}. "
+                        f"expected={expected_status} "
+                        f"observed={last_response.status_code if last_response else 'none'} "
+                        f"body={last_response.text if last_response is not None else '<none>'}"
+                    ),
+                )
+                return last_response
+
+            for stage_cycle in range(1, stage_cycles + 1):
+                cycle_counter += 1
+                created = _request_expect_stage(
+                    "POST",
+                    "/goals",
+                    201,
+                    json={
+                        "title": f"Load profile goal {stage_name} #{stage_cycle}",
+                        "description": "prod-like load profile framework",
+                        "urgency": 0.58,
+                        "value": 0.62,
+                        "deadline_score": 0.34,
+                    },
+                )
+                goal_id = str(created.json()["goal_id"])
+
+                _request_expect_stage("POST", f"/goals/{goal_id}/activate", 200)
+
+                task = _request_expect_stage(
+                    "POST",
+                    "/tasks",
+                    201,
+                    json={"goal_id": goal_id, "title": f"Load profile task {stage_name} #{stage_cycle}"},
+                )
+                task_id = str(task.json()["task_id"])
+                _request_expect_stage("POST", f"/tasks/{task_id}/success", 200)
+
+                _request_expect_stage("POST", f"/goals/{goal_id}/block", 200)
+                _request_expect_stage("POST", f"/goals/{goal_id}/archive", 200)
+
+                if stage_workflow_every > 0 and stage_cycle % stage_workflow_every == 0:
+                    started_run = _request_expect_stage(
+                        "POST",
+                        "/workflows/maintenance.retention_cleanup/start",
+                        201,
+                        json={"requested_by": "load-profile-framework", "payload": {"stage": stage_name, "cycle": stage_cycle}},
+                    )
+                    run_ids.append(str(started_run.json().get("run", {}).get("run_id") or ""))
+                    run_ids = [item for item in run_ids if item]
+                    if len(run_ids) > 100:
+                        run_ids = run_ids[-100:]
+
+                _request_expect_stage(
+                    "POST",
+                    f"/system/consumers/{consumer_id}/drain",
+                    200,
+                    params={"batch_size": int(stage_drain_batch_size)},
+                )
+
+                if stage_readiness_every > 0 and stage_cycle % stage_readiness_every == 0:
+                    readiness = _request_stage("GET", "/system/readiness")
+                    _expect(readiness.status_code == 200, f"Readiness check failed in stage {stage_name}: {readiness.text}")
+                    _expect(bool(readiness.json().get("ready")), f"Readiness became false in stage {stage_name}: {readiness.text}")
+                    slo = _request_stage("GET", "/system/slo")
+                    _expect(slo.status_code == 200, f"SLO check failed in stage {stage_name}: {slo.text}")
+                    _expect(str(slo.json().get("status")) == "ok", f"SLO became non-ok in stage {stage_name}: {slo.text}")
+
+            stage_requests_total = int(sum(stage_statuses.values()))
+            stage_summary = {
+                "name": stage_name,
+                "cycles": stage_cycles,
+                "requests_total": stage_requests_total,
+                "status_counts": {str(code): int(count) for code, count in sorted(stage_statuses.items())},
+                "duration_ms": int((time.perf_counter() - stage_start) * 1000),
+                "latency_ms": {
+                    "p95": round(_percentile(stage_latencies, 95.0), 3) if stage_latencies else 0.0,
+                    "p99": round(_percentile(stage_latencies, 99.0), 3) if stage_latencies else 0.0,
+                    "max": round(max(stage_latencies), 3) if stage_latencies else 0.0,
+                },
+            }
+            stage_summaries.append(stage_summary)
+
+        _wait_for_runs_terminal(client, run_ids, timeout_seconds=30.0)
+        drained_after = _drain_consumer_until_empty(
+            client,
+            consumer_id=consumer_id,
+            drain_batch_size=max(1, int(stages[-1].get("drain_batch_size") or 100)),
+            timeout_seconds=20.0,
+        )
+
+        readiness_final = _request("GET", "/system/readiness")
+        slo_final = _request("GET", "/system/slo")
+        health_final = _request("GET", "/system/health")
+        _expect(readiness_final.status_code == 200, f"Final readiness failed: {readiness_final.text}")
+        _expect(slo_final.status_code == 200, f"Final SLO failed: {slo_final.text}")
+        _expect(health_final.status_code == 200, f"Final health failed: {health_final.text}")
+
+        readiness_payload = readiness_final.json()
+        slo_payload = slo_final.json()
+        health_payload = health_final.json()
+
+        worker_status = dict(readiness_payload.get("checks", {}).get("workflow_worker", {}) or {})
+        queued_runs = int(worker_status.get("queued_runs") or 0)
+        running_runs = int(worker_status.get("running_runs") or 0)
+        invariant_violations = list(health_payload.get("invariant_violations") or [])
+
+        total_requests = int(sum(statuses.values()))
+        http_429_count = int(statuses.get(429, 0))
+        error_count = int(sum(count for code, count in statuses.items() if int(code) >= 500))
+        http_429_rate_percent = _compute_rate_percent(count=http_429_count, total=total_requests)
+        error_rate_percent = _compute_rate_percent(count=error_count, total=total_requests)
+
+        _expect(total_requests > 0, "No requests were executed by selected load profile.")
+        _expect(latencies_ms, "No latency samples were collected by selected load profile.")
+
+        p95_latency_ms = _percentile(latencies_ms, 95.0)
+        p99_latency_ms = _percentile(latencies_ms, 99.0)
+        max_latency_ms = max(latencies_ms)
+
+    criteria: list[dict[str, Any]] = []
+
+    def add(name: str, passed: bool, details: str) -> None:
+        criteria.append({"name": name, "passed": bool(passed), "details": details})
+
+    add("catalog_version_present", bool(catalog_version.strip()), f"catalog_version={catalog_version!r}")
+    add(
+        "profile_selected",
+        bool(str(selected_profile.get("name") or "").strip()) and bool(str(selected_profile.get("version") or "").strip()),
+        f"profile_name={selected_profile.get('name')!r}, profile_version={selected_profile.get('version')!r}",
+    )
+    add("stage_count_non_zero", len(stage_summaries) > 0, f"stage_count={len(stage_summaries)}")
+
+    if profile_mode == "production":
+        add(
+            "min_total_requests",
+            total_requests >= int(budgets["min_total_requests"]),
+            f"requests_total={total_requests}, min_required={int(budgets['min_total_requests'])}",
+        )
+        add(
+            "p95_latency_budget",
+            p95_latency_ms <= float(budgets["max_p95_latency_ms"]),
+            f"p95_latency_ms={p95_latency_ms:.3f}, max={float(budgets['max_p95_latency_ms']):.3f}",
+        )
+        add(
+            "p99_latency_budget",
+            p99_latency_ms <= float(budgets["max_p99_latency_ms"]),
+            f"p99_latency_ms={p99_latency_ms:.3f}, max={float(budgets['max_p99_latency_ms']):.3f}",
+        )
+        add(
+            "max_latency_budget",
+            max_latency_ms <= float(budgets["max_max_latency_ms"]),
+            f"max_latency_ms={max_latency_ms:.3f}, max={float(budgets['max_max_latency_ms']):.3f}",
+        )
+        add(
+            "http_429_budget",
+            http_429_rate_percent <= float(budgets["max_http_429_rate_percent"]),
+            f"http_429_rate_percent={http_429_rate_percent:.4f}, max={float(budgets['max_http_429_rate_percent']):.4f}",
+        )
+        add(
+            "error_rate_budget",
+            error_rate_percent <= float(budgets["max_error_rate_percent"]),
+            f"error_rate_percent={error_rate_percent:.4f}, max={float(budgets['max_error_rate_percent']):.4f}",
+        )
+        add("final_readiness_true", bool(readiness_payload.get("ready")), f"ready={bool(readiness_payload.get('ready'))}")
+        add("final_slo_ok", str(slo_payload.get("status") or "") == "ok", f"slo_status={slo_payload.get('status')!r}")
+        add(
+            "workflow_queue_drained",
+            queued_runs == 0 and running_runs == 0,
+            f"queued_runs={queued_runs}, running_runs={running_runs}",
+        )
+        add(
+            "invariant_violations_absent",
+            len(invariant_violations) == 0,
+            f"invariant_violations={len(invariant_violations)}",
+        )
+    else:
+        add("non_production_profile", True, f"deployment_profile={profile_mode!r} (hard requirements skipped)")
+
+    failed_criteria = [item for item in criteria if item["passed"] is False]
+    success = len(failed_criteria) == 0
+
+    report = {
+        "label": label,
+        "success": bool(success),
+        "config": {
+            "deployment_profile": profile_mode,
+            "profile_file": str(profile_file),
+            "profile_name": str(profile_name),
+            "profile_version": str(profile_version),
+        },
+        "profile": {
+            "catalog_version": catalog_version,
+            "name": str(selected_profile.get("name") or ""),
+            "version": str(selected_profile.get("version") or ""),
+            "description": str(selected_profile.get("description") or ""),
+            "budgets": budgets,
+        },
+        "metrics": {
+            "criteria_total": len(criteria),
+            "criteria_passed": len(criteria) - len(failed_criteria),
+            "criteria_failed": len(failed_criteria),
+            "stages_executed": len(stage_summaries),
+            "cycles_executed": cycle_counter,
+            "requests_total": total_requests,
+            "workflow_runs_started": len(run_ids),
+            "transient_retry_count": transient_retry_count,
+            "drained_after_loop": drained_after,
+            "latency_ms": {
+                "p50": round(_percentile(latencies_ms, 50.0), 3),
+                "p95": round(p95_latency_ms, 3),
+                "p99": round(p99_latency_ms, 3),
+                "max": round(max_latency_ms, 3),
+            },
+            "observed_rates_percent": {
+                "http_429_rate": round(http_429_rate_percent, 4),
+                "error_rate": round(error_rate_percent, 4),
+            },
+            "status_counts": {str(code): int(count) for code, count in sorted(statuses.items())},
+            "final": {
+                "readiness_ready": bool(readiness_payload.get("ready")),
+                "slo_status": str(slo_payload.get("status") or ""),
+                "queued_runs": queued_runs,
+                "running_runs": running_runs,
+                "invariant_violations": len(invariant_violations),
+            },
+        },
+        "stage_summaries": stage_summaries,
+        "criteria": criteria,
+        "failed_criteria": failed_criteria,
+        "generated_at_utc": _utc_now(),
+        "duration_ms": int((time.perf_counter() - started) * 1000),
+    }
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run versioned prod-like load profile framework checks and enforce deterministic latency/error budgets."
+        )
+    )
+    parser.add_argument("--label", default="load-profile-framework-check")
+    parser.add_argument("--deployment-profile", default="production")
+    parser.add_argument("--profile-file", default="docs/load-profile-catalog.json")
+    parser.add_argument("--profile-name", default="prod_like_ci_smoke")
+    parser.add_argument("--profile-version", default="1.0.0")
+    parser.add_argument("--output-file")
+    parser.add_argument("--allow-failure", action="store_true")
+    args = parser.parse_args(argv)
+
+    project_root = Path(__file__).resolve().parents[1]
+    profile_file = Path(str(args.profile_file)).expanduser()
+    if not profile_file.is_absolute():
+        profile_file = (project_root / profile_file).resolve()
+
+    try:
+        report = run_check(
+            label=str(args.label),
+            deployment_profile=str(args.deployment_profile),
+            profile_file=profile_file,
+            profile_name=str(args.profile_name),
+            profile_version=str(args.profile_version),
+        )
+    except Exception as exc:
+        print(f"[load-profile-framework-check] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output_file:
+        output_file = Path(str(args.output_file)).expanduser()
+        if not output_file.is_absolute():
+            output_file = (project_root / output_file).resolve()
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2), encoding="utf-8")
+
+    if report["success"] is False and not bool(args.allow_failure):
+        print(f"[load-profile-framework-check] ERROR: {json.dumps(report, sort_keys=True)}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/p0-runbook-contract-check.py
+++ b/scripts/p0-runbook-contract-check.py
@@ -15,6 +15,7 @@ DEFAULT_REQUIRED_RUNBOOK_SCRIPTS = [
     "run-security-ci-lane-check.ps1",
     "run-alert-routing-oncall-check.ps1",
     "run-incident-drill-automation-check.ps1",
+    "run-load-profile-framework-check.ps1",
     "run-power-loss-durability-drill.ps1",
     "run-disk-pressure-fault-injection-drill.ps1",
     "run-upgrade-downgrade-compatibility-drill.ps1",

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -14,6 +14,8 @@ param(
     [switch]$StrictAlertRoutingOnCallCheck,
     [switch]$SkipIncidentDrillAutomationCheck,
     [switch]$StrictIncidentDrillAutomationCheck,
+    [switch]$SkipLoadProfileFrameworkCheck,
+    [switch]$StrictLoadProfileFrameworkCheck,
     [switch]$SkipReleaseFreezePolicyDrill,
     [switch]$StrictReleaseFreezePolicyDrill,
     [switch]$SkipFileDatabaseProbe,
@@ -291,6 +293,31 @@ if (-not $SkipIncidentDrillAutomationCheck) {
             }
             Write-Warning (
                 "Incident drill automation check failed but StrictIncidentDrillAutomationCheck is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipLoadProfileFrameworkCheck) {
+    Invoke-GateStep -Name "Load profile framework check (versioned prod-like load profile budgets)" -Action {
+        $reportPath = Join-Path $ProjectRoot "artifacts\load-profile-framework-release-gate.json"
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\load-profile-framework-check.py",
+                "--label", "release-gate",
+                "--deployment-profile", "production",
+                "--profile-file", "docs/load-profile-catalog.json",
+                "--profile-name", "prod_like_ci_smoke",
+                "--profile-version", "1.0.0",
+                "--output-file", $reportPath
+            )
+        } catch {
+            if ($StrictLoadProfileFrameworkCheck) {
+                throw
+            }
+            Write-Warning (
+                "Load profile framework check failed but StrictLoadProfileFrameworkCheck is off. " +
                 "Continuing. Error: $($_.Exception.Message)"
             )
         }

--- a/scripts/run-load-profile-framework-check.ps1
+++ b/scripts/run-load-profile-framework-check.ps1
@@ -1,0 +1,34 @@
+param(
+    [string]$PythonExe = "python",
+    [string]$DeploymentProfile = "production",
+    [string]$ProfileFile = "docs\load-profile-catalog.json",
+    [string]$ProfileName = "prod_like_ci_smoke",
+    [string]$ProfileVersion = "1.0.0",
+    [string]$OutputFile = "artifacts\load-profile-framework-check-report.json",
+    [switch]$AllowFailure
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$arguments = @(
+    ".\scripts\load-profile-framework-check.py",
+    "--label", "manual",
+    "--deployment-profile", $DeploymentProfile,
+    "--profile-file", $ProfileFile,
+    "--profile-name", $ProfileName,
+    "--profile-version", $ProfileVersion,
+    "--output-file", $OutputFile
+)
+if ($AllowFailure) {
+    $arguments += "--allow-failure"
+}
+
+& $PythonExe @arguments
+if ($LASTEXITCODE -ne 0) {
+    throw "Load profile framework check failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Load profile framework check passed." -ForegroundColor Green

--- a/scripts/run-p0-runbook-contract-check.ps1
+++ b/scripts/run-p0-runbook-contract-check.ps1
@@ -1,7 +1,7 @@
 param(
     [string]$PythonExe = "python",
     [string]$OutputFile = "artifacts\\p0-runbook-contract-check-report.json",
-    [string]$RequiredRunbookScripts = "run-security-config-hardening-check.ps1,run-audit-trail-hardening-check.ps1,run-security-ci-lane-check.ps1,run-alert-routing-oncall-check.ps1,run-incident-drill-automation-check.ps1,run-power-loss-durability-drill.ps1,run-disk-pressure-fault-injection-drill.ps1,run-upgrade-downgrade-compatibility-drill.ps1,run-backup-restore-stress-drill.ps1,run-release-gate-runtime-stability-drill.ps1,run-p0-burnin-consecutive-green.ps1,run-p0-release-evidence-bundle.ps1,run-p0-closure-report.ps1",
+    [string]$RequiredRunbookScripts = "run-security-config-hardening-check.ps1,run-audit-trail-hardening-check.ps1,run-security-ci-lane-check.ps1,run-alert-routing-oncall-check.ps1,run-incident-drill-automation-check.ps1,run-load-profile-framework-check.ps1,run-power-loss-durability-drill.ps1,run-disk-pressure-fault-injection-drill.ps1,run-upgrade-downgrade-compatibility-drill.ps1,run-backup-restore-stress-drill.ps1,run-release-gate-runtime-stability-drill.ps1,run-p0-burnin-consecutive-green.ps1,run-p0-release-evidence-bundle.ps1,run-p0-closure-report.ps1",
     [string]$RequiredStrictFlags = ""
 )
 

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -4159,3 +4159,162 @@ def test_131_incident_drill_automation_check_fails_when_technical_drill_is_stale
     )
 
     shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_132_load_profile_framework_check_reports_success_with_fixture_profile():
+    workspace = _local_test_dir("pytest-load-profile-framework-check-success").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    profile_file = workspace / "load-profile-catalog.json"
+    output_file = workspace / "load-profile-framework-report.json"
+
+    profile_file.write_text(
+        json.dumps(
+            {
+                "catalog_version": "pytest.stage-c.1",
+                "profiles": [
+                    {
+                        "name": "pytest_smoke",
+                        "version": "1.0.0",
+                        "description": "pytest profile",
+                        "stages": [
+                            {
+                                "name": "steady",
+                                "cycles": 4,
+                                "workflow_start_every_cycles": 0,
+                                "drain_batch_size": 50,
+                                "readiness_check_every_cycles": 2,
+                            },
+                            {
+                                "name": "burst",
+                                "cycles": 6,
+                                "workflow_start_every_cycles": 3,
+                                "drain_batch_size": 80,
+                                "readiness_check_every_cycles": 2,
+                            },
+                        ],
+                        "budgets": {
+                            "max_p95_latency_ms": 5000.0,
+                            "max_p99_latency_ms": 6000.0,
+                            "max_max_latency_ms": 12000.0,
+                            "max_http_429_rate_percent": 50.0,
+                            "max_error_rate_percent": 10.0,
+                            "min_total_requests": 40,
+                        },
+                    }
+                ],
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "load-profile-framework-check.py"),
+        "--label",
+        "pytest-drill",
+        "--deployment-profile",
+        "production",
+        "--profile-file",
+        str(profile_file.resolve()),
+        "--profile-name",
+        "pytest_smoke",
+        "--profile-version",
+        "1.0.0",
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["metrics"]["criteria_failed"] == 0
+    assert payload["metrics"]["requests_total"] >= 40
+    assert payload["profile"]["name"] == "pytest_smoke"
+    assert output_file.exists()
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_133_load_profile_framework_check_fails_when_min_requests_budget_is_unmet():
+    workspace = _local_test_dir("pytest-load-profile-framework-check-failure").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    profile_file = workspace / "load-profile-catalog.json"
+    output_file = workspace / "load-profile-framework-report.json"
+
+    profile_file.write_text(
+        json.dumps(
+            {
+                "catalog_version": "pytest.stage-c.1",
+                "profiles": [
+                    {
+                        "name": "pytest_strict",
+                        "version": "1.0.0",
+                        "description": "pytest strict profile",
+                        "stages": [
+                            {
+                                "name": "steady",
+                                "cycles": 3,
+                                "workflow_start_every_cycles": 0,
+                                "drain_batch_size": 50,
+                                "readiness_check_every_cycles": 0,
+                            }
+                        ],
+                        "budgets": {
+                            "max_p95_latency_ms": 5000.0,
+                            "max_p99_latency_ms": 6000.0,
+                            "max_max_latency_ms": 12000.0,
+                            "max_http_429_rate_percent": 50.0,
+                            "max_error_rate_percent": 10.0,
+                            "min_total_requests": 2000,
+                        },
+                    }
+                ],
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "load-profile-framework-check.py"),
+        "--label",
+        "pytest-drill",
+        "--deployment-profile",
+        "production",
+        "--profile-file",
+        str(profile_file.resolve()),
+        "--profile-name",
+        "pytest_strict",
+        "--profile-version",
+        "1.0.0",
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "[load-profile-framework-check] ERROR: "
+    assert marker in completed.stderr
+    payload = json.loads(completed.stderr.split(marker, 1)[1].strip())
+    assert payload["success"] is False
+    assert payload["metrics"]["criteria_failed"] >= 1
+    assert any(
+        str(item.get("name") or "") == "min_total_requests"
+        for item in payload.get("failed_criteria", [])
+        if isinstance(item, dict)
+    )
+
+    shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
## Summary
- add Stage-C load profile framework check with versioned profile selection (name+version)
- add versioned load profile catalog for CI smoke and release baseline traffic shapes
- integrate strict/skip release-gate and CI artifact export for load profile evidence
- update runbook contract defaults, README/runbook commands, and add execution + failure tests

## Testing
- python -m py_compile scripts/load-profile-framework-check.py scripts/p0-runbook-contract-check.py tests/test_goal_ops.py
- python -m pytest -q tests/test_goal_ops.py -k "test_112_p0_runbook_contract_check_reports_success or test_130_incident_drill_automation_check_reports_success_with_mock_data or test_131_incident_drill_automation_check_fails_when_technical_drill_is_stale or test_132_load_profile_framework_check_reports_success_with_fixture_profile or test_133_load_profile_framework_check_fails_when_min_requests_budget_is_unmet"
- ./scripts/run-load-profile-framework-check.ps1 -ProfileFile docs/load-profile-catalog.json -ProfileName prod_like_ci_smoke -ProfileVersion 1.0.0
- ./scripts/run-p0-runbook-contract-check.ps1
- release-gate targeted smoke (all Skip* enabled except load profile framework step, strict mode enabled)
