### PR TITLE
[codex] Add stage-C RTO/RPO assertion suite gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          .\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictIncidentDrillAutomationCheck -StrictLoadProfileFrameworkCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+          .\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictIncidentDrillAutomationCheck -StrictLoadProfileFrameworkCheck -StrictRtoRpoAssertionCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 
       - name: Upload release evidence artifacts
         uses: actions/upload-artifact@v4
@@ -58,6 +58,7 @@ jobs:
             artifacts/alert-routing-oncall-release-gate.json
             artifacts/incident-drill-automation-release-gate.json
             artifacts/load-profile-framework-release-gate.json
+            artifacts/rto-rpo-assertion-release-gate.json
           if-no-files-found: error
 
   security-ci-lane:

--- a/README.md
+++ b/README.md
@@ -411,11 +411,11 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + security config hardening check + audit trail hardening check + security CI lane check + alert-routing/on-call runbook automation check + incident drill automation check + load profile framework check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle + P0 closure go/no-go report):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + security config hardening check + audit trail hardening check + security CI lane check + alert-routing/on-call runbook automation check + incident drill automation check + load profile framework check + RTO/RPO assertion suite check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle + P0 closure go/no-go report):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictIncidentDrillAutomationCheck -StrictLoadProfileFrameworkCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictIncidentDrillAutomationCheck -StrictLoadProfileFrameworkCheck -StrictRtoRpoAssertionCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 ```
 
 Standalone backup/restore drill:
@@ -507,6 +507,13 @@ Standalone load profile framework check:
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-load-profile-framework-check.ps1 -ProfileFile "docs\load-profile-catalog.json" -ProfileName "prod_like_ci_smoke" -ProfileVersion "1.0.0"
+```
+
+Standalone RTO/RPO assertion suite:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-rto-rpo-assertion-suite.ps1 -PolicyFile "docs\rto-rpo-assertion-policy.json" -SeedRows 48 -TailWriteRows 12 -MaxRtoSeconds 20 -MaxRpoRowsLost 96
 ```
 
 Standalone release-freeze policy check (live service):
@@ -980,5 +987,8 @@ If a value is rejected:
 - [load-profile-framework-check.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/load-profile-framework-check.py)
 - [run-load-profile-framework-check.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-load-profile-framework-check.ps1)
 - [load-profile-catalog.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/load-profile-catalog.json)
+- [rto-rpo-assertion-suite.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/rto-rpo-assertion-suite.py)
+- [run-rto-rpo-assertion-suite.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-rto-rpo-assertion-suite.ps1)
+- [rto-rpo-assertion-policy.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/rto-rpo-assertion-policy.json)
 - [test_goal_ops.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_goal_ops.py)
 - [test_desktop_launcher.py](/C:/Users/raffa/OneDrive/Documents/New%20project/tests/test_desktop_launcher.py)

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -9,7 +9,7 @@ This runbook is optimized for reliability-first releases of the desktop app and 
 Run in repo root:
 
 ```powershell
-.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictIncidentDrillAutomationCheck -StrictLoadProfileFrameworkCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictIncidentDrillAutomationCheck -StrictLoadProfileFrameworkCheck -StrictRtoRpoAssertionCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 ```
 
 This gate covers:
@@ -23,6 +23,7 @@ This gate covers:
 - alert-routing/on-call check (severity route policy, escalation SLA budgets, and runbook-section references)
 - incident drill automation check (tabletop + technical drill cadence, evidence completeness, and follow-up budget)
 - load profile framework check (versioned production-like traffic profile with deterministic latency/error budgets)
+- RTO/RPO assertion suite (restore duration budgets plus bounded data-loss budget assertions)
 - release-freeze policy drill (sustained non-ok window or burn-rate spike freezes ring promotion path)
 - auto-rollback-policy drill (`critical` sustained window triggers stable ring rollback path)
 - desktop-update-safety drill (hash validation + rollback-to-stable fallback path)
@@ -110,6 +111,12 @@ Manual load profile framework invocation:
 
 ```powershell
 .\scripts\run-load-profile-framework-check.ps1 -ProfileFile "docs\load-profile-catalog.json" -ProfileName "prod_like_ci_smoke" -ProfileVersion "1.0.0"
+```
+
+Manual RTO/RPO assertion suite invocation:
+
+```powershell
+.\scripts\run-rto-rpo-assertion-suite.ps1 -PolicyFile "docs\rto-rpo-assertion-policy.json" -SeedRows 48 -TailWriteRows 12 -MaxRtoSeconds 20 -MaxRpoRowsLost 96
 ```
 
 Manual release-freeze policy invocation (live endpoint, stable ring):
@@ -955,6 +962,39 @@ Actions:
 2. Add/retain explicit `name` + `version` for each profile and run checks with pinned values (`--profile-name`, `--profile-version`).
 3. For major profile updates, run both old and new versions once in rehearsal, compare deltas, then switch release gate default.
 4. Record selected profile/version in release notes for auditability and rollback analysis.
+
+### 3.33 RTO zero-loss restore assertion
+
+Symptoms:
+- restore path was not validated recently for strict recovery-time objective on full-state backup
+- operators need deterministic proof that zero-loss restore remains within release budget
+
+Actions:
+1. Execute RTO/RPO suite with default policy:
+   ```powershell
+   .\scripts\run-rto-rpo-assertion-suite.ps1 -PolicyFile "docs\rto-rpo-assertion-policy.json" -SeedRows 48 -TailWriteRows 12 -MaxRtoSeconds 20 -MaxRpoRowsLost 96
+   ```
+2. Validate `restore.zero_loss` criteria:
+   - `zero_loss_restore_matches_source = true`
+   - `zero_loss_rows_lost_zero = true`
+   - `zero_loss_rto_budget = true`
+3. Confirm runtime probe remains healthy (`readiness=true`, `slo=ok`, integrity endpoint ok) on restored DB.
+4. If RTO budget fails, hold release and optimize restore chain before re-running gate.
+
+### 3.34 RPO bounded-loss assertion
+
+Symptoms:
+- backup cutoff points might allow excessive data loss after incident rollback/restore
+- no current evidence that RPO remains within agreed bounded-loss budget
+
+Actions:
+1. Run the same suite and inspect `restore.bounded_loss` scenario output.
+2. Validate RPO constraints:
+   - `bounded_loss_restore_matches_backup_point = true`
+   - `bounded_loss_rpo_budget = true` (rows lost <= policy max)
+   - `bounded_loss_rto_budget = true`
+3. Track `bounded_rows_lost` trend over releases; investigate increases even if still within budget.
+4. If bounded-loss budget is exceeded, freeze promotion and open incident with report JSON attached.
 
 ## 4. Operational Defaults
 

--- a/docs/rto-rpo-assertion-policy.json
+++ b/docs/rto-rpo-assertion-policy.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.0.0",
+  "max_rto_seconds": 20.0,
+  "max_rpo_rows_lost": 96,
+  "scenarios": [
+    {
+      "id": "restore.zero_loss",
+      "runbook_section": "### 3.33 RTO zero-loss restore assertion"
+    },
+    {
+      "id": "restore.bounded_loss",
+      "runbook_section": "### 3.34 RPO bounded-loss assertion"
+    }
+  ]
+}

--- a/scripts/p0-runbook-contract-check.py
+++ b/scripts/p0-runbook-contract-check.py
@@ -16,6 +16,7 @@ DEFAULT_REQUIRED_RUNBOOK_SCRIPTS = [
     "run-alert-routing-oncall-check.ps1",
     "run-incident-drill-automation-check.ps1",
     "run-load-profile-framework-check.ps1",
+    "run-rto-rpo-assertion-suite.ps1",
     "run-power-loss-durability-drill.ps1",
     "run-disk-pressure-fault-injection-drill.ps1",
     "run-upgrade-downgrade-compatibility-drill.ps1",

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -16,6 +16,8 @@ param(
     [switch]$StrictIncidentDrillAutomationCheck,
     [switch]$SkipLoadProfileFrameworkCheck,
     [switch]$StrictLoadProfileFrameworkCheck,
+    [switch]$SkipRtoRpoAssertionCheck,
+    [switch]$StrictRtoRpoAssertionCheck,
     [switch]$SkipReleaseFreezePolicyDrill,
     [switch]$StrictReleaseFreezePolicyDrill,
     [switch]$SkipFileDatabaseProbe,
@@ -902,6 +904,36 @@ if (-not $SkipBackupRestoreStressDrill) {
             }
             Write-Warning (
                 "Backup/restore stress drill failed but StrictBackupRestoreStressDrill is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipRtoRpoAssertionCheck) {
+    Invoke-GateStep -Name "RTO/RPO assertion suite (restore-time and bounded data-loss budgets)" -Action {
+        $workspace = Join-Path $ProjectRoot ".tmp\rto-rpo-assertion-suite"
+        $reportPath = Join-Path $ProjectRoot "artifacts\rto-rpo-assertion-release-gate.json"
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\rto-rpo-assertion-suite.py",
+                "--workspace", $workspace,
+                "--label", "release-gate",
+                "--deployment-profile", "production",
+                "--policy-file", "docs/rto-rpo-assertion-policy.json",
+                "--runbook-file", "docs/production-runbook.md",
+                "--seed-rows", "48",
+                "--tail-write-rows", "12",
+                "--max-rto-seconds", "20",
+                "--max-rpo-rows-lost", "96",
+                "--output-file", $reportPath
+            )
+        } catch {
+            if ($StrictRtoRpoAssertionCheck) {
+                throw
+            }
+            Write-Warning (
+                "RTO/RPO assertion suite failed but StrictRtoRpoAssertionCheck is off. " +
                 "Continuing. Error: $($_.Exception.Message)"
             )
         }

--- a/scripts/rto-rpo-assertion-suite.py
+++ b/scripts/rto-rpo-assertion-suite.py
@@ -1,0 +1,595 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from goal_ops_console.config import Settings
+from goal_ops_console.database import Database, new_id, now_utc
+from goal_ops_console.main import create_app
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _quoted_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(path), check_same_thread=False, isolation_level=None)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _read_json_file(path: Path) -> dict[str, Any]:
+    _expect(path.exists(), f"Required file not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    _expect(isinstance(payload, dict), f"Expected JSON object in {path}")
+    return payload
+
+
+def _integrity_report(conn: sqlite3.Connection) -> dict[str, Any]:
+    quick_rows = [str(row[0]) for row in conn.execute("PRAGMA quick_check").fetchall()]
+    full_rows = [str(row[0]) for row in conn.execute("PRAGMA integrity_check").fetchall()]
+    quick_ok = len(quick_rows) == 1 and quick_rows[0].lower() == "ok"
+    full_ok = len(full_rows) == 1 and full_rows[0].lower() == "ok"
+    return {
+        "quick_ok": quick_ok,
+        "quick_result": "ok" if quick_ok else "; ".join(quick_rows) if quick_rows else "no result",
+        "full_ok": full_ok,
+        "full_result": "ok" if full_ok else "; ".join(full_rows) if full_rows else "no result",
+    }
+
+
+def _table_counts(conn: sqlite3.Connection) -> dict[str, int]:
+    table_rows = conn.execute(
+        """SELECT name
+           FROM sqlite_master
+           WHERE type = 'table'
+           AND name NOT LIKE 'sqlite_%'
+           ORDER BY name ASC"""
+    ).fetchall()
+    counts: dict[str, int] = {}
+    for row in table_rows:
+        table_name = str(row[0])
+        query = f"SELECT COUNT(*) FROM {_quoted_identifier(table_name)}"
+        counts[table_name] = int(conn.execute(query).fetchone()[0])
+    return counts
+
+
+def _total_rows(counts: dict[str, int]) -> int:
+    return int(sum(int(value) for value in counts.values()))
+
+
+def _snapshot(database_path: Path) -> dict[str, Any]:
+    conn = _connect(database_path)
+    try:
+        counts = _table_counts(conn)
+        integrity = _integrity_report(conn)
+    finally:
+        conn.close()
+    return {
+        "counts": counts,
+        "total_rows": _total_rows(counts),
+        "integrity": integrity,
+    }
+
+
+def _copy_database(source_path: Path, target_path: Path) -> None:
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    if target_path.exists():
+        target_path.unlink()
+    source_conn = _connect(source_path)
+    target_conn = _connect(target_path)
+    try:
+        source_conn.backup(target_conn)
+    finally:
+        target_conn.close()
+        source_conn.close()
+
+
+def _seed_rows(*, db_path: Path, row_count: int, phase: str, start_index: int) -> dict[str, int]:
+    db = Database(str(db_path))
+    db.initialize()
+
+    inserted = {
+        "goals": 0,
+        "goal_queue": 0,
+        "tasks": 0,
+        "task_state": 0,
+        "events": 0,
+        "workflow_runs": 0,
+    }
+
+    workflow_id = "drill.rto_rpo_assertion"
+    timestamp = now_utc()
+    db.execute(
+        """INSERT OR IGNORE INTO workflow_definitions
+           (workflow_id, name, description, entrypoint, is_enabled, version, created_at, updated_at)
+           VALUES (?, ?, ?, ?, 1, 1, ?, ?)""",
+        workflow_id,
+        "RTO/RPO Assertion Drill",
+        "Synthetic workflow rows for RTO/RPO assertion suite",
+        "maintenance.retention_cleanup",
+        timestamp,
+        timestamp,
+    )
+
+    for offset in range(max(0, int(row_count))):
+        index = int(start_index) + offset
+        ts = now_utc()
+        goal_id = new_id()
+        task_id = new_id()
+        event_id = new_id()
+        run_id = new_id()
+        correlation_id = f"{phase}:{goal_id}:{index}"
+
+        db.execute(
+            """INSERT INTO goals
+               (goal_id, title, description, state, blocked_reason, escalation_reason, version, created_at, updated_at)
+               VALUES (?, ?, ?, 'active', NULL, NULL, 1, ?, ?)""",
+            goal_id,
+            f"RTO/RPO Goal {phase}-{index}",
+            "Seeded by rto-rpo assertion suite",
+            ts,
+            ts,
+        )
+        inserted["goals"] += 1
+
+        db.execute(
+            """INSERT INTO goal_queue
+               (goal_id, urgency, value, deadline_score, base_priority, priority, wait_cycles, force_promoted,
+                status, version, created_at, updated_at)
+               VALUES (?, 0.6, 0.5, 0.3, 0.47, 0.47, 0, 0, 'active', 1, ?, ?)""",
+            goal_id,
+            ts,
+            ts,
+        )
+        inserted["goal_queue"] += 1
+
+        db.execute(
+            """INSERT INTO tasks
+               (task_id, goal_id, title, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            task_id,
+            goal_id,
+            f"RTO/RPO Task {phase}-{index}",
+            ts,
+            ts,
+        )
+        inserted["tasks"] += 1
+
+        db.execute(
+            """INSERT INTO task_state
+               (task_id, goal_id, correlation_id, status, retry_count, failure_type, error_hash,
+                version, created_at, updated_at)
+               VALUES (?, ?, ?, 'pending', 0, NULL, NULL, 1, ?, ?)""",
+            task_id,
+            goal_id,
+            correlation_id,
+            ts,
+            ts,
+        )
+        inserted["task_state"] += 1
+
+        db.execute(
+            """INSERT INTO events
+               (event_id, event_type, entity_id, correlation_id, payload, emitted_at)
+               VALUES (?, 'drill.rto_rpo.seeded', ?, ?, ?, ?)""",
+            event_id,
+            goal_id,
+            correlation_id,
+            json.dumps({"phase": phase, "index": index}, ensure_ascii=True, sort_keys=True),
+            ts,
+        )
+        inserted["events"] += 1
+
+        db.execute(
+            """INSERT INTO workflow_runs
+               (run_id, workflow_id, status, requested_by, correlation_id, idempotency_key,
+                input_payload, result_payload, started_at, finished_at, created_at, updated_at)
+               VALUES (?, ?, 'succeeded', ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            run_id,
+            workflow_id,
+            "rto-rpo-assertion-suite",
+            f"workflow:{workflow_id}:{run_id[:8]}",
+            f"{phase}-{index}",
+            json.dumps({"phase": phase, "index": index}, ensure_ascii=True, sort_keys=True),
+            json.dumps({"ok": True}, ensure_ascii=True, sort_keys=True),
+            ts,
+            ts,
+            ts,
+            ts,
+        )
+        inserted["workflow_runs"] += 1
+
+    return inserted
+
+
+def _restored_probe(restored_db: Path) -> dict[str, Any]:
+    app = create_app(
+        Settings(
+            database_url=str(restored_db),
+            workflow_worker_poll_interval_seconds=0.05,
+            workflow_startup_recovery_max_age_seconds=0,
+        )
+    )
+    with TestClient(app, raise_server_exceptions=False) as client:
+        readiness = client.get("/system/readiness")
+        slo = client.get("/system/slo")
+        integrity = client.get("/system/database/integrity?mode=quick")
+        create_goal = client.post(
+            "/goals",
+            json={
+                "title": "RTO/RPO restore probe goal",
+                "description": "post-restore mutation probe",
+                "urgency": 0.7,
+                "value": 0.6,
+                "deadline_score": 0.3,
+            },
+        )
+
+    _expect(readiness.status_code == 200, f"Restored readiness failed: {readiness.text}")
+    _expect(slo.status_code == 200, f"Restored SLO failed: {slo.text}")
+    _expect(integrity.status_code == 200, f"Restored integrity failed: {integrity.text}")
+    _expect(create_goal.status_code == 201, f"Restored mutation probe failed: {create_goal.status_code} {create_goal.text}")
+
+    readiness_payload = readiness.json()
+    slo_payload = slo.json()
+    integrity_payload = integrity.json()
+
+    _expect(bool(readiness_payload.get("ready")), f"Restored readiness is false: {readiness_payload}")
+    _expect(str(slo_payload.get("status")) == "ok", f"Restored SLO not ok: {slo_payload}")
+    _expect(
+        bool((integrity_payload.get("integrity") or {}).get("ok")),
+        f"Restored integrity endpoint not ok: {integrity_payload}",
+    )
+
+    return {
+        "readiness_ready": bool(readiness_payload.get("ready")),
+        "slo_status": str(slo_payload.get("status")),
+        "integrity_ok": bool((integrity_payload.get("integrity") or {}).get("ok")),
+        "post_restore_goal_status_code": int(create_goal.status_code),
+        "post_restore_goal_id": str((create_goal.json() or {}).get("goal_id") or ""),
+    }
+
+
+def run_check(
+    *,
+    label: str,
+    deployment_profile: str,
+    workspace: Path,
+    policy_file: Path,
+    runbook_file: Path,
+    seed_rows: int,
+    tail_write_rows: int,
+    max_rto_seconds: float,
+    max_rpo_rows_lost: int,
+    keep_artifacts: bool,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    profile = str(deployment_profile).strip().lower() or "production"
+
+    policy = _read_json_file(policy_file)
+    runbook_text = runbook_file.read_text(encoding="utf-8")
+
+    policy_version = str(policy.get("version") or "")
+    _expect(bool(policy_version), "Policy field 'version' is required.")
+
+    scenario_defs = policy.get("scenarios") if isinstance(policy.get("scenarios"), list) else []
+    _expect(len(scenario_defs) >= 2, "Policy must contain at least two scenarios.")
+
+    raw_policy_max_rto = policy.get("max_rto_seconds")
+    policy_max_rto_seconds = float(raw_policy_max_rto) if raw_policy_max_rto is not None else 0.0
+    _expect(policy_max_rto_seconds > 0, "Policy field 'max_rto_seconds' must be > 0.")
+
+    raw_policy_max_rpo = policy.get("max_rpo_rows_lost")
+    policy_max_rpo_rows_lost = int(raw_policy_max_rpo) if raw_policy_max_rpo is not None else -1
+    _expect(policy_max_rpo_rows_lost >= 0, "Policy field 'max_rpo_rows_lost' must be >= 0.")
+
+    effective_max_rto_seconds = min(float(max_rto_seconds), policy_max_rto_seconds)
+    effective_max_rpo_rows_lost = min(int(max_rpo_rows_lost), policy_max_rpo_rows_lost)
+
+    run_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+    run_dir = workspace / f"rto-rpo-assertion-suite-{run_id}"
+    run_dir.mkdir(parents=True, exist_ok=False)
+
+    source_db = run_dir / "source.db"
+    backup_zero = run_dir / "backup-zero-loss.db"
+    restored_zero = run_dir / "restored-zero-loss.db"
+    backup_bounded = run_dir / "backup-bounded-loss.db"
+    restored_bounded = run_dir / "restored-bounded-loss.db"
+
+    try:
+        seeded_initial = _seed_rows(
+            db_path=source_db,
+            row_count=max(1, int(seed_rows)),
+            phase="initial",
+            start_index=0,
+        )
+
+        source_initial = _snapshot(source_db)
+        _expect(
+            bool(source_initial["integrity"]["quick_ok"]) and bool(source_initial["integrity"]["full_ok"]),
+            f"Source DB integrity failed after initial seed: {source_initial['integrity']}",
+        )
+
+        _copy_database(source_db, backup_zero)
+        zero_restore_started = time.perf_counter()
+        _copy_database(backup_zero, restored_zero)
+        zero_restore_duration_ms = int((time.perf_counter() - zero_restore_started) * 1000)
+        zero_snapshot = _snapshot(restored_zero)
+        zero_probe = _restored_probe(restored_zero)
+
+        source_before_bounded_backup = _snapshot(source_db)
+        _copy_database(source_db, backup_bounded)
+
+        seeded_tail = _seed_rows(
+            db_path=source_db,
+            row_count=max(0, int(tail_write_rows)),
+            phase="tail",
+            start_index=max(1, int(seed_rows)),
+        )
+        source_after_tail = _snapshot(source_db)
+
+        bounded_restore_started = time.perf_counter()
+        _copy_database(backup_bounded, restored_bounded)
+        bounded_restore_duration_ms = int((time.perf_counter() - bounded_restore_started) * 1000)
+        bounded_snapshot = _snapshot(restored_bounded)
+        bounded_probe = _restored_probe(restored_bounded)
+
+        zero_rows_lost = max(0, int(source_initial["total_rows"]) - int(zero_snapshot["total_rows"]))
+        bounded_rows_lost = max(0, int(source_after_tail["total_rows"]) - int(bounded_snapshot["total_rows"]))
+
+        criteria: list[dict[str, Any]] = []
+
+        def add(name: str, passed: bool, details: str) -> None:
+            criteria.append({"name": name, "passed": bool(passed), "details": details})
+
+        if profile == "production":
+            add("policy_version_present", bool(policy_version), f"policy_version={policy_version!r}")
+
+            for index, scenario in enumerate(scenario_defs):
+                if not isinstance(scenario, dict):
+                    add(f"scenario_{index + 1}.shape", False, "scenario entry is not an object")
+                    continue
+                scenario_id = str(scenario.get("id") or "").strip()
+                runbook_section = str(scenario.get("runbook_section") or "").strip()
+                add(
+                    f"scenario_{index + 1}.id_present",
+                    bool(scenario_id),
+                    f"scenario_id={scenario_id!r}",
+                )
+                add(
+                    f"{scenario_id or ('scenario_' + str(index + 1))}.runbook_section_present",
+                    bool(runbook_section) and runbook_section in runbook_text,
+                    f"runbook_section={runbook_section!r}",
+                )
+
+            add(
+                "zero_loss_restore_matches_source",
+                zero_snapshot["counts"] == source_initial["counts"],
+                (
+                    f"source_total_rows={source_initial['total_rows']}, "
+                    f"restored_total_rows={zero_snapshot['total_rows']}"
+                ),
+            )
+            add(
+                "zero_loss_rows_lost_zero",
+                zero_rows_lost == 0,
+                f"zero_rows_lost={zero_rows_lost}",
+            )
+            add(
+                "zero_loss_rto_budget",
+                (zero_restore_duration_ms / 1000.0) <= float(effective_max_rto_seconds),
+                (
+                    f"zero_restore_duration_seconds={zero_restore_duration_ms / 1000.0:.3f}, "
+                    f"max_rto_seconds={effective_max_rto_seconds:.3f}"
+                ),
+            )
+            add(
+                "zero_loss_integrity_ok",
+                bool(zero_snapshot["integrity"]["quick_ok"]) and bool(zero_snapshot["integrity"]["full_ok"]),
+                f"zero_integrity={json.dumps(zero_snapshot['integrity'], sort_keys=True)}",
+            )
+            add(
+                "zero_loss_runtime_probe_ok",
+                bool(zero_probe["readiness_ready"]) and str(zero_probe["slo_status"]) == "ok" and bool(zero_probe["integrity_ok"]),
+                f"zero_probe={json.dumps(zero_probe, sort_keys=True)}",
+            )
+
+            add(
+                "bounded_loss_restore_matches_backup_point",
+                bounded_snapshot["counts"] == source_before_bounded_backup["counts"],
+                (
+                    f"backup_point_total_rows={source_before_bounded_backup['total_rows']}, "
+                    f"restored_total_rows={bounded_snapshot['total_rows']}"
+                ),
+            )
+            add(
+                "bounded_loss_rto_budget",
+                (bounded_restore_duration_ms / 1000.0) <= float(effective_max_rto_seconds),
+                (
+                    f"bounded_restore_duration_seconds={bounded_restore_duration_ms / 1000.0:.3f}, "
+                    f"max_rto_seconds={effective_max_rto_seconds:.3f}"
+                ),
+            )
+            add(
+                "bounded_loss_rpo_budget",
+                bounded_rows_lost <= int(effective_max_rpo_rows_lost),
+                (
+                    f"bounded_rows_lost={bounded_rows_lost}, "
+                    f"max_rpo_rows_lost={effective_max_rpo_rows_lost}"
+                ),
+            )
+            add(
+                "bounded_loss_integrity_ok",
+                bool(bounded_snapshot["integrity"]["quick_ok"]) and bool(bounded_snapshot["integrity"]["full_ok"]),
+                f"bounded_integrity={json.dumps(bounded_snapshot['integrity'], sort_keys=True)}",
+            )
+            add(
+                "bounded_loss_runtime_probe_ok",
+                bool(bounded_probe["readiness_ready"]) and str(bounded_probe["slo_status"]) == "ok" and bool(bounded_probe["integrity_ok"]),
+                f"bounded_probe={json.dumps(bounded_probe, sort_keys=True)}",
+            )
+        else:
+            add("non_production_profile", True, f"deployment_profile={profile!r} (hard requirements skipped)")
+
+        failed_criteria = [item for item in criteria if item["passed"] is False]
+        success = len(failed_criteria) == 0
+
+        report = {
+            "label": label,
+            "success": bool(success),
+            "config": {
+                "deployment_profile": profile,
+                "policy_file": str(policy_file),
+                "runbook_file": str(runbook_file),
+                "seed_rows": max(1, int(seed_rows)),
+                "tail_write_rows": max(0, int(tail_write_rows)),
+                "max_rto_seconds": float(effective_max_rto_seconds),
+                "max_rpo_rows_lost": int(effective_max_rpo_rows_lost),
+            },
+            "policy": policy,
+            "metrics": {
+                "criteria_total": len(criteria),
+                "criteria_passed": len(criteria) - len(failed_criteria),
+                "criteria_failed": len(failed_criteria),
+                "zero_restore_duration_ms": int(zero_restore_duration_ms),
+                "bounded_restore_duration_ms": int(bounded_restore_duration_ms),
+                "max_restore_duration_ms": int(max(zero_restore_duration_ms, bounded_restore_duration_ms)),
+                "zero_rows_lost": int(zero_rows_lost),
+                "bounded_rows_lost": int(bounded_rows_lost),
+                "seeded_initial_rows": int(source_initial["total_rows"]),
+                "seeded_tail_rows": int(_total_rows(seeded_tail)),
+                "source_total_rows_after_tail": int(source_after_tail["total_rows"]),
+            },
+            "seeded": {
+                "initial": seeded_initial,
+                "tail": seeded_tail,
+            },
+            "scenarios": {
+                "zero_loss": {
+                    "source": source_initial,
+                    "restored": zero_snapshot,
+                    "runtime_probe": zero_probe,
+                    "restore_duration_ms": int(zero_restore_duration_ms),
+                    "rows_lost": int(zero_rows_lost),
+                },
+                "bounded_loss": {
+                    "backup_point_source": source_before_bounded_backup,
+                    "source_after_tail": source_after_tail,
+                    "restored": bounded_snapshot,
+                    "runtime_probe": bounded_probe,
+                    "restore_duration_ms": int(bounded_restore_duration_ms),
+                    "rows_lost": int(bounded_rows_lost),
+                },
+            },
+            "criteria": criteria,
+            "failed_criteria": failed_criteria,
+            "paths": {
+                "run_dir": str(run_dir),
+                "source_db": str(source_db),
+                "backup_zero_db": str(backup_zero),
+                "restored_zero_db": str(restored_zero),
+                "backup_bounded_db": str(backup_bounded),
+                "restored_bounded_db": str(restored_bounded),
+            },
+            "generated_at_utc": _utc_now(),
+            "duration_ms": int((time.perf_counter() - started) * 1000),
+        }
+        return report
+    finally:
+        if not keep_artifacts:
+            import shutil
+
+            shutil.rmtree(run_dir, ignore_errors=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "RTO/RPO assertion suite: validate restore-time and data-loss budgets over zero-loss and bounded-loss scenarios."
+        )
+    )
+    parser.add_argument("--label", default="rto-rpo-assertion-suite")
+    parser.add_argument("--deployment-profile", default="production")
+    parser.add_argument("--workspace", default=str(PROJECT_ROOT / ".tmp" / "rto-rpo-assertion-suite"))
+    parser.add_argument("--policy-file", default="docs/rto-rpo-assertion-policy.json")
+    parser.add_argument("--runbook-file", default="docs/production-runbook.md")
+    parser.add_argument("--seed-rows", type=int, default=48)
+    parser.add_argument("--tail-write-rows", type=int, default=12)
+    parser.add_argument("--max-rto-seconds", type=float, default=20.0)
+    parser.add_argument("--max-rpo-rows-lost", type=int, default=96)
+    parser.add_argument("--keep-artifacts", action="store_true")
+    parser.add_argument("--output-file")
+    parser.add_argument("--allow-failure", action="store_true")
+    args = parser.parse_args(argv)
+
+    project_root = Path(__file__).resolve().parents[1]
+
+    workspace = Path(str(args.workspace)).expanduser()
+    if not workspace.is_absolute():
+        workspace = (project_root / workspace).resolve()
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    policy_file = Path(str(args.policy_file)).expanduser()
+    if not policy_file.is_absolute():
+        policy_file = (project_root / policy_file).resolve()
+
+    runbook_file = Path(str(args.runbook_file)).expanduser()
+    if not runbook_file.is_absolute():
+        runbook_file = (project_root / runbook_file).resolve()
+
+    try:
+        report = run_check(
+            label=str(args.label),
+            deployment_profile=str(args.deployment_profile),
+            workspace=workspace,
+            policy_file=policy_file,
+            runbook_file=runbook_file,
+            seed_rows=max(1, int(args.seed_rows)),
+            tail_write_rows=max(0, int(args.tail_write_rows)),
+            max_rto_seconds=max(0.1, float(args.max_rto_seconds)),
+            max_rpo_rows_lost=max(0, int(args.max_rpo_rows_lost)),
+            keep_artifacts=bool(args.keep_artifacts),
+        )
+    except Exception as exc:
+        print(f"[rto-rpo-assertion-suite] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output_file:
+        output_file = Path(str(args.output_file)).expanduser()
+        if not output_file.is_absolute():
+            output_file = (project_root / output_file).resolve()
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2), encoding="utf-8")
+
+    if report["success"] is False and not bool(args.allow_failure):
+        print(f"[rto-rpo-assertion-suite] ERROR: {json.dumps(report, sort_keys=True)}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-p0-runbook-contract-check.ps1
+++ b/scripts/run-p0-runbook-contract-check.ps1
@@ -1,7 +1,7 @@
 param(
     [string]$PythonExe = "python",
     [string]$OutputFile = "artifacts\\p0-runbook-contract-check-report.json",
-    [string]$RequiredRunbookScripts = "run-security-config-hardening-check.ps1,run-audit-trail-hardening-check.ps1,run-security-ci-lane-check.ps1,run-alert-routing-oncall-check.ps1,run-incident-drill-automation-check.ps1,run-load-profile-framework-check.ps1,run-power-loss-durability-drill.ps1,run-disk-pressure-fault-injection-drill.ps1,run-upgrade-downgrade-compatibility-drill.ps1,run-backup-restore-stress-drill.ps1,run-release-gate-runtime-stability-drill.ps1,run-p0-burnin-consecutive-green.ps1,run-p0-release-evidence-bundle.ps1,run-p0-closure-report.ps1",
+    [string]$RequiredRunbookScripts = "run-security-config-hardening-check.ps1,run-audit-trail-hardening-check.ps1,run-security-ci-lane-check.ps1,run-alert-routing-oncall-check.ps1,run-incident-drill-automation-check.ps1,run-load-profile-framework-check.ps1,run-rto-rpo-assertion-suite.ps1,run-power-loss-durability-drill.ps1,run-disk-pressure-fault-injection-drill.ps1,run-upgrade-downgrade-compatibility-drill.ps1,run-backup-restore-stress-drill.ps1,run-release-gate-runtime-stability-drill.ps1,run-p0-burnin-consecutive-green.ps1,run-p0-release-evidence-bundle.ps1,run-p0-closure-report.ps1",
     [string]$RequiredStrictFlags = ""
 )
 

--- a/scripts/run-rto-rpo-assertion-suite.ps1
+++ b/scripts/run-rto-rpo-assertion-suite.ps1
@@ -1,0 +1,46 @@
+param(
+    [string]$PythonExe = "python",
+    [string]$DeploymentProfile = "production",
+    [string]$Workspace = ".tmp\rto-rpo-assertion-suite",
+    [string]$PolicyFile = "docs\rto-rpo-assertion-policy.json",
+    [string]$RunbookFile = "docs\production-runbook.md",
+    [int]$SeedRows = 48,
+    [int]$TailWriteRows = 12,
+    [double]$MaxRtoSeconds = 20.0,
+    [int]$MaxRpoRowsLost = 96,
+    [string]$OutputFile = "artifacts\rto-rpo-assertion-suite-report.json",
+    [switch]$KeepArtifacts,
+    [switch]$AllowFailure
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$arguments = @(
+    ".\scripts\rto-rpo-assertion-suite.py",
+    "--label", "manual",
+    "--deployment-profile", $DeploymentProfile,
+    "--workspace", $Workspace,
+    "--policy-file", $PolicyFile,
+    "--runbook-file", $RunbookFile,
+    "--seed-rows", [string]$SeedRows,
+    "--tail-write-rows", [string]$TailWriteRows,
+    "--max-rto-seconds", [string]$MaxRtoSeconds,
+    "--max-rpo-rows-lost", [string]$MaxRpoRowsLost,
+    "--output-file", $OutputFile
+)
+if ($KeepArtifacts) {
+    $arguments += "--keep-artifacts"
+}
+if ($AllowFailure) {
+    $arguments += "--allow-failure"
+}
+
+& $PythonExe @arguments
+if ($LASTEXITCODE -ne 0) {
+    throw "RTO/RPO assertion suite failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "RTO/RPO assertion suite passed." -ForegroundColor Green

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -4318,3 +4318,147 @@ def test_133_load_profile_framework_check_fails_when_min_requests_budget_is_unme
     )
 
     shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_134_rto_rpo_assertion_suite_reports_success_with_fixture_policy():
+    workspace = _local_test_dir("pytest-rto-rpo-assertion-suite-success").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    policy_file = workspace / "rto-rpo-policy.json"
+    output_file = workspace / "rto-rpo-report.json"
+
+    policy_file.write_text(
+        json.dumps(
+            {
+                "version": "pytest.1.0.0",
+                "max_rto_seconds": 30.0,
+                "max_rpo_rows_lost": 400,
+                "scenarios": [
+                    {
+                        "id": "restore.zero_loss",
+                        "runbook_section": "### 3.33 RTO zero-loss restore assertion",
+                    },
+                    {
+                        "id": "restore.bounded_loss",
+                        "runbook_section": "### 3.34 RPO bounded-loss assertion",
+                    },
+                ],
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "rto-rpo-assertion-suite.py"),
+        "--label",
+        "pytest-drill",
+        "--deployment-profile",
+        "production",
+        "--workspace",
+        str((workspace / "suite-workspace").resolve()),
+        "--policy-file",
+        str(policy_file.resolve()),
+        "--runbook-file",
+        str((project_root / "docs" / "production-runbook.md").resolve()),
+        "--seed-rows",
+        "18",
+        "--tail-write-rows",
+        "6",
+        "--max-rto-seconds",
+        "30",
+        "--max-rpo-rows-lost",
+        "400",
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["metrics"]["criteria_failed"] == 0
+    assert payload["metrics"]["max_restore_duration_ms"] >= 0
+    assert payload["metrics"]["bounded_rows_lost"] <= 400
+    assert output_file.exists()
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_135_rto_rpo_assertion_suite_fails_when_rpo_budget_is_exceeded():
+    workspace = _local_test_dir("pytest-rto-rpo-assertion-suite-failure").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    policy_file = workspace / "rto-rpo-policy.json"
+    output_file = workspace / "rto-rpo-report.json"
+
+    policy_file.write_text(
+        json.dumps(
+            {
+                "version": "pytest.1.0.0",
+                "max_rto_seconds": 30.0,
+                "max_rpo_rows_lost": 0,
+                "scenarios": [
+                    {
+                        "id": "restore.zero_loss",
+                        "runbook_section": "### 3.33 RTO zero-loss restore assertion",
+                    },
+                    {
+                        "id": "restore.bounded_loss",
+                        "runbook_section": "### 3.34 RPO bounded-loss assertion",
+                    },
+                ],
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "rto-rpo-assertion-suite.py"),
+        "--label",
+        "pytest-drill",
+        "--deployment-profile",
+        "production",
+        "--workspace",
+        str((workspace / "suite-workspace").resolve()),
+        "--policy-file",
+        str(policy_file.resolve()),
+        "--runbook-file",
+        str((project_root / "docs" / "production-runbook.md").resolve()),
+        "--seed-rows",
+        "18",
+        "--tail-write-rows",
+        "6",
+        "--max-rto-seconds",
+        "30",
+        "--max-rpo-rows-lost",
+        "0",
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "[rto-rpo-assertion-suite] ERROR: "
+    assert marker in completed.stderr
+    payload = json.loads(completed.stderr.split(marker, 1)[1].strip())
+    assert payload["success"] is False
+    assert payload["metrics"]["criteria_failed"] >= 1
+    assert any(
+        str(item.get("name") or "") == "bounded_loss_rpo_budget"
+        for item in payload.get("failed_criteria", [])
+        if isinstance(item, dict)
+    )
+
+    shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
## Summary
- add Stage-C RTO/RPO assertion suite script with deterministic zero-loss and bounded-loss restore scenarios
- add policy + PS1 wrapper for explicit restore-time and data-loss budgets
- integrate strict/skip release-gate + CI artifact upload for RTO/RPO release evidence
- extend runbook contract defaults, README/runbook commands, and add success/failure tests

## Testing
- python -m py_compile scripts/rto-rpo-assertion-suite.py scripts/p0-runbook-contract-check.py tests/test_goal_ops.py
- python -m pytest -q tests/test_goal_ops.py -k "test_112_p0_runbook_contract_check_reports_success or test_132_load_profile_framework_check_reports_success_with_fixture_profile or test_133_load_profile_framework_check_fails_when_min_requests_budget_is_unmet or test_134_rto_rpo_assertion_suite_reports_success_with_fixture_policy or test_135_rto_rpo_assertion_suite_fails_when_rpo_budget_is_exceeded"
- ./scripts/run-rto-rpo-assertion-suite.ps1 -PolicyFile docs/rto-rpo-assertion-policy.json -SeedRows 48 -TailWriteRows 12 -MaxRtoSeconds 20 -MaxRpoRowsLost 96
- ./scripts/run-p0-runbook-contract-check.ps1
- release-gate targeted smoke (all Skip* enabled except RTO/RPO assertion step, strict mode enabled)
