### PR TITLE
P0: Auto-rollback hard triggers (burn-rate + readiness regression)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
             artifacts/alert-routing-oncall-release-gate.json
             artifacts/incident-drill-automation-release-gate.json
             artifacts/load-profile-framework-release-gate.json
+            artifacts/auto-rollback-policy-release-gate.json
             artifacts/canary-guardrails-release-gate.json
             artifacts/rto-rpo-assertion-release-gate.json
           if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + security config hardening check + audit trail hardening check + security CI lane check + alert-routing/on-call runbook automation check + incident drill automation check + load profile framework check + canary guardrails check + RTO/RPO assertion suite check + release-freeze policy drill + auto-rollback-policy drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle + P0 closure go/no-go report):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + security config hardening check + audit trail hardening check + security CI lane check + alert-routing/on-call runbook automation check + incident drill automation check + load profile framework check + canary guardrails check + RTO/RPO assertion suite check + release-freeze policy drill + auto-rollback hard-trigger drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle + P0 closure go/no-go report):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
@@ -460,11 +460,11 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-upgrade-downgrade-compatibility-drill.ps1 -NMinus1Runs 800 -PayloadBytes 512
 ```
 
-Standalone auto-rollback policy check (live service):
+Standalone auto-rollback hard-trigger check (sustained critical OR burn-rate spike OR readiness regression):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\run-auto-rollback-policy.ps1 -BaseUrl "http://127.0.0.1:8000" -ManifestPath ".\artifacts\desktop-rings.json" -CriticalWindowSeconds 300 -PollIntervalSeconds 30 -MaxObservationSeconds 900
+.\scripts\run-auto-rollback-policy.ps1 -BaseUrl "http://127.0.0.1:8000" -ManifestPath ".\artifacts\desktop-rings.json" -CriticalWindowSeconds 300 -ReadinessRegressionWindowSeconds 120 -MaxErrorBudgetBurnRatePercent 2.0 -ExpectedTriggerReason auto -PollIntervalSeconds 30 -MaxObservationSeconds 900
 ```
 
 Standalone security config hardening check (production profile policy):

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -26,7 +26,7 @@ This gate covers:
 - canary guardrails check (staged ring exposure with deterministic halt/freeze policy and promotion-block validation)
 - RTO/RPO assertion suite (restore duration budgets plus bounded data-loss budget assertions)
 - release-freeze policy drill (sustained non-ok window or burn-rate spike freezes ring promotion path)
-- auto-rollback-policy drill (`critical` sustained window triggers stable ring rollback path)
+- auto-rollback hard-trigger drill (sustained `critical`, burn-rate spike, or readiness regression triggers stable ring rollback path)
 - desktop-update-safety drill (hash validation + rollback-to-stable fallback path)
 - recovery hard-abort drill (kill running worker process, restart, and verify no hanging `running` runs)
 - recovery idempotence drill (repeated restarts keep startup recovery one-shot/idempotent for interrupted runs)
@@ -72,10 +72,10 @@ Manual upgrade/downgrade compatibility drill invocation:
 .\scripts\run-upgrade-downgrade-compatibility-drill.ps1 -NMinus1Runs 800 -PayloadBytes 512
 ```
 
-Manual auto-rollback policy invocation (live endpoint, stable ring):
+Manual auto-rollback hard-trigger invocation (live endpoint, stable ring):
 
 ```powershell
-.\scripts\run-auto-rollback-policy.ps1 -BaseUrl "http://127.0.0.1:8000" -ManifestPath ".\artifacts\desktop-rings.json" -CriticalWindowSeconds 300 -PollIntervalSeconds 30 -MaxObservationSeconds 900
+.\scripts\run-auto-rollback-policy.ps1 -BaseUrl "http://127.0.0.1:8000" -ManifestPath ".\artifacts\desktop-rings.json" -CriticalWindowSeconds 300 -ReadinessRegressionWindowSeconds 120 -MaxErrorBudgetBurnRatePercent 2.0 -ExpectedTriggerReason auto -PollIntervalSeconds 30 -MaxObservationSeconds 900
 ```
 
 Manual security config hardening check invocation:
@@ -464,9 +464,9 @@ Actions:
    ```powershell
    .\scripts\run-release-freeze-policy.ps1 -BaseUrl "http://127.0.0.1:8000" -ManifestPath ".\artifacts\desktop-rings.json" -NonOkWindowSeconds 300 -PollIntervalSeconds 30 -MaxObservationSeconds 900
    ```
-4. If status remains `critical`, enforce sustained-window rollback policy check:
+4. If status remains `critical` or readiness regresses under elevated burn-rate, enforce hard-trigger rollback policy check:
    ```powershell
-   .\scripts\run-auto-rollback-policy.ps1 -BaseUrl "http://127.0.0.1:8000" -ManifestPath ".\artifacts\desktop-rings.json" -CriticalWindowSeconds 300 -PollIntervalSeconds 30 -MaxObservationSeconds 900
+   .\scripts\run-auto-rollback-policy.ps1 -BaseUrl "http://127.0.0.1:8000" -ManifestPath ".\artifacts\desktop-rings.json" -CriticalWindowSeconds 300 -ReadinessRegressionWindowSeconds 120 -MaxErrorBudgetBurnRatePercent 2.0 -ExpectedTriggerReason auto -PollIntervalSeconds 30 -MaxObservationSeconds 900
    ```
 5. Export diagnostics snapshot and attach to incident ticket.
 
@@ -1038,6 +1038,41 @@ Actions:
    .\scripts\run-canary-guardrails-check.ps1 -PolicyFile "docs\canary-guardrails-policy.json" -ExpectedDecision promote -MockSloStatuses "ok,ok,ok,ok" -MockErrorBudgetBurnRates "0.4,0.5,0.6,0.7"
    ```
 4. Only clear freeze and continue promotion after a green guardrail report is attached to incident/change record.
+
+### 3.37 Auto-rollback hard triggers
+
+Symptoms:
+- incident conditions escalate beyond release-freeze scope and require immediate stable rollback
+- operators need deterministic policy evidence for rollback trigger reason
+
+Actions:
+1. Execute hard-trigger rollback drill:
+   ```powershell
+   .\scripts\run-auto-rollback-policy.ps1 -ManifestPath ".\artifacts\desktop-rings.json" -MockSloStatuses "ok,ok,ok,ok" -MockErrorBudgetBurnRates "0.5,0.8,2.5,2.5" -MockReadinessValues "true,true,true,true" -CriticalWindowSeconds 4 -ReadinessRegressionWindowSeconds 2 -MaxErrorBudgetBurnRatePercent 2.0 -ExpectedTriggerReason error_budget_burn_rate -PollIntervalSeconds 1 -MaxObservationSeconds 8 -SeedPreviousVersion "0.0.1" -SeedIncidentVersion "0.0.2"
+   ```
+2. Validate drill report fields:
+   - `observation.triggered = true`
+   - `observation.trigger_reason` is one of `critical_window`, `error_budget_burn_rate`, `readiness_regression`
+   - `decision.expected_reason_matched = true`
+3. Confirm rollback execution succeeded (`rollback.executed = true`) and stable ring swapped to previous version.
+4. Attach report JSON to incident evidence before promotion resumes.
+
+### 3.38 Readiness-regression rollback guard
+
+Symptoms:
+- readiness flips to `ready=false` while SLO remains non-critical or ambiguous
+- uncertainty whether rollback policy reacts quickly enough to sustained readiness regression
+
+Actions:
+1. Run readiness-focused rollback trigger check:
+   ```powershell
+   .\scripts\run-auto-rollback-policy.ps1 -ManifestPath ".\artifacts\desktop-rings.json" -MockSloStatuses "ok,degraded,degraded,degraded" -MockErrorBudgetBurnRates "0.5,0.8,0.9,0.9" -MockReadinessValues "true,false,false,false" -CriticalWindowSeconds 4 -ReadinessRegressionWindowSeconds 1 -MaxErrorBudgetBurnRatePercent 2.0 -ExpectedTriggerReason readiness_regression -PollIntervalSeconds 1 -MaxObservationSeconds 8 -SeedPreviousVersion "0.0.1" -SeedIncidentVersion "0.0.2"
+   ```
+2. Verify hard-trigger precedence in report:
+   - `observation.trigger_reason = readiness_regression`
+   - `decision.recommended_action = rollback_executed` (or `manual_rollback_required` in dry-run mode)
+3. If expected trigger reason is not matched, keep release blocked and escalate policy defect immediately.
+4. Resume rollout only after readiness is stable and a fresh rollback-policy drill passes with expected reason.
 
 ## 4. Operational Defaults
 

--- a/scripts/auto-rollback-policy.py
+++ b/scripts/auto-rollback-policy.py
@@ -23,6 +23,8 @@ if str(PROJECT_ROOT) not in sys.path:
 from goal_ops_console.config import Settings
 from goal_ops_console.main import create_app
 
+ALLOWED_TRIGGER_REASONS = {"auto", "critical_window", "error_budget_burn_rate", "readiness_regression"}
+
 
 def _expect(condition: bool, message: str) -> None:
     if not condition:
@@ -152,47 +154,156 @@ def _fetch_slo_from_url(base_url: str) -> dict[str, Any]:
     return payload
 
 
-def _build_mock_fetcher(mock_statuses: list[str]) -> Callable[[], dict[str, Any]]:
-    values = [item.strip().lower() for item in mock_statuses if item.strip()]
-    _expect(values, "Mock SLO statuses are empty.")
-    for status in values:
+def _fetch_readiness_from_url(base_url: str) -> dict[str, Any]:
+    normalized = base_url.rstrip("/") + "/"
+    with urlopen(urljoin(normalized, "system/readiness"), timeout=5) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    _expect(isinstance(payload, dict), "Remote /system/readiness payload is not a JSON object.")
+    return payload
+
+
+def _extract_error_budget_burn_rate_percent(slo_payload: dict[str, Any]) -> float:
+    indicators = slo_payload.get("indicators") or {}
+    success_rate = indicators.get("http_success_rate_percent")
+    http_429_rate = indicators.get("http_429_rate_percent")
+    event_failure_rate = indicators.get("event_failure_rate_percent")
+
+    candidates: list[float] = []
+    if isinstance(success_rate, (int, float)):
+        candidates.append(max(0.0, 100.0 - float(success_rate)))
+    if isinstance(http_429_rate, (int, float)):
+        candidates.append(max(0.0, float(http_429_rate)))
+    if isinstance(event_failure_rate, (int, float)):
+        candidates.append(max(0.0, float(event_failure_rate)))
+    if not candidates:
+        return 0.0
+    return max(candidates)
+
+
+def _extract_readiness_ready(readiness_payload: dict[str, Any]) -> bool:
+    if isinstance(readiness_payload.get("ready"), bool):
+        return bool(readiness_payload["ready"])
+
+    checks = readiness_payload.get("checks")
+    if isinstance(checks, dict):
+        values: list[bool] = []
+        for item in checks.values():
+            if isinstance(item, dict) and isinstance(item.get("ok"), bool):
+                values.append(bool(item["ok"]))
+        if values:
+            return all(values)
+
+    return True
+
+
+def _parse_mock_readiness_tokens(
+    *,
+    tokens: list[str],
+    required_size: int,
+) -> list[bool]:
+    if not tokens:
+        return [True for _ in range(required_size)]
+
+    parsed: list[bool] = []
+    for raw in tokens:
+        normalized = raw.strip().lower()
+        if normalized in {"1", "true", "t", "yes", "y", "ok", "ready"}:
+            parsed.append(True)
+            continue
+        if normalized in {"0", "false", "f", "no", "n", "not_ready", "degraded", "critical"}:
+            parsed.append(False)
+            continue
+        raise RuntimeError(f"Invalid mock readiness value {raw!r}.")
+
+    if len(parsed) < required_size:
+        parsed.extend([parsed[-1]] * (required_size - len(parsed)))
+    return parsed
+
+
+def _build_mock_fetcher(
+    *,
+    mock_statuses: list[str],
+    mock_error_budget_burn_rates: list[float],
+    mock_readiness_values: list[str],
+) -> Callable[[], dict[str, Any]]:
+    statuses = [item.strip().lower() for item in mock_statuses if item.strip()]
+    _expect(statuses, "Mock SLO statuses are empty.")
+    for status in statuses:
         _expect(status in {"ok", "degraded", "critical"}, f"Invalid mock status {status!r}")
+
+    burn_rates = [float(item) for item in mock_error_budget_burn_rates]
+    if not burn_rates:
+        burn_rates = [0.0 for _ in statuses]
+    if len(burn_rates) < len(statuses):
+        burn_rates.extend([burn_rates[-1]] * (len(statuses) - len(burn_rates)))
+
+    readiness_values = _parse_mock_readiness_tokens(
+        tokens=[item.strip() for item in mock_readiness_values if item.strip()],
+        required_size=len(statuses),
+    )
 
     index = {"value": 0}
 
     def _next_payload() -> dict[str, Any]:
         current_index = index["value"]
-        if current_index >= len(values):
-            status = values[-1]
+        if current_index >= len(statuses):
+            status = statuses[-1]
+            burn_rate = burn_rates[-1]
+            readiness_ready = readiness_values[-1]
         else:
-            status = values[current_index]
+            status = statuses[current_index]
+            burn_rate = burn_rates[current_index]
+            readiness_ready = readiness_values[current_index]
             index["value"] = current_index + 1
+
         return {
-            "timestamp_utc": _utc_iso(),
-            "status": status,
-            "alerts": [{"code": "mock", "severity": "critical"}] if status == "critical" else [],
+            "slo": {
+                "timestamp_utc": _utc_iso(),
+                "status": status,
+                "alerts": [{"code": "mock", "severity": "critical"}] if status == "critical" else [],
+                "indicators": {
+                    "http_success_rate_percent": max(0.0, 100.0 - float(burn_rate)),
+                    "http_429_rate_percent": max(0.0, float(burn_rate) / 2.0),
+                    "event_failure_rate_percent": max(0.0, float(burn_rate) / 2.0),
+                },
+            },
+            "readiness": {
+                "ready": bool(readiness_ready),
+                "checks": {"mock_guard": {"ok": bool(readiness_ready)}},
+            },
         }
 
     return _next_payload
 
 
-def _observe_slo(
+def _observe_policy(
     *,
     fetch_payload: Callable[[], dict[str, Any]],
     critical_window_seconds: int,
+    readiness_regression_window_seconds: int,
     poll_interval_seconds: float,
     max_observation_seconds: int,
+    max_error_budget_burn_rate_percent: float,
 ) -> dict[str, Any]:
     started = time.perf_counter()
     deadline = started + max(1, int(max_observation_seconds))
     critical_started: float | None = None
+    readiness_regression_started: float | None = None
     samples: list[dict[str, Any]] = []
     trigger_sample: dict[str, Any] | None = None
+    trigger_reason = "none"
 
     while time.perf_counter() <= deadline:
         now = time.perf_counter()
         payload = fetch_payload()
-        status = str(payload.get("status") or "").strip().lower()
+        _expect(isinstance(payload, dict), "Signal fetcher returned non-object payload.")
+
+        slo_payload = payload.get("slo")
+        readiness_payload = payload.get("readiness")
+        _expect(isinstance(slo_payload, dict), "Signal payload missing 'slo' JSON object.")
+        _expect(isinstance(readiness_payload, dict), "Signal payload missing 'readiness' JSON object.")
+
+        status = str(slo_payload.get("status") or "").strip().lower()
         _expect(status in {"ok", "degraded", "critical"}, f"Unknown SLO status {status!r}")
 
         if status == "critical":
@@ -203,16 +314,40 @@ def _observe_slo(
             critical_started = None
             critical_streak_seconds = 0.0
 
+        readiness_ready = _extract_readiness_ready(readiness_payload)
+        if not readiness_ready:
+            if readiness_regression_started is None:
+                readiness_regression_started = now
+            readiness_regression_streak_seconds = now - readiness_regression_started
+        else:
+            readiness_regression_started = None
+            readiness_regression_streak_seconds = 0.0
+
+        burn_rate = _extract_error_budget_burn_rate_percent(slo_payload)
+
         sample = {
             "sampled_at_utc": _utc_iso(),
             "status": status,
             "critical_streak_seconds": round(float(critical_streak_seconds), 3),
-            "alert_count": len(payload.get("alerts") or []),
+            "error_budget_burn_rate_percent": round(float(burn_rate), 4),
+            "readiness_ready": bool(readiness_ready),
+            "readiness_regression_streak_seconds": round(float(readiness_regression_streak_seconds), 3),
+            "alert_count": len(slo_payload.get("alerts") or []),
         }
         samples.append(sample)
 
+        # Hard trigger precedence: readiness regression > error-budget spike > sustained critical.
+        if (not readiness_ready) and readiness_regression_streak_seconds >= float(readiness_regression_window_seconds):
+            trigger_sample = sample
+            trigger_reason = "readiness_regression"
+            break
+        if burn_rate > float(max_error_budget_burn_rate_percent):
+            trigger_sample = sample
+            trigger_reason = "error_budget_burn_rate"
+            break
         if status == "critical" and critical_streak_seconds >= float(critical_window_seconds):
             trigger_sample = sample
+            trigger_reason = "critical_window"
             break
 
         time.sleep(max(0.05, float(poll_interval_seconds)))
@@ -221,6 +356,7 @@ def _observe_slo(
     triggered = trigger_sample is not None
     return {
         "triggered": triggered,
+        "trigger_reason": trigger_reason,
         "trigger_sample": trigger_sample,
         "sample_count": len(samples),
         "samples": samples,
@@ -231,14 +367,25 @@ def _observe_slo(
 def _checklist(
     *,
     triggered: bool,
+    trigger_reason: str,
+    expected_trigger_reason: str,
+    expected_reason_matched: bool,
     rollback_attempted: bool,
     rollback_executed: bool,
     report_file: Path,
 ) -> list[dict[str, Any]]:
     return [
         {
-            "step": "Confirm sustained critical SLO window breach.",
+            "step": "Confirm hard-trigger breach (critical-window, burn-rate, or readiness regression).",
             "done": triggered,
+        },
+        {
+            "step": "Validate trigger reason against expected policy path.",
+            "done": bool(expected_reason_matched) if expected_trigger_reason != "auto" else True,
+            "details": {
+                "observed_trigger_reason": trigger_reason,
+                "expected_trigger_reason": expected_trigger_reason,
+            },
         },
         {
             "step": "Capture pre-rollback ring state.",
@@ -267,14 +414,20 @@ def run_policy(
     manifest_path: Path,
     ring: str,
     critical_window_seconds: int,
+    readiness_regression_window_seconds: int,
     poll_interval_seconds: float,
     max_observation_seconds: int,
+    max_error_budget_burn_rate_percent: float,
     dry_run: bool,
     database_url: str,
     base_url: str,
     mock_statuses: list[str],
+    mock_error_budget_burn_rates: list[float],
+    mock_readiness_values: list[str],
     seed_previous_version: str,
     seed_incident_version: str,
+    expected_trigger_reason: str,
+    output_file: Path | None,
 ) -> dict[str, Any]:
     started = time.perf_counter()
     paths = _create_paths(workspace_root)
@@ -287,6 +440,12 @@ def run_policy(
     rollback_executed = False
     rollback_error = ""
 
+    expected_trigger_reason = str(expected_trigger_reason).strip().lower() or "auto"
+    _expect(
+        expected_trigger_reason in ALLOWED_TRIGGER_REASONS,
+        f"Invalid --expected-trigger-reason={expected_trigger_reason!r}.",
+    )
+
     try:
         if seed_previous_version and seed_incident_version:
             _expect(
@@ -297,41 +456,72 @@ def run_policy(
             _rings_promote(manifest_path, ring=ring, version=seed_incident_version)
 
         if mock_statuses:
-            fetch_payload = _build_mock_fetcher(mock_statuses)
+            fetch_payload = _build_mock_fetcher(
+                mock_statuses=mock_statuses,
+                mock_error_budget_burn_rates=mock_error_budget_burn_rates,
+                mock_readiness_values=mock_readiness_values,
+            )
             source = {
                 "type": "mock",
                 "mock_statuses": [value.strip().lower() for value in mock_statuses if value.strip()],
+                "mock_error_budget_burn_rates": [float(value) for value in mock_error_budget_burn_rates],
+                "mock_readiness_values": [value.strip().lower() for value in mock_readiness_values if value.strip()],
             }
-            observation = _observe_slo(
+            observation = _observe_policy(
                 fetch_payload=fetch_payload,
                 critical_window_seconds=critical_window_seconds,
+                readiness_regression_window_seconds=readiness_regression_window_seconds,
                 poll_interval_seconds=poll_interval_seconds,
                 max_observation_seconds=max_observation_seconds,
+                max_error_budget_burn_rate_percent=max_error_budget_burn_rate_percent,
             )
         elif base_url.strip():
             source = {"type": "base_url", "base_url": base_url.strip()}
-            observation = _observe_slo(
-                fetch_payload=lambda: _fetch_slo_from_url(base_url.strip()),
+            observation = _observe_policy(
+                fetch_payload=lambda: {
+                    "slo": _fetch_slo_from_url(base_url.strip()),
+                    "readiness": _fetch_readiness_from_url(base_url.strip()),
+                },
                 critical_window_seconds=critical_window_seconds,
+                readiness_regression_window_seconds=readiness_regression_window_seconds,
                 poll_interval_seconds=poll_interval_seconds,
                 max_observation_seconds=max_observation_seconds,
+                max_error_budget_burn_rate_percent=max_error_budget_burn_rate_percent,
             )
         else:
-            _expect(database_url.strip(), "Either --mock-slo-statuses, --base-url, or --database-url is required.")
+            _expect(
+                database_url.strip(),
+                "Either --mock-slo-statuses, --base-url, or --database-url is required.",
+            )
             source = {"type": "database_url", "database_url": database_url.strip()}
             app = create_app(Settings(database_url=database_url.strip()))
             with TestClient(app) as client:
-                observation = _observe_slo(
-                    fetch_payload=lambda: client.get("/system/slo").json(),
+                observation = _observe_policy(
+                    fetch_payload=lambda: {
+                        "slo": client.get("/system/slo").json(),
+                        "readiness": client.get("/system/readiness").json(),
+                    },
                     critical_window_seconds=critical_window_seconds,
+                    readiness_regression_window_seconds=readiness_regression_window_seconds,
                     poll_interval_seconds=poll_interval_seconds,
                     max_observation_seconds=max_observation_seconds,
+                    max_error_budget_burn_rate_percent=max_error_budget_burn_rate_percent,
                 )
 
         triggered = bool(observation["triggered"])
-        recommended_action = "no_action"
+        observed_trigger_reason = str(observation.get("trigger_reason") or "none")
+        expected_reason_matched = expected_trigger_reason == "auto" or (
+            triggered and observed_trigger_reason == expected_trigger_reason
+        )
 
-        if triggered:
+        if expected_trigger_reason != "auto" and not expected_reason_matched:
+            rollback_attempted = False
+            rollback_executed = False
+            rollback_error = (
+                f"Observed trigger_reason={observed_trigger_reason!r}, expected={expected_trigger_reason!r}."
+            )
+            recommended_action = "unexpected_trigger_reason"
+        elif triggered:
             rollback_attempted = True
             rollback_pre_state = _rings_show(manifest_path, ring=ring)
             if dry_run:
@@ -348,15 +538,18 @@ def run_policy(
         else:
             recommended_action = "no_action"
 
-        success = (not triggered) or dry_run or rollback_executed
+        success = ((not triggered) or dry_run or rollback_executed) and expected_reason_matched
         report = {
             "label": label,
             "success": success,
             "source": source,
             "policy": {
                 "critical_window_seconds": int(critical_window_seconds),
+                "readiness_regression_window_seconds": int(readiness_regression_window_seconds),
                 "poll_interval_seconds": float(poll_interval_seconds),
                 "max_observation_seconds": int(max_observation_seconds),
+                "max_error_budget_burn_rate_percent": float(max_error_budget_burn_rate_percent),
+                "expected_trigger_reason": expected_trigger_reason,
                 "dry_run": bool(dry_run),
             },
             "observation": observation,
@@ -371,8 +564,11 @@ def run_policy(
             },
             "decision": {
                 "triggered": triggered,
+                "observed_trigger_reason": observed_trigger_reason,
+                "expected_trigger_reason": expected_trigger_reason,
+                "expected_reason_matched": expected_reason_matched,
                 "recommended_action": recommended_action,
-                "runbook_path": "docs/production-runbook.md#2-rollback",
+                "runbook_path": "docs/production-runbook.md#337-auto-rollback-hard-triggers",
             },
             "paths": {
                 "run_dir": str(paths.run_dir),
@@ -388,6 +584,9 @@ def run_policy(
         )
         report["checklist"] = _checklist(
             triggered=triggered,
+            trigger_reason=observed_trigger_reason,
+            expected_trigger_reason=expected_trigger_reason,
+            expected_reason_matched=expected_reason_matched,
             rollback_attempted=rollback_attempted,
             rollback_executed=rollback_executed,
             report_file=paths.report_file,
@@ -396,6 +595,13 @@ def run_policy(
             json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2),
             encoding="utf-8",
         )
+
+        if output_file is not None:
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+            output_file.write_text(
+                json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2),
+                encoding="utf-8",
+            )
 
         if not success:
             raise RuntimeError(f"Auto rollback policy failed: {json.dumps(report, sort_keys=True)}")
@@ -408,8 +614,8 @@ def run_policy(
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Operationalize auto rollback policy: if /system/slo stays critical for a sustained window, "
-            "execute ring rollback and emit incident checklist artifact."
+            "Operationalize hard auto-rollback policy: trigger stable ring rollback for sustained critical SLO, "
+            "error-budget burn-rate spikes, or sustained readiness regressions."
         )
     )
     parser.add_argument("--workspace", default=str(PROJECT_ROOT / ".tmp" / "auto-rollback-policy"))
@@ -417,13 +623,19 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--manifest-path", default=str(PROJECT_ROOT / "artifacts" / "desktop-rings.json"))
     parser.add_argument("--ring", default="stable")
     parser.add_argument("--critical-window-seconds", type=int, default=300)
+    parser.add_argument("--readiness-regression-window-seconds", type=int, default=120)
     parser.add_argument("--poll-interval-seconds", type=float, default=30.0)
     parser.add_argument("--max-observation-seconds", type=int, default=900)
+    parser.add_argument("--max-error-budget-burn-rate-percent", type=float, default=2.0)
     parser.add_argument("--database-url", default="")
     parser.add_argument("--base-url", default="")
     parser.add_argument("--mock-slo-statuses", default="")
+    parser.add_argument("--mock-error-budget-burn-rates", default="")
+    parser.add_argument("--mock-readiness-values", default="")
     parser.add_argument("--seed-previous-version", default="")
     parser.add_argument("--seed-incident-version", default="")
+    parser.add_argument("--expected-trigger-reason", default="auto")
+    parser.add_argument("--output-file")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--keep-artifacts", action="store_true")
     return parser.parse_args(argv)
@@ -434,7 +646,14 @@ def main(argv: list[str] | None = None) -> int:
     workspace_root = Path(str(args.workspace)).expanduser()
     workspace_root.mkdir(parents=True, exist_ok=True)
     manifest_path = Path(str(args.manifest_path)).expanduser()
+    output_file = Path(str(args.output_file)).expanduser() if args.output_file else None
     mock_statuses = [part.strip() for part in str(args.mock_slo_statuses).split(",") if part.strip()]
+    mock_error_budget_burn_rates = [
+        float(part.strip())
+        for part in str(args.mock_error_budget_burn_rates).split(",")
+        if part.strip()
+    ]
+    mock_readiness_values = [part.strip() for part in str(args.mock_readiness_values).split(",") if part.strip()]
 
     source_count = int(bool(mock_statuses)) + int(bool(str(args.base_url).strip())) + int(
         bool(str(args.database_url).strip())
@@ -449,11 +668,31 @@ def main(argv: list[str] | None = None) -> int:
     if int(args.critical_window_seconds) <= 0:
         print("[auto-rollback-policy] ERROR: --critical-window-seconds must be positive.", file=sys.stderr)
         return 2
+    if int(args.readiness_regression_window_seconds) <= 0:
+        print("[auto-rollback-policy] ERROR: --readiness-regression-window-seconds must be positive.", file=sys.stderr)
+        return 2
     if float(args.poll_interval_seconds) <= 0:
         print("[auto-rollback-policy] ERROR: --poll-interval-seconds must be positive.", file=sys.stderr)
         return 2
     if int(args.max_observation_seconds) <= 0:
         print("[auto-rollback-policy] ERROR: --max-observation-seconds must be positive.", file=sys.stderr)
+        return 2
+    if float(args.max_error_budget_burn_rate_percent) < 0:
+        print(
+            "[auto-rollback-policy] ERROR: --max-error-budget-burn-rate-percent must be >= 0.",
+            file=sys.stderr,
+        )
+        return 2
+
+    expected_trigger_reason = str(args.expected_trigger_reason).strip().lower() or "auto"
+    if expected_trigger_reason not in ALLOWED_TRIGGER_REASONS:
+        print(
+            (
+                "[auto-rollback-policy] ERROR: --expected-trigger-reason must be one of "
+                f"{sorted(ALLOWED_TRIGGER_REASONS)}."
+            ),
+            file=sys.stderr,
+        )
         return 2
 
     try:
@@ -464,14 +703,20 @@ def main(argv: list[str] | None = None) -> int:
             manifest_path=manifest_path,
             ring=str(args.ring).strip() or "stable",
             critical_window_seconds=int(args.critical_window_seconds),
+            readiness_regression_window_seconds=int(args.readiness_regression_window_seconds),
             poll_interval_seconds=float(args.poll_interval_seconds),
             max_observation_seconds=int(args.max_observation_seconds),
+            max_error_budget_burn_rate_percent=float(args.max_error_budget_burn_rate_percent),
             dry_run=bool(args.dry_run),
             database_url=str(args.database_url).strip(),
             base_url=str(args.base_url).strip(),
             mock_statuses=mock_statuses,
+            mock_error_budget_burn_rates=mock_error_budget_burn_rates,
+            mock_readiness_values=mock_readiness_values,
             seed_previous_version=str(args.seed_previous_version).strip(),
             seed_incident_version=str(args.seed_incident_version).strip(),
+            expected_trigger_reason=expected_trigger_reason,
+            output_file=output_file,
         )
     except Exception as exc:
         print(f"[auto-rollback-policy] ERROR: {exc}", file=sys.stderr)

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -396,9 +396,10 @@ if (-not $SkipReleaseFreezePolicyDrill) {
 }
 
 if (-not $SkipAutoRollbackPolicyDrill) {
-    Invoke-GateStep -Name "Auto rollback policy drill (sustained critical => ring rollback)" -Action {
+    Invoke-GateStep -Name "Auto rollback hard-trigger drill (readiness regression + burn-rate + sustained critical => ring rollback)" -Action {
         $workspace = Join-Path $ProjectRoot ".tmp\auto-rollback-policy-drills"
         $manifestPath = Join-Path $workspace "desktop-rings.json"
+        $reportPath = Join-Path $ProjectRoot "artifacts\auto-rollback-policy-release-gate.json"
         New-Item -ItemType Directory -Force -Path $workspace | Out-Null
         try {
             Invoke-NativeCommand -Executable $PythonExe -Arguments @(
@@ -407,12 +408,18 @@ if (-not $SkipAutoRollbackPolicyDrill) {
                 "--label", "release-gate",
                 "--manifest-path", $manifestPath,
                 "--ring", "stable",
-                "--mock-slo-statuses", "critical,critical,critical,critical",
-                "--critical-window-seconds", "2",
+                "--mock-slo-statuses", "ok,degraded,degraded,degraded",
+                "--mock-error-budget-burn-rates", "0.5,0.8,0.9,0.9",
+                "--mock-readiness-values", "true,false,false,false",
+                "--critical-window-seconds", "4",
+                "--readiness-regression-window-seconds", "1",
                 "--poll-interval-seconds", "1",
                 "--max-observation-seconds", "8",
+                "--max-error-budget-burn-rate-percent", "2.0",
                 "--seed-previous-version", "0.0.1",
-                "--seed-incident-version", "0.0.2"
+                "--seed-incident-version", "0.0.2",
+                "--expected-trigger-reason", "readiness_regression",
+                "--output-file", $reportPath
             )
         } catch {
             if ($StrictAutoRollbackPolicyDrill) {

--- a/scripts/run-auto-rollback-policy.ps1
+++ b/scripts/run-auto-rollback-policy.ps1
@@ -4,13 +4,19 @@ param(
     [string]$ManifestPath = "artifacts\\desktop-rings.json",
     [string]$Ring = "stable",
     [int]$CriticalWindowSeconds = 300,
+    [int]$ReadinessRegressionWindowSeconds = 120,
     [int]$PollIntervalSeconds = 30,
     [int]$MaxObservationSeconds = 900,
+    [double]$MaxErrorBudgetBurnRatePercent = 2.0,
     [string]$BaseUrl = "",
     [string]$DatabaseUrl = "",
     [string]$MockSloStatuses = "",
+    [string]$MockErrorBudgetBurnRates = "",
+    [string]$MockReadinessValues = "",
     [string]$SeedPreviousVersion = "",
     [string]$SeedIncidentVersion = "",
+    [string]$ExpectedTriggerReason = "auto",
+    [string]$OutputFile = "artifacts\\auto-rollback-policy-report.json",
     [switch]$DryRun,
     [switch]$KeepArtifacts
 )
@@ -27,9 +33,15 @@ $args = @(
     "--manifest-path", $ManifestPath,
     "--ring", $Ring,
     "--critical-window-seconds", [string]$CriticalWindowSeconds,
+    "--readiness-regression-window-seconds", [string]$ReadinessRegressionWindowSeconds,
     "--poll-interval-seconds", [string]$PollIntervalSeconds,
-    "--max-observation-seconds", [string]$MaxObservationSeconds
+    "--max-observation-seconds", [string]$MaxObservationSeconds,
+    "--max-error-budget-burn-rate-percent", [string]$MaxErrorBudgetBurnRatePercent,
+    "--expected-trigger-reason", $ExpectedTriggerReason
 )
+if (-not [string]::IsNullOrWhiteSpace($OutputFile)) {
+    $args += @("--output-file", $OutputFile)
+}
 if (-not [string]::IsNullOrWhiteSpace($BaseUrl)) {
     $args += @("--base-url", $BaseUrl)
 }
@@ -38,6 +50,12 @@ if (-not [string]::IsNullOrWhiteSpace($DatabaseUrl)) {
 }
 if (-not [string]::IsNullOrWhiteSpace($MockSloStatuses)) {
     $args += @("--mock-slo-statuses", $MockSloStatuses)
+}
+if (-not [string]::IsNullOrWhiteSpace($MockErrorBudgetBurnRates)) {
+    $args += @("--mock-error-budget-burn-rates", $MockErrorBudgetBurnRates)
+}
+if (-not [string]::IsNullOrWhiteSpace($MockReadinessValues)) {
+    $args += @("--mock-readiness-values", $MockReadinessValues)
 }
 if (-not [string]::IsNullOrWhiteSpace($SeedPreviousVersion)) {
     $args += @("--seed-previous-version", $SeedPreviousVersion)

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1734,6 +1734,7 @@ def test_76_auto_rollback_policy_triggers_and_executes_rollback():
     payload = json.loads(output_lines[-1])
     assert payload["success"] is True
     assert payload["observation"]["triggered"] is True
+    assert payload["observation"]["trigger_reason"] == "critical_window"
     assert payload["rollback"]["attempted"] is True
     assert payload["rollback"]["executed"] is True
     assert payload["decision"]["recommended_action"] == "rollback_executed"
@@ -4569,6 +4570,136 @@ def test_137_canary_guardrails_check_fails_when_expected_promote_but_halt_occurs
         for item in payload.get("failed_criteria", [])
         if isinstance(item, dict)
     )
+    assert output_file.exists()
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_138_auto_rollback_policy_triggers_on_error_budget_burn_rate():
+    workspace = _local_test_dir("pytest-auto-rollback-hard-trigger-burn-rate").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    manifest_path = workspace / "desktop-rings.json"
+    output_file = workspace / "auto-rollback-burn-rate-report.json"
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "auto-rollback-policy.py"),
+        "--workspace",
+        str(workspace),
+        "--label",
+        "pytest-drill",
+        "--manifest-path",
+        str(manifest_path),
+        "--ring",
+        "stable",
+        "--mock-slo-statuses",
+        "ok,ok,ok,ok",
+        "--mock-error-budget-burn-rates",
+        "0.5,0.8,2.5,2.5",
+        "--mock-readiness-values",
+        "true,true,true,true",
+        "--critical-window-seconds",
+        "4",
+        "--readiness-regression-window-seconds",
+        "2",
+        "--max-error-budget-burn-rate-percent",
+        "2.0",
+        "--poll-interval-seconds",
+        "1",
+        "--max-observation-seconds",
+        "8",
+        "--seed-previous-version",
+        "0.0.1",
+        "--seed-incident-version",
+        "0.0.2",
+        "--expected-trigger-reason",
+        "error_budget_burn_rate",
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0 and "powershell executable not found" in completed.stderr.lower():
+        shutil.rmtree(workspace, ignore_errors=True)
+        pytest.skip("PowerShell is unavailable in this environment")
+    assert completed.returncode == 0, completed.stderr
+
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["observation"]["triggered"] is True
+    assert payload["observation"]["trigger_reason"] == "error_budget_burn_rate"
+    assert payload["decision"]["expected_reason_matched"] is True
+    assert payload["rollback"]["executed"] is True
+    assert payload["decision"]["recommended_action"] == "rollback_executed"
+    assert output_file.exists()
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_139_auto_rollback_policy_triggers_on_readiness_regression():
+    workspace = _local_test_dir("pytest-auto-rollback-hard-trigger-readiness").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    manifest_path = workspace / "desktop-rings.json"
+    output_file = workspace / "auto-rollback-readiness-report.json"
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "auto-rollback-policy.py"),
+        "--workspace",
+        str(workspace),
+        "--label",
+        "pytest-drill",
+        "--manifest-path",
+        str(manifest_path),
+        "--ring",
+        "stable",
+        "--mock-slo-statuses",
+        "ok,degraded,degraded,degraded",
+        "--mock-error-budget-burn-rates",
+        "0.5,0.8,0.9,0.9",
+        "--mock-readiness-values",
+        "true,false,false,false",
+        "--critical-window-seconds",
+        "4",
+        "--readiness-regression-window-seconds",
+        "1",
+        "--max-error-budget-burn-rate-percent",
+        "2.0",
+        "--poll-interval-seconds",
+        "1",
+        "--max-observation-seconds",
+        "8",
+        "--seed-previous-version",
+        "0.0.1",
+        "--seed-incident-version",
+        "0.0.2",
+        "--expected-trigger-reason",
+        "readiness_regression",
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0 and "powershell executable not found" in completed.stderr.lower():
+        shutil.rmtree(workspace, ignore_errors=True)
+        pytest.skip("PowerShell is unavailable in this environment")
+    assert completed.returncode == 0, completed.stderr
+
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["observation"]["triggered"] is True
+    assert payload["observation"]["trigger_reason"] == "readiness_regression"
+    assert payload["decision"]["expected_reason_matched"] is True
+    assert payload["rollback"]["executed"] is True
+    assert payload["decision"]["recommended_action"] == "rollback_executed"
     assert output_file.exists()
 
     shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
﻿## Summary
- extend `auto-rollback-policy.py` from single critical-window trigger to hard-trigger evaluation across:
  - sustained critical SLO window
  - error-budget burn-rate spikes
  - sustained readiness regressions
- add expected trigger-reason validation (`--expected-trigger-reason`) to enforce deterministic drill paths
- add explicit output artifact support (`--output-file`) for release-gate/CI evidence collection
- update release-gate auto-rollback drill to validate readiness-regression trigger path and emit `artifacts/auto-rollback-policy-release-gate.json`
- extend PowerShell wrapper with new hard-trigger options and defaults
- add tests for burn-rate and readiness trigger paths plus stronger assertion on legacy critical-window path
- update README + production runbook (including new sections 3.37/3.38)

## Validation
- `python -m py_compile scripts\\auto-rollback-policy.py tests\\test_goal_ops.py`
- `pytest -q tests/test_goal_ops.py::test_76_auto_rollback_policy_triggers_and_executes_rollback tests/test_goal_ops.py::test_138_auto_rollback_policy_triggers_on_error_budget_burn_rate tests/test_goal_ops.py::test_139_auto_rollback_policy_triggers_on_readiness_regression`
- `.\\scripts\\run-auto-rollback-policy.ps1 -ManifestPath "artifacts\\desktop-rings.json" -MockSloStatuses "ok,degraded,degraded,degraded" -MockErrorBudgetBurnRates "0.5,0.8,0.9,0.9" -MockReadinessValues "true,false,false,false" -CriticalWindowSeconds 4 -ReadinessRegressionWindowSeconds 1 -MaxErrorBudgetBurnRatePercent 2.0 -ExpectedTriggerReason readiness_regression -PollIntervalSeconds 1 -MaxObservationSeconds 8 -SeedPreviousVersion "0.0.1" -SeedIncidentVersion "0.0.2" -OutputFile "artifacts\\auto-rollback-policy-manual.json"`
- targeted release-gate smoke (all `Skip*` true except auto-rollback + `-StrictAutoRollbackPolicyDrill`) passed
- `.\\scripts\\run-p0-runbook-contract-check.ps1 -OutputFile "artifacts\\p0-runbook-contract-check-report.json"`
