### PR TITLE
Stage C: Disaster-Recovery Rehearsal Pack (Gate + CI + Runbook)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          .\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictIncidentDrillAutomationCheck -StrictLoadProfileFrameworkCheck -StrictCanaryGuardrailCheck -StrictRtoRpoAssertionCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+          .\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictIncidentDrillAutomationCheck -StrictLoadProfileFrameworkCheck -StrictCanaryGuardrailCheck -StrictRtoRpoAssertionCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictDisasterRecoveryRehearsalPack -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 
       - name: Upload release evidence artifacts
         uses: actions/upload-artifact@v4
@@ -51,6 +51,8 @@ jobs:
             artifacts/p0-release-evidence-bundle-release-gate.json
             artifacts/p0-release-evidence-files-release-gate/**
             artifacts/p0-closure-report-release-gate.json
+            artifacts/p0-disaster-recovery-rehearsal-pack-release-gate.json
+            artifacts/p0-disaster-recovery-rehearsal-pack-evidence-release-gate/**
             artifacts/security-config-hardening-release-gate.json
             artifacts/audit-trail-hardening-release-gate.json
             artifacts/security-ci-lane-release-gate.json

--- a/.github/workflows/disaster-recovery-rehearsal.yml
+++ b/.github/workflows/disaster-recovery-rehearsal.yml
@@ -1,0 +1,57 @@
+name: Disaster Recovery Rehearsal
+
+on:
+  schedule:
+    - cron: "45 2 * * *"
+  workflow_dispatch:
+    inputs:
+      max_total_duration_seconds:
+        description: "Duration budget in seconds for the full rehearsal pack"
+        required: false
+        default: "2400"
+
+jobs:
+  rehearsal:
+    name: Disaster Recovery Rehearsal Pack (Windows)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test]"
+
+      - name: Run disaster-recovery rehearsal pack
+        shell: pwsh
+        env:
+          MAX_TOTAL_DURATION_SECONDS: ${{ github.event.inputs.max_total_duration_seconds || '2400' }}
+        run: |
+          python .\scripts\disaster-recovery-rehearsal-pack.py `
+            --label github-actions-scheduled `
+            --profile scheduled `
+            --workspace .\.tmp\disaster-recovery-rehearsal-pack-scheduled `
+            --runbook-file .\docs\production-runbook.md `
+            --rto-rpo-policy-file .\docs\rto-rpo-assertion-policy.json `
+            --max-failed-drills 0 `
+            --max-total-duration-seconds $env:MAX_TOTAL_DURATION_SECONDS `
+            --output-file .\artifacts\p0-disaster-recovery-rehearsal-pack-scheduled.json `
+            --evidence-dir .\artifacts\p0-disaster-recovery-rehearsal-pack-evidence-scheduled
+
+      - name: Upload disaster-recovery rehearsal artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: p0-disaster-recovery-rehearsal-pack-scheduled
+          path: |
+            artifacts/p0-disaster-recovery-rehearsal-pack-scheduled.json
+            artifacts/p0-disaster-recovery-rehearsal-pack-evidence-scheduled/**
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -411,11 +411,11 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 
 ## Run Release Gate
 
-Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + security config hardening check + audit trail hardening check + security CI lane check + alert-routing/on-call runbook automation check + incident drill automation check + load profile framework check + canary guardrails check + RTO/RPO assertion suite check + release-freeze policy drill + auto-rollback hard-trigger drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle + P0 closure go/no-go report):
+Reliability-focused pre-release gate (tests + desktop smoke + readiness + DB integrity + SLO alert check + security config hardening check + audit trail hardening check + security CI lane check + alert-routing/on-call runbook automation check + incident drill automation check + load profile framework check + canary guardrails check + RTO/RPO assertion suite check + release-freeze policy drill + auto-rollback hard-trigger drill + desktop-update-safety drill + recovery hard-abort drill + recovery idempotence drill + power-loss durability drill + WAL checkpoint crash drill + disk-pressure fault-injection drill + fsync/I/O stall drill + real SQLite FULL saturation drill + DB corruption quarantine drill + storage corruption hardening drill + workflow lock-resilience drill + workflow soak drill + workflow worker restart drill + DB safe-mode watchdog drill + invariant monitor watchdog drill + event-consumer recovery chaos drill + invariant burst drill + long soak budget drill + migration state + migration rehearsal on S/M/L/XL DB copies + upgrade/downgrade compatibility drill + backup/restore drill + backup/restore stress drill + snapshot/restore crash-consistency drill + multi-db atomic-switch drill + incident/rollback drill under burst load + disaster-recovery rehearsal pack + release-gate runtime stability drill + critical drill flake gate + P0 burn-in consecutive-green monitor + P0 runbook contract check + P0 release evidence bundle + P0 closure go/no-go report):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictIncidentDrillAutomationCheck -StrictLoadProfileFrameworkCheck -StrictCanaryGuardrailCheck -StrictRtoRpoAssertionCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictIncidentDrillAutomationCheck -StrictLoadProfileFrameworkCheck -StrictCanaryGuardrailCheck -StrictRtoRpoAssertionCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictDisasterRecoveryRehearsalPack -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 ```
 
 Standalone backup/restore drill:
@@ -444,6 +444,13 @@ Standalone multi-db atomic-switch drill (pointer crash + candidate-integrity rej
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-multi-db-atomic-switch-drill.ps1 -SeedRows 96 -PayloadBytes 128
+```
+
+Standalone disaster-recovery rehearsal pack (consolidated restore/snapshot/switch/RTO-RPO evidence):
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-disaster-recovery-rehearsal-pack.ps1 -Profile scheduled -MaxTotalDurationSeconds 2400
 ```
 
 Standalone migration rehearsal drill:
@@ -740,6 +747,9 @@ Nightly stability canary workflow:
 Nightly burn-in monitor workflow:
 [p0-burnin-monitor.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/p0-burnin-monitor.yml)
 
+Nightly disaster-recovery rehearsal workflow:
+[disaster-recovery-rehearsal.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/disaster-recovery-rehearsal.yml)
+
 Recommended branch protection on `master`:
 
 1. Open repository settings on GitHub.
@@ -965,6 +975,8 @@ If a value is rejected:
 - [multi-db-atomic-switch-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/multi-db-atomic-switch-drill.py)
 - [multi-db-atomic-switch-target.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/multi-db-atomic-switch-target.py)
 - [run-multi-db-atomic-switch-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-multi-db-atomic-switch-drill.ps1)
+- [disaster-recovery-rehearsal-pack.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/disaster-recovery-rehearsal-pack.py)
+- [run-disaster-recovery-rehearsal-pack.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-disaster-recovery-rehearsal-pack.ps1)
 - [incident-rollback-drill.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/incident-rollback-drill.py)
 - [run-incident-rollback-drill.ps1](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/run-incident-rollback-drill.ps1)
 - [critical-drill-flake-gate.py](/C:/Users/raffa/OneDrive/Documents/New%20project/scripts/critical-drill-flake-gate.py)

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -9,7 +9,7 @@ This runbook is optimized for reliability-first releases of the desktop app and 
 Run in repo root:
 
 ```powershell
-.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictIncidentDrillAutomationCheck -StrictLoadProfileFrameworkCheck -StrictCanaryGuardrailCheck -StrictRtoRpoAssertionCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
+.\scripts\release-gate.ps1 -StrictSecurityConfigHardeningCheck -StrictAuditTrailHardeningCheck -StrictSecurityCiLaneCheck -StrictAlertRoutingOnCallCheck -StrictIncidentDrillAutomationCheck -StrictLoadProfileFrameworkCheck -StrictCanaryGuardrailCheck -StrictRtoRpoAssertionCheck -StrictReleaseFreezePolicyDrill -StrictFileDatabaseProbe -StrictAutoRollbackPolicyDrill -StrictDesktopUpdateSafetyDrill -StrictRecoveryHardAbortDrill -StrictRecoveryIdempotenceDrill -StrictPowerLossDurabilityDrill -StrictWalCheckpointCrashDrill -StrictDiskPressureFaultInjectionDrill -StrictFsyncIoStallDrill -StrictSqliteRealFullDrill -StrictDbCorruptionQuarantineDrill -StrictStorageCorruptionHardeningDrill -StrictWorkflowLockResilienceDrill -StrictWorkflowSoakDrill -StrictWorkflowWorkerRestartDrill -StrictDbSafeModeWatchdogDrill -StrictInvariantMonitorWatchdogDrill -StrictEventConsumerRecoveryChaosDrill -StrictInvariantBurstDrill -StrictLongSoakBudgetDrill -StrictMigrationRehearsal -StrictUpgradeDowngradeCompatibilityDrill -StrictBackupRestoreDrill -StrictBackupRestoreStressDrill -StrictSnapshotRestoreCrashConsistencyDrill -StrictMultiDbAtomicSwitchDrill -StrictIncidentRollbackDrill -StrictDisasterRecoveryRehearsalPack -StrictReleaseGateRuntimeStabilityDrill -StrictCriticalDrillFlakeGate -StrictP0BurnInConsecutiveGreen -StrictP0RunbookContractCheck -StrictP0ReleaseEvidenceBundle -StrictP0ClosureReport
 ```
 
 This gate covers:
@@ -54,6 +54,7 @@ This gate covers:
 - snapshot/restore crash-consistency drill (hard-aborted copy fault matrix, manifest preflight checks, and deterministic recovery restore)
 - multi-db atomic-switch drill (pointer update crash simulation, corrupted-candidate reject, and deterministic switch rollback path)
 - incident/rollback drill with controlled burst load, SLO incident detection, and stable-ring rollback validation
+- disaster-recovery rehearsal pack (aggregated backup/snapshot/switch/RTO-RPO drills with deterministic release-block decision + evidence files)
 - release-gate runtime stability drill (critical-drill duration/variance budget sampling)
 - P0 burn-in consecutive-green monitor (latest CI history must satisfy N consecutive fully green runs)
 - P0 runbook contract check (release-gate/CI/runbook strict-flag and script-reference consistency)
@@ -264,6 +265,12 @@ Manual multi-db atomic-switch drill invocation:
 .\scripts\run-multi-db-atomic-switch-drill.ps1 -SeedRows 96 -PayloadBytes 128
 ```
 
+Manual disaster-recovery rehearsal pack invocation:
+
+```powershell
+.\scripts\run-disaster-recovery-rehearsal-pack.ps1 -Profile scheduled -MaxTotalDurationSeconds 2400
+```
+
 Manual release-gate runtime stability drill invocation:
 
 ```powershell
@@ -303,6 +310,7 @@ Verify before release:
 - burn-in monitor report confirms threshold met (`metrics.consecutive_green >= metrics.required_consecutive`)
 - runbook contract report confirms zero missing flags/scripts (`success=true`)
 - release evidence bundle report confirms all required P0 reports present and successful (`success=true`)
+- disaster-recovery rehearsal release-gate report is present and green (`artifacts\p0-disaster-recovery-rehearsal-pack-release-gate.json`, `success=true`)
 - closure report confirms all readiness criteria are green (`success=true`, `metrics.criteria_failed=0`)
 - security hardening report confirms production policy criteria are green (`success=true`)
 - `master` branch only receives PR merges (no direct pushes).
@@ -1073,6 +1081,40 @@ Actions:
    - `decision.recommended_action = rollback_executed` (or `manual_rollback_required` in dry-run mode)
 3. If expected trigger reason is not matched, keep release blocked and escalate policy defect immediately.
 4. Resume rollout only after readiness is stable and a fresh rollback-policy drill passes with expected reason.
+
+### 3.39 Disaster-recovery rehearsal pack
+
+Symptoms:
+- restore/snapshot/switch and RTO/RPO signals are green individually, but there is no single consolidated go/no-go artifact
+- release evidence lacks deterministic proof that all disaster-recovery drills passed under one execution budget
+
+Actions:
+1. Execute consolidated rehearsal pack (release-gate profile):
+   ```powershell
+   .\scripts\run-disaster-recovery-rehearsal-pack.ps1 -Profile release-gate -MaxFailedDrills 0 -MaxTotalDurationSeconds 2400 -OutputFile "artifacts\p0-disaster-recovery-rehearsal-pack-release-gate.json" -EvidenceDir "artifacts\p0-disaster-recovery-rehearsal-pack-evidence-release-gate"
+   ```
+2. Validate release-block decision:
+   - `success = true`
+   - `decision.release_blocked = false`
+   - `metrics.drills_failed = 0`
+   - `metrics.duration_budget_exceeded = false`
+3. Confirm per-drill evidence exists under `paths.evidence_files` and attach artifacts to change/incident record.
+4. If report fails any threshold, keep release blocked and remediate before re-running release gate.
+
+### 3.40 Scheduled DR evidence freshness
+
+Symptoms:
+- no recent periodic disaster-recovery rehearsal evidence is available
+- operators cannot confirm recovery posture drift between releases
+
+Actions:
+1. Trigger scheduled pack manually if needed:
+   ```powershell
+   .\scripts\run-disaster-recovery-rehearsal-pack.ps1 -Profile scheduled -MaxTotalDurationSeconds 2400 -OutputFile "artifacts\p0-disaster-recovery-rehearsal-pack-scheduled.json" -EvidenceDir "artifacts\p0-disaster-recovery-rehearsal-pack-evidence-scheduled"
+   ```
+2. Verify report criteria remain green (`success=true`, `metrics.drills_failed=0`, `decision.release_blocked=false`).
+3. Track report timestamp (`generated_at_utc`) and keep at least one recent successful scheduled report available during release review.
+4. If scheduled report fails, open incident and hold promotion until fresh green evidence is produced.
 
 ## 4. Operational Defaults
 

--- a/scripts/disaster-recovery-rehearsal-pack.py
+++ b/scripts/disaster-recovery-rehearsal-pack.py
@@ -1,0 +1,488 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _parse_csv_list(text: str) -> list[str]:
+    return [item.strip() for item in str(text).split(",") if item.strip()]
+
+
+def _resolve_path(project_root: Path, value: str) -> Path:
+    path = Path(str(value)).expanduser()
+    if not path.is_absolute():
+        path = project_root / path
+    return path.resolve()
+
+
+def _extract_json_from_text(raw: str) -> dict[str, Any] | None:
+    candidate = str(raw or "").strip()
+    if not candidate:
+        return None
+    lines = [line.strip() for line in candidate.splitlines() if line.strip()]
+    if lines:
+        try:
+            payload = json.loads(lines[-1])
+            if isinstance(payload, dict):
+                return payload
+        except Exception:
+            pass
+    start = candidate.find("{")
+    end = candidate.rfind("}")
+    if start >= 0 and end > start:
+        try:
+            payload = json.loads(candidate[start : end + 1])
+            if isinstance(payload, dict):
+                return payload
+        except Exception:
+            return None
+    return None
+
+
+def _build_default_plan(
+    *,
+    profile: str,
+    python_exe: str,
+    run_dir: Path,
+    runbook_file: Path,
+    rto_rpo_policy_file: Path,
+) -> list[dict[str, Any]]:
+    if profile == "release-gate":
+        return [
+            {
+                "name": "snapshot_restore_crash_consistency",
+                "command": [
+                    python_exe,
+                    str(PROJECT_ROOT / "scripts" / "snapshot-restore-crash-consistency-drill.py"),
+                    "--workspace",
+                    str((run_dir / "snapshot-restore").resolve()),
+                    "--label",
+                    "disaster-recovery-pack-release-gate",
+                    "--seed-rows",
+                    "80",
+                    "--payload-bytes",
+                    "128",
+                ],
+            },
+            {
+                "name": "multi_db_atomic_switch",
+                "command": [
+                    python_exe,
+                    str(PROJECT_ROOT / "scripts" / "multi-db-atomic-switch-drill.py"),
+                    "--workspace",
+                    str((run_dir / "multi-db-atomic-switch").resolve()),
+                    "--label",
+                    "disaster-recovery-pack-release-gate",
+                    "--seed-rows",
+                    "80",
+                    "--payload-bytes",
+                    "128",
+                ],
+            },
+            {
+                "name": "rto_rpo_assertion",
+                "command": [
+                    python_exe,
+                    str(PROJECT_ROOT / "scripts" / "rto-rpo-assertion-suite.py"),
+                    "--workspace",
+                    str((run_dir / "rto-rpo-assertion").resolve()),
+                    "--label",
+                    "disaster-recovery-pack-release-gate",
+                    "--deployment-profile",
+                    "production",
+                    "--policy-file",
+                    str(rto_rpo_policy_file.resolve()),
+                    "--runbook-file",
+                    str(runbook_file.resolve()),
+                    "--seed-rows",
+                    "48",
+                    "--tail-write-rows",
+                    "12",
+                    "--max-rto-seconds",
+                    "20",
+                    "--max-rpo-rows-lost",
+                    "96",
+                    "--output-file",
+                    str((run_dir / "rto-rpo-assertion-report.json").resolve()),
+                ],
+            },
+        ]
+
+    _expect(profile == "scheduled", f"Unsupported profile {profile!r}.")
+    return [
+        {
+            "name": "backup_restore",
+            "command": [
+                python_exe,
+                str(PROJECT_ROOT / "scripts" / "backup-restore-drill.py"),
+                "--workspace",
+                str((run_dir / "backup-restore").resolve()),
+                "--label",
+                "disaster-recovery-pack-scheduled",
+            ],
+        },
+        {
+            "name": "backup_restore_stress",
+            "command": [
+                python_exe,
+                str(PROJECT_ROOT / "scripts" / "backup-restore-stress-drill.py"),
+                "--workspace",
+                str((run_dir / "backup-restore-stress").resolve()),
+                "--label",
+                "disaster-recovery-pack-scheduled",
+                "--rounds",
+                "3",
+                "--goals-per-round",
+                "120",
+                "--tasks-per-goal",
+                "2",
+                "--workflow-runs-per-round",
+                "24",
+            ],
+        },
+        {
+            "name": "snapshot_restore_crash_consistency",
+            "command": [
+                python_exe,
+                str(PROJECT_ROOT / "scripts" / "snapshot-restore-crash-consistency-drill.py"),
+                "--workspace",
+                str((run_dir / "snapshot-restore").resolve()),
+                "--label",
+                "disaster-recovery-pack-scheduled",
+                "--seed-rows",
+                "96",
+                "--payload-bytes",
+                "128",
+            ],
+        },
+        {
+            "name": "multi_db_atomic_switch",
+            "command": [
+                python_exe,
+                str(PROJECT_ROOT / "scripts" / "multi-db-atomic-switch-drill.py"),
+                "--workspace",
+                str((run_dir / "multi-db-atomic-switch").resolve()),
+                "--label",
+                "disaster-recovery-pack-scheduled",
+                "--seed-rows",
+                "96",
+                "--payload-bytes",
+                "128",
+            ],
+        },
+        {
+            "name": "rto_rpo_assertion",
+            "command": [
+                python_exe,
+                str(PROJECT_ROOT / "scripts" / "rto-rpo-assertion-suite.py"),
+                "--workspace",
+                str((run_dir / "rto-rpo-assertion").resolve()),
+                "--label",
+                "disaster-recovery-pack-scheduled",
+                "--deployment-profile",
+                "production",
+                "--policy-file",
+                str(rto_rpo_policy_file.resolve()),
+                "--runbook-file",
+                str(runbook_file.resolve()),
+                "--seed-rows",
+                "48",
+                "--tail-write-rows",
+                "12",
+                "--max-rto-seconds",
+                "20",
+                "--max-rpo-rows-lost",
+                "96",
+                "--output-file",
+                str((run_dir / "rto-rpo-assertion-report.json").resolve()),
+            ],
+        },
+    ]
+
+
+def _run_drill(name: str, command: list[str]) -> dict[str, Any]:
+    started = time.perf_counter()
+    completed = subprocess.run(
+        command,
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    duration_seconds = round(float(time.perf_counter() - started), 3)
+
+    stdout_text = str(completed.stdout or "")
+    stderr_text = str(completed.stderr or "")
+    payload = _extract_json_from_text(stdout_text)
+    if payload is None and completed.returncode != 0:
+        payload = _extract_json_from_text(stderr_text)
+
+    payload_success = (
+        bool(payload.get("success")) if isinstance(payload, dict) and isinstance(payload.get("success"), bool) else None
+    )
+    success = completed.returncode == 0 and payload_success is True
+    error_summary = ""
+    if completed.returncode != 0:
+        error_summary = (stderr_text.strip() or stdout_text.strip())[:400]
+    elif payload_success is not True:
+        error_summary = "Command succeeded but payload.success != true."
+
+    return {
+        "name": name,
+        "command": command,
+        "returncode": int(completed.returncode),
+        "duration_seconds": duration_seconds,
+        "success": bool(success),
+        "payload_success": payload_success,
+        "payload": payload if isinstance(payload, dict) else None,
+        "stdout_excerpt": stdout_text.strip()[:400],
+        "stderr_excerpt": stderr_text.strip()[:400],
+        "error_summary": error_summary or None,
+    }
+
+
+def _load_mock_results(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    _expect(isinstance(payload, dict), "Mock drill results file must contain a JSON object.")
+    drills = payload.get("drills")
+    _expect(isinstance(drills, list), "Mock drill results file must define list key 'drills'.")
+
+    normalized: list[dict[str, Any]] = []
+    for index, item in enumerate(drills):
+        _expect(isinstance(item, dict), f"Mock drill result at index {index} must be an object.")
+        name = str(item.get("name") or "").strip()
+        _expect(bool(name), f"Mock drill result at index {index} is missing 'name'.")
+        success_value = item.get("success")
+        _expect(
+            isinstance(success_value, bool),
+            f"Mock drill result '{name}' must provide boolean 'success'.",
+        )
+        payload_value = item.get("payload")
+        normalized.append(
+            {
+                "name": name,
+                "command": ["<mock>"],
+                "returncode": 0 if success_value else 1,
+                "duration_seconds": round(float(item.get("duration_seconds", 0.01)), 3),
+                "success": bool(success_value),
+                "payload_success": bool(success_value),
+                "payload": payload_value if isinstance(payload_value, dict) else {"success": bool(success_value)},
+                "stdout_excerpt": "<mock>",
+                "stderr_excerpt": "",
+                "error_summary": None if success_value else "Mock drill marked as failed.",
+            }
+        )
+    return normalized
+
+
+def run_pack(
+    *,
+    label: str,
+    profile: str,
+    python_exe: str,
+    workspace_root: Path,
+    runbook_file: Path,
+    rto_rpo_policy_file: Path,
+    drill_filter: list[str],
+    mock_drill_results_file: Path | None,
+    max_failed_drills: int,
+    max_total_duration_seconds: int,
+    output_file: Path,
+    evidence_dir: Path,
+    keep_artifacts: bool,
+    allow_failure: bool,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    run_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+    run_dir = workspace_root / f"disaster-recovery-rehearsal-pack-{run_id}"
+    run_dir.mkdir(parents=True, exist_ok=False)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        if mock_drill_results_file is not None:
+            drill_results = _load_mock_results(mock_drill_results_file)
+            effective_profile = "mock"
+        else:
+            plan = _build_default_plan(
+                profile=profile,
+                python_exe=python_exe,
+                run_dir=run_dir,
+                runbook_file=runbook_file,
+                rto_rpo_policy_file=rto_rpo_policy_file,
+            )
+            available_names = [str(item["name"]) for item in plan]
+            if drill_filter:
+                unknown = [name for name in drill_filter if name not in available_names]
+                _expect(not unknown, f"Unknown drill-filter item(s): {unknown}")
+                selected = [item for item in plan if str(item["name"]) in drill_filter]
+            else:
+                selected = plan
+            _expect(selected, "No drills selected for disaster recovery rehearsal pack.")
+            drill_results = [_run_drill(str(item["name"]), list(item["command"])) for item in selected]
+            effective_profile = profile
+
+        copied_evidence_files: list[str] = []
+        for drill in drill_results:
+            evidence_path = evidence_dir / f"{drill['name']}-report.json"
+            evidence_payload = drill["payload"]
+            if not isinstance(evidence_payload, dict):
+                evidence_payload = {
+                    "success": False,
+                    "error": str(drill.get("error_summary") or "missing payload"),
+                    "name": str(drill["name"]),
+                }
+            evidence_path.write_text(
+                json.dumps(evidence_payload, ensure_ascii=True, sort_keys=True, indent=2),
+                encoding="utf-8",
+            )
+            copied_evidence_files.append(str(evidence_path.resolve()))
+
+        failed_drills = [item for item in drill_results if not bool(item.get("success"))]
+        total_duration_seconds = round(sum(float(item.get("duration_seconds") or 0.0) for item in drill_results), 3)
+        duration_budget_exceeded = total_duration_seconds > float(max_total_duration_seconds)
+
+        success = len(failed_drills) <= int(max_failed_drills) and not duration_budget_exceeded
+        report = {
+            "label": label,
+            "success": bool(success),
+            "profile": effective_profile,
+            "config": {
+                "python_exe": python_exe,
+                "workspace_root": str(workspace_root),
+                "runbook_file": str(runbook_file),
+                "rto_rpo_policy_file": str(rto_rpo_policy_file),
+                "drill_filter": drill_filter,
+                "mock_drill_results_file": str(mock_drill_results_file) if mock_drill_results_file else None,
+                "max_failed_drills": int(max_failed_drills),
+                "max_total_duration_seconds": int(max_total_duration_seconds),
+                "keep_artifacts": bool(keep_artifacts),
+                "allow_failure": bool(allow_failure),
+            },
+            "metrics": {
+                "drills_total": len(drill_results),
+                "drills_passed": len(drill_results) - len(failed_drills),
+                "drills_failed": len(failed_drills),
+                "total_duration_seconds": total_duration_seconds,
+                "duration_budget_exceeded": bool(duration_budget_exceeded),
+            },
+            "decision": {
+                "release_blocked": not bool(success),
+                "recommended_action": "block_release" if not success else "proceed",
+                "runbook_path": "docs/production-runbook.md#339-disaster-recovery-rehearsal-pack",
+            },
+            "drills": drill_results,
+            "failed_drills": failed_drills,
+            "paths": {
+                "run_dir": str(run_dir),
+                "output_file": str(output_file),
+                "evidence_dir": str(evidence_dir),
+                "evidence_files": copied_evidence_files,
+            },
+            "generated_at_utc": _utc_now(),
+            "duration_ms": int((time.perf_counter() - started) * 1000),
+        }
+        output_file.write_text(
+            json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2),
+            encoding="utf-8",
+        )
+
+        if not success and not allow_failure:
+            raise RuntimeError(f"Disaster recovery rehearsal pack failed: {json.dumps(report, sort_keys=True)}")
+        return report
+    finally:
+        if not keep_artifacts and run_dir.exists():
+            shutil.rmtree(run_dir, ignore_errors=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a disaster-recovery rehearsal pack (restore/snapshot/switch/RTO-RPO) and emit "
+            "a consolidated evidence report for release blocking and scheduled operations."
+        )
+    )
+    parser.add_argument("--label", default="disaster-recovery-rehearsal-pack")
+    parser.add_argument("--profile", choices=["release-gate", "scheduled"], default="scheduled")
+    parser.add_argument("--python-exe", default=sys.executable)
+    parser.add_argument("--workspace", default=str(PROJECT_ROOT / ".tmp" / "disaster-recovery-rehearsal-pack"))
+    parser.add_argument("--runbook-file", default=str(PROJECT_ROOT / "docs" / "production-runbook.md"))
+    parser.add_argument("--rto-rpo-policy-file", default=str(PROJECT_ROOT / "docs" / "rto-rpo-assertion-policy.json"))
+    parser.add_argument("--drill-filter", default="")
+    parser.add_argument("--mock-drill-results-file", default="")
+    parser.add_argument("--max-failed-drills", type=int, default=0)
+    parser.add_argument("--max-total-duration-seconds", type=int, default=2400)
+    parser.add_argument(
+        "--output-file",
+        default=str(PROJECT_ROOT / "artifacts" / "disaster-recovery-rehearsal-pack-report.json"),
+    )
+    parser.add_argument(
+        "--evidence-dir",
+        default=str(PROJECT_ROOT / "artifacts" / "disaster-recovery-rehearsal-pack-evidence"),
+    )
+    parser.add_argument("--keep-artifacts", action="store_true")
+    parser.add_argument("--allow-failure", action="store_true")
+    args = parser.parse_args(argv)
+
+    if int(args.max_failed_drills) < 0:
+        print("[disaster-recovery-rehearsal-pack] ERROR: --max-failed-drills must be >= 0.", file=sys.stderr)
+        return 2
+    if int(args.max_total_duration_seconds) <= 0:
+        print("[disaster-recovery-rehearsal-pack] ERROR: --max-total-duration-seconds must be > 0.", file=sys.stderr)
+        return 2
+
+    drill_filter = _parse_csv_list(args.drill_filter)
+    mock_results_file = None
+    if str(args.mock_drill_results_file).strip():
+        mock_results_file = _resolve_path(PROJECT_ROOT, args.mock_drill_results_file)
+        if not mock_results_file.exists():
+            print(
+                f"[disaster-recovery-rehearsal-pack] ERROR: mock results file not found: {mock_results_file}",
+                file=sys.stderr,
+            )
+            return 2
+
+    try:
+        report = run_pack(
+            label=str(args.label),
+            profile=str(args.profile),
+            python_exe=str(args.python_exe),
+            workspace_root=_resolve_path(PROJECT_ROOT, args.workspace),
+            runbook_file=_resolve_path(PROJECT_ROOT, args.runbook_file),
+            rto_rpo_policy_file=_resolve_path(PROJECT_ROOT, args.rto_rpo_policy_file),
+            drill_filter=drill_filter,
+            mock_drill_results_file=mock_results_file,
+            max_failed_drills=int(args.max_failed_drills),
+            max_total_duration_seconds=int(args.max_total_duration_seconds),
+            output_file=_resolve_path(PROJECT_ROOT, args.output_file),
+            evidence_dir=_resolve_path(PROJECT_ROOT, args.evidence_dir),
+            keep_artifacts=bool(args.keep_artifacts),
+            allow_failure=bool(args.allow_failure),
+        )
+    except Exception as exc:
+        print(f"[disaster-recovery-rehearsal-pack] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/p0-runbook-contract-check.py
+++ b/scripts/p0-runbook-contract-check.py
@@ -18,6 +18,7 @@ DEFAULT_REQUIRED_RUNBOOK_SCRIPTS = [
     "run-load-profile-framework-check.ps1",
     "run-canary-guardrails-check.ps1",
     "run-rto-rpo-assertion-suite.ps1",
+    "run-disaster-recovery-rehearsal-pack.ps1",
     "run-power-loss-durability-drill.ps1",
     "run-disk-pressure-fault-injection-drill.ps1",
     "run-upgrade-downgrade-compatibility-drill.ps1",

--- a/scripts/release-gate.ps1
+++ b/scripts/release-gate.ps1
@@ -76,6 +76,8 @@ param(
     [switch]$StrictMultiDbAtomicSwitchDrill,
     [switch]$SkipIncidentRollbackDrill,
     [switch]$StrictIncidentRollbackDrill,
+    [switch]$SkipDisasterRecoveryRehearsalPack,
+    [switch]$StrictDisasterRecoveryRehearsalPack,
     [switch]$SkipReleaseGateRuntimeStabilityDrill,
     [switch]$StrictReleaseGateRuntimeStabilityDrill,
     [switch]$SkipCriticalDrillFlakeGate,
@@ -1044,6 +1046,37 @@ if (-not $SkipIncidentRollbackDrill) {
             }
             Write-Warning (
                 "Incident/rollback drill failed but StrictIncidentRollbackDrill is off. " +
+                "Continuing. Error: $($_.Exception.Message)"
+            )
+        }
+    }
+}
+
+if (-not $SkipDisasterRecoveryRehearsalPack) {
+    Invoke-GateStep -Name "Disaster-recovery rehearsal pack (consolidated restore/switch/RTO-RPO evidence)" -Action {
+        $workspace = Join-Path $ProjectRoot ".tmp\disaster-recovery-rehearsal-pack"
+        $reportPath = Join-Path $ProjectRoot "artifacts\p0-disaster-recovery-rehearsal-pack-release-gate.json"
+        $evidenceDir = Join-Path $ProjectRoot "artifacts\p0-disaster-recovery-rehearsal-pack-evidence-release-gate"
+        $P0EvidenceReportPaths += $reportPath
+        try {
+            Invoke-NativeCommand -Executable $PythonExe -Arguments @(
+                ".\scripts\disaster-recovery-rehearsal-pack.py",
+                "--workspace", $workspace,
+                "--label", "release-gate",
+                "--profile", "release-gate",
+                "--runbook-file", "docs/production-runbook.md",
+                "--rto-rpo-policy-file", "docs/rto-rpo-assertion-policy.json",
+                "--max-failed-drills", "0",
+                "--max-total-duration-seconds", "2400",
+                "--output-file", $reportPath,
+                "--evidence-dir", $evidenceDir
+            )
+        } catch {
+            if ($StrictDisasterRecoveryRehearsalPack) {
+                throw
+            }
+            Write-Warning (
+                "Disaster-recovery rehearsal pack failed but StrictDisasterRecoveryRehearsalPack is off. " +
                 "Continuing. Error: $($_.Exception.Message)"
             )
         }

--- a/scripts/run-disaster-recovery-rehearsal-pack.ps1
+++ b/scripts/run-disaster-recovery-rehearsal-pack.ps1
@@ -1,0 +1,53 @@
+param(
+    [string]$PythonExe = "python",
+    [ValidateSet("release-gate", "scheduled")]
+    [string]$Profile = "scheduled",
+    [string]$Workspace = ".tmp\disaster-recovery-rehearsal-pack",
+    [string]$RunbookFile = "docs\production-runbook.md",
+    [string]$RtoRpoPolicyFile = "docs\rto-rpo-assertion-policy.json",
+    [string]$DrillFilter = "",
+    [string]$MockDrillResultsFile = "",
+    [int]$MaxFailedDrills = 0,
+    [int]$MaxTotalDurationSeconds = 2400,
+    [string]$OutputFile = "artifacts\disaster-recovery-rehearsal-pack-report.json",
+    [string]$EvidenceDir = "artifacts\disaster-recovery-rehearsal-pack-evidence",
+    [switch]$KeepArtifacts,
+    [switch]$AllowFailure
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$arguments = @(
+    ".\scripts\disaster-recovery-rehearsal-pack.py",
+    "--label", "manual",
+    "--profile", $Profile,
+    "--workspace", $Workspace,
+    "--runbook-file", $RunbookFile,
+    "--rto-rpo-policy-file", $RtoRpoPolicyFile,
+    "--max-failed-drills", [string]$MaxFailedDrills,
+    "--max-total-duration-seconds", [string]$MaxTotalDurationSeconds,
+    "--output-file", $OutputFile,
+    "--evidence-dir", $EvidenceDir
+)
+if (-not [string]::IsNullOrWhiteSpace($DrillFilter)) {
+    $arguments += @("--drill-filter", $DrillFilter)
+}
+if (-not [string]::IsNullOrWhiteSpace($MockDrillResultsFile)) {
+    $arguments += @("--mock-drill-results-file", $MockDrillResultsFile)
+}
+if ($KeepArtifacts) {
+    $arguments += "--keep-artifacts"
+}
+if ($AllowFailure) {
+    $arguments += "--allow-failure"
+}
+
+& $PythonExe @arguments
+if ($LASTEXITCODE -ne 0) {
+    throw "Disaster-recovery rehearsal pack failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Disaster-recovery rehearsal pack passed." -ForegroundColor Green

--- a/scripts/run-p0-runbook-contract-check.ps1
+++ b/scripts/run-p0-runbook-contract-check.ps1
@@ -1,7 +1,7 @@
 param(
     [string]$PythonExe = "python",
     [string]$OutputFile = "artifacts\\p0-runbook-contract-check-report.json",
-    [string]$RequiredRunbookScripts = "run-security-config-hardening-check.ps1,run-audit-trail-hardening-check.ps1,run-security-ci-lane-check.ps1,run-alert-routing-oncall-check.ps1,run-incident-drill-automation-check.ps1,run-load-profile-framework-check.ps1,run-canary-guardrails-check.ps1,run-rto-rpo-assertion-suite.ps1,run-power-loss-durability-drill.ps1,run-disk-pressure-fault-injection-drill.ps1,run-upgrade-downgrade-compatibility-drill.ps1,run-backup-restore-stress-drill.ps1,run-release-gate-runtime-stability-drill.ps1,run-p0-burnin-consecutive-green.ps1,run-p0-release-evidence-bundle.ps1,run-p0-closure-report.ps1",
+    [string]$RequiredRunbookScripts = "run-security-config-hardening-check.ps1,run-audit-trail-hardening-check.ps1,run-security-ci-lane-check.ps1,run-alert-routing-oncall-check.ps1,run-incident-drill-automation-check.ps1,run-load-profile-framework-check.ps1,run-canary-guardrails-check.ps1,run-rto-rpo-assertion-suite.ps1,run-disaster-recovery-rehearsal-pack.ps1,run-power-loss-durability-drill.ps1,run-disk-pressure-fault-injection-drill.ps1,run-upgrade-downgrade-compatibility-drill.ps1,run-backup-restore-stress-drill.ps1,run-release-gate-runtime-stability-drill.ps1,run-p0-burnin-consecutive-green.ps1,run-p0-release-evidence-bundle.ps1,run-p0-closure-report.ps1",
     [string]$RequiredStrictFlags = ""
 )
 

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -4703,3 +4703,158 @@ def test_139_auto_rollback_policy_triggers_on_readiness_regression():
     assert output_file.exists()
 
     shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_140_disaster_recovery_rehearsal_pack_reports_success_with_mock_results():
+    workspace = _local_test_dir("pytest-disaster-recovery-rehearsal-pack-success").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    mock_results_file = workspace / "mock-drill-results.json"
+    output_file = workspace / "disaster-recovery-rehearsal-pack-report.json"
+    evidence_dir = workspace / "evidence"
+
+    mock_results_file.write_text(
+        json.dumps(
+            {
+                "drills": [
+                    {
+                        "name": "snapshot_restore_crash_consistency",
+                        "success": True,
+                        "duration_seconds": 0.8,
+                        "payload": {"success": True, "report": "snapshot"},
+                    },
+                    {
+                        "name": "multi_db_atomic_switch",
+                        "success": True,
+                        "duration_seconds": 0.7,
+                        "payload": {"success": True, "report": "switch"},
+                    },
+                    {
+                        "name": "rto_rpo_assertion",
+                        "success": True,
+                        "duration_seconds": 0.6,
+                        "payload": {"success": True, "report": "rto-rpo"},
+                    },
+                ]
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "disaster-recovery-rehearsal-pack.py"),
+        "--label",
+        "pytest-drill",
+        "--profile",
+        "release-gate",
+        "--workspace",
+        str((workspace / "run-workspace").resolve()),
+        "--mock-drill-results-file",
+        str(mock_results_file.resolve()),
+        "--max-failed-drills",
+        "0",
+        "--max-total-duration-seconds",
+        "120",
+        "--output-file",
+        str(output_file.resolve()),
+        "--evidence-dir",
+        str(evidence_dir.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["profile"] == "mock"
+    assert payload["metrics"]["drills_total"] == 3
+    assert payload["metrics"]["drills_failed"] == 0
+    assert payload["metrics"]["duration_budget_exceeded"] is False
+    assert payload["decision"]["release_blocked"] is False
+    assert output_file.exists()
+    assert len(payload["paths"]["evidence_files"]) == 3
+    for evidence_file in payload["paths"]["evidence_files"]:
+        assert Path(evidence_file).exists()
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_141_disaster_recovery_rehearsal_pack_fails_when_duration_budget_is_exceeded():
+    workspace = _local_test_dir("pytest-disaster-recovery-rehearsal-pack-duration-failure").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    mock_results_file = workspace / "mock-drill-results.json"
+    output_file = workspace / "disaster-recovery-rehearsal-pack-report.json"
+    evidence_dir = workspace / "evidence"
+
+    mock_results_file.write_text(
+        json.dumps(
+            {
+                "drills": [
+                    {
+                        "name": "snapshot_restore_crash_consistency",
+                        "success": True,
+                        "duration_seconds": 3.0,
+                        "payload": {"success": True},
+                    },
+                    {
+                        "name": "multi_db_atomic_switch",
+                        "success": True,
+                        "duration_seconds": 2.5,
+                        "payload": {"success": True},
+                    },
+                ]
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "disaster-recovery-rehearsal-pack.py"),
+        "--label",
+        "pytest-drill",
+        "--profile",
+        "release-gate",
+        "--workspace",
+        str((workspace / "run-workspace").resolve()),
+        "--mock-drill-results-file",
+        str(mock_results_file.resolve()),
+        "--max-failed-drills",
+        "0",
+        "--max-total-duration-seconds",
+        "1",
+        "--output-file",
+        str(output_file.resolve()),
+        "--evidence-dir",
+        str(evidence_dir.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "[disaster-recovery-rehearsal-pack] ERROR: "
+    assert marker in completed.stderr
+    error_text = completed.stderr.split(marker, 1)[1].strip()
+    payload_text = error_text
+    nested_marker = "Disaster recovery rehearsal pack failed: "
+    if payload_text.startswith(nested_marker):
+        payload_text = payload_text.split(nested_marker, 1)[1]
+    payload = json.loads(payload_text)
+    assert payload["success"] is False
+    assert payload["metrics"]["drills_failed"] == 0
+    assert payload["metrics"]["duration_budget_exceeded"] is True
+    assert payload["decision"]["release_blocked"] is True
+    assert output_file.exists()
+
+    shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
﻿## Summary
- add `scripts/disaster-recovery-rehearsal-pack.py` to orchestrate DR drills into one deterministic release-block decision and evidence bundle
- add `scripts/run-disaster-recovery-rehearsal-pack.ps1` wrapper with profile/filter/mock controls
- integrate a strict/skip release-gate step (`StrictDisasterRecoveryRehearsalPack`) and include artifacts in CI release evidence upload
- add scheduled workflow `.github/workflows/disaster-recovery-rehearsal.yml` for recurring DR evidence generation
- update README + production runbook + P0 runbook contract required-script list
- add automated tests for success/failure paths of the new rehearsal pack

## Verification
- `python -m py_compile scripts/disaster-recovery-rehearsal-pack.py scripts/p0-runbook-contract-check.py tests/test_goal_ops.py`
- `python -m pytest -q tests/test_goal_ops.py -k "test_112_p0_runbook_contract_check_reports_success or test_140_disaster_recovery_rehearsal_pack_reports_success_with_mock_results or test_141_disaster_recovery_rehearsal_pack_fails_when_duration_budget_is_exceeded"`
- `python -m pytest -q tests/test_goal_ops.py -k test_112_p0_runbook_contract_check_reports_success`
- wrapper smoke: `scripts/run-disaster-recovery-rehearsal-pack.ps1` with mock drill file
- release-gate smoke with all `Skip*` enabled except disaster-recovery pack + `StrictDisasterRecoveryRehearsalPack`
- `python scripts/p0-runbook-contract-check.py --label local-verify --output-file artifacts/p0-runbook-contract-check-local-verify.json`
