### PR TITLE
Stage F: add P0 schema contract drill to nightly stability canary

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,7 +728,7 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-p0-runbook-contract-check.ps1
 ```
 
-Standalone P0 report schema contract check (minimal schema + decision contract across all `*-release-gate.json` files):
+Standalone P0 report schema contract check (baseline `label/success` schema on required release-gate evidence reports):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
@@ -800,7 +800,7 @@ python .\scripts\desktop-smoke.py
 
 ## Nightly Stability Canary
 
-Run the full canary profile locally (includes release-freeze policy, power-loss durability, DB corruption quarantine, upgrade/downgrade compatibility, watchdog drills, recovery chaos, invariant burst, Stage-D safe-mode UX/A11y checks, and long soak budgets). Missing baseline drill entries are treated as regressions.
+Run the full canary profile locally (includes release-freeze policy, power-loss durability, DB corruption quarantine, upgrade/downgrade compatibility, watchdog drills, recovery chaos, invariant burst, Stage-D safe-mode UX/A11y checks, P0 report-schema contract validation on required canary evidence reports, and long soak budgets). Missing baseline drill entries are treated as regressions.
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -63,7 +63,7 @@ This gate covers:
 - release-gate runtime stability drill (critical-drill duration/variance budget sampling across storage + Stage-D UX/A11y contracts)
 - P0 burn-in consecutive-green monitor (latest CI history must satisfy N consecutive fully green runs)
 - P0 runbook contract check (release-gate token + CI artifact path + runbook metric token + strict-flag/script-reference consistency and canary baseline drill completeness)
-- P0 report schema contract check (minimal top-level + decision-field schema contract across all release-gate JSON reports)
+- P0 report schema contract check (baseline `label/success` schema contract across required release-gate evidence reports)
 - P0 release evidence bundle (single artifact with required P0 report files, optional label contract enforcement, and status summary)
 - P0 closure report (single go/no-go signal from burn-in + contract + evidence checks)
 
@@ -339,7 +339,7 @@ Verify before release:
   - `Desktop Smoke (Windows)`
 - burn-in monitor report confirms threshold met (`metrics.consecutive_green >= metrics.required_consecutive`)
 - runbook contract report confirms zero missing flags/scripts and canary baseline drills (`success=true`)
-- report schema contract check confirms zero schema and decision-field violations (`success=true`, `metrics.schema_failed_reports=0`, `metrics.missing_required_files=0`)
+- report schema contract check confirms zero baseline schema violations on required reports (`success=true`, `metrics.schema_failed_reports=0`, `metrics.missing_required_files=0`)
 - release evidence bundle report confirms all required `*-release-gate.json` reports are present and successful (`success=true`)
 - release evidence bundle report confirms label consistency when enforced (`metrics.label_mismatch_reports=0`)
 - disaster-recovery rehearsal release-gate report is present and green (`artifacts\p0-disaster-recovery-rehearsal-pack-release-gate.json`, `success=true`)
@@ -403,7 +403,7 @@ After release is live:
 
 ### 1.6 Nightly stability canary
 
-The scheduled workflow [stability-canary.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/stability-canary.yml) runs a nightly trend check against [stability-canary-baseline.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/stability-canary-baseline.json), including power-loss durability, DB corruption quarantine startup recovery, upgrade/downgrade compatibility, and Stage-D safe-mode UX + A11y baseline checks.
+The scheduled workflow [stability-canary.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/stability-canary.yml) runs a nightly trend check against [stability-canary-baseline.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/stability-canary-baseline.json), including power-loss durability, DB corruption quarantine startup recovery, upgrade/downgrade compatibility, Stage-D safe-mode UX + A11y baseline checks, and a P0 report-schema contract drill against required canary evidence reports.
 Missing baseline entries are treated as regressions and fail the canary.
 
 Manual canary invocation:

--- a/docs/stability-canary-baseline.json
+++ b/docs/stability-canary-baseline.json
@@ -31,6 +31,9 @@
     "a11y_test_harness": {
       "baseline_duration_seconds": 3.0
     },
+    "p0_report_schema_contract": {
+      "baseline_duration_seconds": 3.0
+    },
     "long_soak_budget": {
       "baseline_duration_seconds": 140.0,
       "max_http_429_rate_percent": 1.0,

--- a/scripts/p0-runbook-contract-check.py
+++ b/scripts/p0-runbook-contract-check.py
@@ -44,6 +44,7 @@ DEFAULT_REQUIRED_CANARY_DRILLS = [
     "invariant_burst",
     "safe_mode_ux_degradation",
     "a11y_test_harness",
+    "p0_report_schema_contract",
     "long_soak_budget",
 ]
 

--- a/scripts/stability-canary.py
+++ b/scripts/stability-canary.py
@@ -60,6 +60,18 @@ def run_canary(
 ) -> dict[str, Any]:
     baseline = _load_json_file(baseline_file)
     max_duration_regression_percent = float(baseline.get("max_duration_regression_percent", 25.0))
+    safe_mode_report_file = (
+        PROJECT_ROOT / ".tmp" / "stability-canary-safe-mode-ux" / "safe-mode-ux-degradation-report.json"
+    )
+    a11y_report_file = PROJECT_ROOT / ".tmp" / "stability-canary-a11y" / "a11y-test-harness-report.json"
+    p0_schema_artifacts_dir = PROJECT_ROOT / ".tmp" / "stability-canary-p0-schema"
+    p0_schema_report_file = p0_schema_artifacts_dir / "p0-report-schema-contract-report.json"
+    p0_schema_required_files = ",".join(
+        [
+            str(safe_mode_report_file),
+            str(a11y_report_file),
+        ]
+    )
 
     drill_commands: dict[str, list[str]] = {
         "release_freeze_policy": [
@@ -170,7 +182,7 @@ def run_canary(
             "--label",
             "stability-canary",
             "--output-file",
-            str(PROJECT_ROOT / ".tmp" / "stability-canary-safe-mode-ux" / "safe-mode-ux-degradation-report.json"),
+            str(safe_mode_report_file),
         ],
         "a11y_test_harness": [
             sys.executable,
@@ -178,7 +190,27 @@ def run_canary(
             "--label",
             "stability-canary",
             "--output-file",
-            str(PROJECT_ROOT / ".tmp" / "stability-canary-a11y" / "a11y-test-harness-report.json"),
+            str(a11y_report_file),
+        ],
+        "p0_report_schema_contract": [
+            sys.executable,
+            str(PROJECT_ROOT / "scripts" / "p0-report-schema-contract-check.py"),
+            "--label",
+            "stability-canary",
+            "--project-root",
+            str(PROJECT_ROOT),
+            "--artifacts-dir",
+            str(p0_schema_artifacts_dir),
+            "--include-glob",
+            "*-report.json",
+            "--required-files",
+            p0_schema_required_files,
+            "--required-label",
+            "stability-canary",
+            "--required-top-level-keys",
+            "label,success",
+            "--output-file",
+            str(p0_schema_report_file),
         ],
         "long_soak_budget": [
             sys.executable,

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -2285,6 +2285,7 @@ def test_94_stability_canary_reports_success_with_short_soak():
                     "invariant_burst": {"baseline_duration_seconds": 0.1},
                     "safe_mode_ux_degradation": {"baseline_duration_seconds": 0.1},
                     "a11y_test_harness": {"baseline_duration_seconds": 0.1},
+                    "p0_report_schema_contract": {"baseline_duration_seconds": 0.1},
                     "long_soak_budget": {
                         "baseline_duration_seconds": 0.1,
                         "max_http_429_rate_percent": 1.0,
@@ -2323,6 +2324,7 @@ def test_94_stability_canary_reports_success_with_short_soak():
     assert payload["success"] is True
     assert payload["drills"]["safe_mode_ux_degradation"]["payload"]["success"] is True
     assert payload["drills"]["a11y_test_harness"]["payload"]["success"] is True
+    assert payload["drills"]["p0_report_schema_contract"]["payload"]["success"] is True
     assert report_file.exists()
     shutil.rmtree(workspace, ignore_errors=True)
 
@@ -5262,8 +5264,10 @@ def test_151_stability_canary_baseline_includes_stage_d_drills():
 
     assert "safe_mode_ux_degradation" in drills
     assert "a11y_test_harness" in drills
+    assert "p0_report_schema_contract" in drills
     assert float(drills["safe_mode_ux_degradation"]["baseline_duration_seconds"]) > 0
     assert float(drills["a11y_test_harness"]["baseline_duration_seconds"]) > 0
+    assert float(drills["p0_report_schema_contract"]["baseline_duration_seconds"]) > 0
 
 
 def test_152_stability_canary_fails_when_stage_d_baseline_entries_are_missing():
@@ -5325,6 +5329,7 @@ def test_152_stability_canary_fails_when_stage_d_baseline_entries_are_missing():
     missing_drills = {str(entry.get("drill")) for entry in missing_entries}
     assert "safe_mode_ux_degradation" in missing_drills
     assert "a11y_test_harness" in missing_drills
+    assert "p0_report_schema_contract" in missing_drills
     shutil.rmtree(workspace, ignore_errors=True)
 
 
@@ -5386,6 +5391,7 @@ def test_153_p0_runbook_contract_check_fails_when_canary_baseline_is_missing_sta
     missing = set(payload["checks"]["missing_required_canary_drills"])
     assert "safe_mode_ux_degradation" in missing
     assert "a11y_test_harness" in missing
+    assert "p0_report_schema_contract" in missing
 
     shutil.rmtree(workspace, ignore_errors=True)
 


### PR DESCRIPTION
﻿## Summary
- extend `scripts/stability-canary.py` with a new `p0_report_schema_contract` drill that validates required canary evidence reports (`safe_mode_ux_degradation`, `a11y_test_harness`) via `p0-report-schema-contract-check.py`
- add the new drill to `docs/stability-canary-baseline.json` and require it in `scripts/p0-runbook-contract-check.py`
- align README + production runbook wording with the baseline `label/success` schema contract semantics and nightly canary scope
- expand regression tests for canary baseline/drill coverage

## Validation
- `python -m pytest -q tests/test_goal_ops.py -k "test_94 or test_151 or test_152 or test_153 or test_154"`
- `python -m py_compile scripts/stability-canary.py scripts/p0-runbook-contract-check.py`
