### PR TITLE
Stage G: add P0 runbook contract drill to nightly stability canary

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,7 +800,7 @@ python .\scripts\desktop-smoke.py
 
 ## Nightly Stability Canary
 
-Run the full canary profile locally (includes release-freeze policy, power-loss durability, DB corruption quarantine, upgrade/downgrade compatibility, watchdog drills, recovery chaos, invariant burst, Stage-D safe-mode UX/A11y checks, P0 report-schema contract validation on required canary evidence reports, and long soak budgets). Missing baseline drill entries are treated as regressions.
+Run the full canary profile locally (includes release-freeze policy, power-loss durability, DB corruption quarantine, upgrade/downgrade compatibility, watchdog drills, recovery chaos, invariant burst, Stage-D safe-mode UX/A11y checks, P0 report-schema contract validation on required canary evidence reports, P0 runbook-contract consistency checks, and long soak budgets). Missing baseline drill entries are treated as regressions.
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -403,7 +403,7 @@ After release is live:
 
 ### 1.6 Nightly stability canary
 
-The scheduled workflow [stability-canary.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/stability-canary.yml) runs a nightly trend check against [stability-canary-baseline.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/stability-canary-baseline.json), including power-loss durability, DB corruption quarantine startup recovery, upgrade/downgrade compatibility, Stage-D safe-mode UX + A11y baseline checks, and a P0 report-schema contract drill against required canary evidence reports.
+The scheduled workflow [stability-canary.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/stability-canary.yml) runs a nightly trend check against [stability-canary-baseline.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/stability-canary-baseline.json), including power-loss durability, DB corruption quarantine startup recovery, upgrade/downgrade compatibility, Stage-D safe-mode UX + A11y baseline checks, a P0 report-schema contract drill against required canary evidence reports, and a P0 runbook-contract consistency drill.
 Missing baseline entries are treated as regressions and fail the canary.
 
 Manual canary invocation:

--- a/docs/stability-canary-baseline.json
+++ b/docs/stability-canary-baseline.json
@@ -34,6 +34,9 @@
     "p0_report_schema_contract": {
       "baseline_duration_seconds": 3.0
     },
+    "p0_runbook_contract": {
+      "baseline_duration_seconds": 3.0
+    },
     "long_soak_budget": {
       "baseline_duration_seconds": 140.0,
       "max_http_429_rate_percent": 1.0,

--- a/scripts/p0-runbook-contract-check.py
+++ b/scripts/p0-runbook-contract-check.py
@@ -45,6 +45,7 @@ DEFAULT_REQUIRED_CANARY_DRILLS = [
     "safe_mode_ux_degradation",
     "a11y_test_harness",
     "p0_report_schema_contract",
+    "p0_runbook_contract",
     "long_soak_budget",
 ]
 

--- a/scripts/stability-canary.py
+++ b/scripts/stability-canary.py
@@ -66,6 +66,9 @@ def run_canary(
     a11y_report_file = PROJECT_ROOT / ".tmp" / "stability-canary-a11y" / "a11y-test-harness-report.json"
     p0_schema_artifacts_dir = PROJECT_ROOT / ".tmp" / "stability-canary-p0-schema"
     p0_schema_report_file = p0_schema_artifacts_dir / "p0-report-schema-contract-report.json"
+    p0_runbook_contract_report_file = (
+        PROJECT_ROOT / ".tmp" / "stability-canary-p0-runbook-contract" / "p0-runbook-contract-check-report.json"
+    )
     p0_schema_required_files = ",".join(
         [
             str(safe_mode_report_file),
@@ -211,6 +214,16 @@ def run_canary(
             "label,success",
             "--output-file",
             str(p0_schema_report_file),
+        ],
+        "p0_runbook_contract": [
+            sys.executable,
+            str(PROJECT_ROOT / "scripts" / "p0-runbook-contract-check.py"),
+            "--label",
+            "stability-canary",
+            "--project-root",
+            str(PROJECT_ROOT),
+            "--output-file",
+            str(p0_runbook_contract_report_file),
         ],
         "long_soak_budget": [
             sys.executable,

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -2286,6 +2286,7 @@ def test_94_stability_canary_reports_success_with_short_soak():
                     "safe_mode_ux_degradation": {"baseline_duration_seconds": 0.1},
                     "a11y_test_harness": {"baseline_duration_seconds": 0.1},
                     "p0_report_schema_contract": {"baseline_duration_seconds": 0.1},
+                    "p0_runbook_contract": {"baseline_duration_seconds": 0.1},
                     "long_soak_budget": {
                         "baseline_duration_seconds": 0.1,
                         "max_http_429_rate_percent": 1.0,
@@ -2325,6 +2326,7 @@ def test_94_stability_canary_reports_success_with_short_soak():
     assert payload["drills"]["safe_mode_ux_degradation"]["payload"]["success"] is True
     assert payload["drills"]["a11y_test_harness"]["payload"]["success"] is True
     assert payload["drills"]["p0_report_schema_contract"]["payload"]["success"] is True
+    assert payload["drills"]["p0_runbook_contract"]["payload"]["success"] is True
     assert report_file.exists()
     shutil.rmtree(workspace, ignore_errors=True)
 
@@ -5265,9 +5267,11 @@ def test_151_stability_canary_baseline_includes_stage_d_drills():
     assert "safe_mode_ux_degradation" in drills
     assert "a11y_test_harness" in drills
     assert "p0_report_schema_contract" in drills
+    assert "p0_runbook_contract" in drills
     assert float(drills["safe_mode_ux_degradation"]["baseline_duration_seconds"]) > 0
     assert float(drills["a11y_test_harness"]["baseline_duration_seconds"]) > 0
     assert float(drills["p0_report_schema_contract"]["baseline_duration_seconds"]) > 0
+    assert float(drills["p0_runbook_contract"]["baseline_duration_seconds"]) > 0
 
 
 def test_152_stability_canary_fails_when_stage_d_baseline_entries_are_missing():
@@ -5330,6 +5334,7 @@ def test_152_stability_canary_fails_when_stage_d_baseline_entries_are_missing():
     assert "safe_mode_ux_degradation" in missing_drills
     assert "a11y_test_harness" in missing_drills
     assert "p0_report_schema_contract" in missing_drills
+    assert "p0_runbook_contract" in missing_drills
     shutil.rmtree(workspace, ignore_errors=True)
 
 
@@ -5392,6 +5397,7 @@ def test_153_p0_runbook_contract_check_fails_when_canary_baseline_is_missing_sta
     assert "safe_mode_ux_degradation" in missing
     assert "a11y_test_harness" in missing
     assert "p0_report_schema_contract" in missing
+    assert "p0_runbook_contract" in missing
 
     shutil.rmtree(workspace, ignore_errors=True)
 


### PR DESCRIPTION
﻿## Summary
- extend `scripts/stability-canary.py` with a new `p0_runbook_contract` drill, so nightly canary validates runbook/release-gate/CI/baseline consistency
- add `p0_runbook_contract` baseline timing entry in `docs/stability-canary-baseline.json`
- require `p0_runbook_contract` in `scripts/p0-runbook-contract-check.py` canary drill defaults
- update regression tests and docs to reflect the expanded nightly canary scope

## Validation
- `python -m pytest -q tests/test_goal_ops.py -k "test_94 or test_151 or test_152 or test_153"`
- `python -m py_compile scripts/stability-canary.py scripts/p0-runbook-contract-check.py`
