### PR TITLE
Stage H: add P0 release-evidence bundle drill to nightly canary

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,7 +800,7 @@ python .\scripts\desktop-smoke.py
 
 ## Nightly Stability Canary
 
-Run the full canary profile locally (includes release-freeze policy, power-loss durability, DB corruption quarantine, upgrade/downgrade compatibility, watchdog drills, recovery chaos, invariant burst, Stage-D safe-mode UX/A11y checks, P0 report-schema contract validation on required canary evidence reports, P0 runbook-contract consistency checks, and long soak budgets). Missing baseline drill entries are treated as regressions.
+Run the full canary profile locally (includes release-freeze policy, power-loss durability, DB corruption quarantine, upgrade/downgrade compatibility, watchdog drills, recovery chaos, invariant burst, Stage-D safe-mode UX/A11y checks, P0 report-schema contract validation on required canary evidence reports, P0 runbook-contract consistency checks, P0 release-evidence bundle checks, and long soak budgets). Missing baseline drill entries are treated as regressions.
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -403,7 +403,7 @@ After release is live:
 
 ### 1.6 Nightly stability canary
 
-The scheduled workflow [stability-canary.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/stability-canary.yml) runs a nightly trend check against [stability-canary-baseline.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/stability-canary-baseline.json), including power-loss durability, DB corruption quarantine startup recovery, upgrade/downgrade compatibility, Stage-D safe-mode UX + A11y baseline checks, a P0 report-schema contract drill against required canary evidence reports, and a P0 runbook-contract consistency drill.
+The scheduled workflow [stability-canary.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/stability-canary.yml) runs a nightly trend check against [stability-canary-baseline.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/stability-canary-baseline.json), including power-loss durability, DB corruption quarantine startup recovery, upgrade/downgrade compatibility, Stage-D safe-mode UX + A11y baseline checks, a P0 report-schema contract drill against required canary evidence reports, a P0 runbook-contract consistency drill, and a P0 release-evidence bundle drill.
 Missing baseline entries are treated as regressions and fail the canary.
 
 Manual canary invocation:

--- a/docs/stability-canary-baseline.json
+++ b/docs/stability-canary-baseline.json
@@ -37,6 +37,9 @@
     "p0_runbook_contract": {
       "baseline_duration_seconds": 3.0
     },
+    "p0_release_evidence_bundle": {
+      "baseline_duration_seconds": 3.0
+    },
     "long_soak_budget": {
       "baseline_duration_seconds": 140.0,
       "max_http_429_rate_percent": 1.0,

--- a/scripts/p0-runbook-contract-check.py
+++ b/scripts/p0-runbook-contract-check.py
@@ -46,6 +46,7 @@ DEFAULT_REQUIRED_CANARY_DRILLS = [
     "a11y_test_harness",
     "p0_report_schema_contract",
     "p0_runbook_contract",
+    "p0_release_evidence_bundle",
     "long_soak_budget",
 ]
 

--- a/scripts/stability-canary.py
+++ b/scripts/stability-canary.py
@@ -69,10 +69,21 @@ def run_canary(
     p0_runbook_contract_report_file = (
         PROJECT_ROOT / ".tmp" / "stability-canary-p0-runbook-contract" / "p0-runbook-contract-check-report.json"
     )
+    p0_evidence_artifacts_dir = PROJECT_ROOT / ".tmp" / "stability-canary-p0-evidence"
+    p0_evidence_bundle_file = p0_evidence_artifacts_dir / "p0-release-evidence-bundle-report.json"
+    p0_evidence_bundle_dir = p0_evidence_artifacts_dir / "p0-release-evidence-files"
     p0_schema_required_files = ",".join(
         [
             str(safe_mode_report_file),
             str(a11y_report_file),
+        ]
+    )
+    p0_evidence_required_files = ",".join(
+        [
+            str(safe_mode_report_file),
+            str(a11y_report_file),
+            str(p0_schema_report_file),
+            str(p0_runbook_contract_report_file),
         ]
     )
 
@@ -224,6 +235,26 @@ def run_canary(
             str(PROJECT_ROOT),
             "--output-file",
             str(p0_runbook_contract_report_file),
+        ],
+        "p0_release_evidence_bundle": [
+            sys.executable,
+            str(PROJECT_ROOT / "scripts" / "p0-release-evidence-bundle.py"),
+            "--label",
+            "stability-canary",
+            "--project-root",
+            str(PROJECT_ROOT),
+            "--artifacts-dir",
+            str(p0_evidence_artifacts_dir),
+            "--include-glob",
+            "*-report.json",
+            "--required-files",
+            p0_evidence_required_files,
+            "--required-label",
+            "stability-canary",
+            "--output-file",
+            str(p0_evidence_bundle_file),
+            "--bundle-dir",
+            str(p0_evidence_bundle_dir),
         ],
         "long_soak_budget": [
             sys.executable,

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -2287,6 +2287,7 @@ def test_94_stability_canary_reports_success_with_short_soak():
                     "a11y_test_harness": {"baseline_duration_seconds": 0.1},
                     "p0_report_schema_contract": {"baseline_duration_seconds": 0.1},
                     "p0_runbook_contract": {"baseline_duration_seconds": 0.1},
+                    "p0_release_evidence_bundle": {"baseline_duration_seconds": 0.1},
                     "long_soak_budget": {
                         "baseline_duration_seconds": 0.1,
                         "max_http_429_rate_percent": 1.0,
@@ -2327,6 +2328,7 @@ def test_94_stability_canary_reports_success_with_short_soak():
     assert payload["drills"]["a11y_test_harness"]["payload"]["success"] is True
     assert payload["drills"]["p0_report_schema_contract"]["payload"]["success"] is True
     assert payload["drills"]["p0_runbook_contract"]["payload"]["success"] is True
+    assert payload["drills"]["p0_release_evidence_bundle"]["payload"]["success"] is True
     assert report_file.exists()
     shutil.rmtree(workspace, ignore_errors=True)
 
@@ -5268,10 +5270,12 @@ def test_151_stability_canary_baseline_includes_stage_d_drills():
     assert "a11y_test_harness" in drills
     assert "p0_report_schema_contract" in drills
     assert "p0_runbook_contract" in drills
+    assert "p0_release_evidence_bundle" in drills
     assert float(drills["safe_mode_ux_degradation"]["baseline_duration_seconds"]) > 0
     assert float(drills["a11y_test_harness"]["baseline_duration_seconds"]) > 0
     assert float(drills["p0_report_schema_contract"]["baseline_duration_seconds"]) > 0
     assert float(drills["p0_runbook_contract"]["baseline_duration_seconds"]) > 0
+    assert float(drills["p0_release_evidence_bundle"]["baseline_duration_seconds"]) > 0
 
 
 def test_152_stability_canary_fails_when_stage_d_baseline_entries_are_missing():
@@ -5335,6 +5339,7 @@ def test_152_stability_canary_fails_when_stage_d_baseline_entries_are_missing():
     assert "a11y_test_harness" in missing_drills
     assert "p0_report_schema_contract" in missing_drills
     assert "p0_runbook_contract" in missing_drills
+    assert "p0_release_evidence_bundle" in missing_drills
     shutil.rmtree(workspace, ignore_errors=True)
 
 
@@ -5398,6 +5403,7 @@ def test_153_p0_runbook_contract_check_fails_when_canary_baseline_is_missing_sta
     assert "a11y_test_harness" in missing
     assert "p0_report_schema_contract" in missing
     assert "p0_runbook_contract" in missing
+    assert "p0_release_evidence_bundle" in missing
 
     shutil.rmtree(workspace, ignore_errors=True)
 


### PR DESCRIPTION
﻿## Summary
- extend `scripts/stability-canary.py` with a `p0_release_evidence_bundle` drill that bundles and validates required canary evidence reports
- include the new drill in `docs/stability-canary-baseline.json` and `scripts/p0-runbook-contract-check.py` required canary drill defaults
- update docs to reflect nightly canary now checking P0 release-evidence bundle consistency
- expand canary baseline/contract regression tests

## Validation
- `python -m pytest -q tests/test_goal_ops.py -k "test_94 or test_151 or test_152 or test_153"`
- `python -m py_compile scripts/stability-canary.py scripts/p0-runbook-contract-check.py scripts/p0-release-evidence-bundle.py`
