### PR TITLE
Stage I: add P0 burn-in + closure drills to nightly canary

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,7 +800,7 @@ python .\scripts\desktop-smoke.py
 
 ## Nightly Stability Canary
 
-Run the full canary profile locally (includes release-freeze policy, power-loss durability, DB corruption quarantine, upgrade/downgrade compatibility, watchdog drills, recovery chaos, invariant burst, Stage-D safe-mode UX/A11y checks, P0 report-schema contract validation on required canary evidence reports, P0 runbook-contract consistency checks, P0 release-evidence bundle checks, and long soak budgets). Missing baseline drill entries are treated as regressions.
+Run the full canary profile locally (includes release-freeze policy, power-loss durability, DB corruption quarantine, upgrade/downgrade compatibility, watchdog drills, recovery chaos, invariant burst, Stage-D safe-mode UX/A11y checks, P0 burn-in consecutive-green fixture checks, P0 report-schema contract validation on required canary evidence reports, P0 runbook-contract consistency checks, P0 release-evidence bundle checks, P0 closure go/no-go checks, and long soak budgets). Missing baseline drill entries are treated as regressions.
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -403,7 +403,7 @@ After release is live:
 
 ### 1.6 Nightly stability canary
 
-The scheduled workflow [stability-canary.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/stability-canary.yml) runs a nightly trend check against [stability-canary-baseline.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/stability-canary-baseline.json), including power-loss durability, DB corruption quarantine startup recovery, upgrade/downgrade compatibility, Stage-D safe-mode UX + A11y baseline checks, a P0 report-schema contract drill against required canary evidence reports, a P0 runbook-contract consistency drill, and a P0 release-evidence bundle drill.
+The scheduled workflow [stability-canary.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/stability-canary.yml) runs a nightly trend check against [stability-canary-baseline.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/stability-canary-baseline.json), including power-loss durability, DB corruption quarantine startup recovery, upgrade/downgrade compatibility, Stage-D safe-mode UX + A11y baseline checks, a P0 burn-in consecutive-green fixture drill, a P0 report-schema contract drill against required canary evidence reports, a P0 runbook-contract consistency drill, a P0 release-evidence bundle drill, and a P0 closure go/no-go drill.
 Missing baseline entries are treated as regressions and fail the canary.
 
 Manual canary invocation:

--- a/docs/stability-canary-baseline.json
+++ b/docs/stability-canary-baseline.json
@@ -40,6 +40,12 @@
     "p0_release_evidence_bundle": {
       "baseline_duration_seconds": 3.0
     },
+    "p0_burnin_consecutive_green": {
+      "baseline_duration_seconds": 3.0
+    },
+    "p0_closure_report": {
+      "baseline_duration_seconds": 3.0
+    },
     "long_soak_budget": {
       "baseline_duration_seconds": 140.0,
       "max_http_429_rate_percent": 1.0,

--- a/scripts/p0-runbook-contract-check.py
+++ b/scripts/p0-runbook-contract-check.py
@@ -47,6 +47,8 @@ DEFAULT_REQUIRED_CANARY_DRILLS = [
     "p0_report_schema_contract",
     "p0_runbook_contract",
     "p0_release_evidence_bundle",
+    "p0_burnin_consecutive_green",
+    "p0_closure_report",
     "long_soak_budget",
 ]
 

--- a/scripts/stability-canary.py
+++ b/scripts/stability-canary.py
@@ -23,6 +23,61 @@ def _load_json_file(path: Path) -> dict[str, Any]:
     return data
 
 
+def _write_json_file(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, sort_keys=True), encoding="utf-8")
+
+
+def _prepare_p0_burnin_fixtures(*, runs_file: Path, jobs_dir: Path, required_jobs: list[str]) -> None:
+    runs_payload = {
+        "workflow_runs": [
+            {
+                "id": 9203,
+                "name": "CI",
+                "status": "completed",
+                "conclusion": "success",
+                "head_sha": "sha-9203",
+                "updated_at": "2026-04-17T00:00:03Z",
+            },
+            {
+                "id": 9202,
+                "name": "CI",
+                "status": "completed",
+                "conclusion": "success",
+                "head_sha": "sha-9202",
+                "updated_at": "2026-04-17T00:00:02Z",
+            },
+            {
+                "id": 9201,
+                "name": "CI",
+                "status": "completed",
+                "conclusion": "success",
+                "head_sha": "sha-9201",
+                "updated_at": "2026-04-17T00:00:01Z",
+            },
+            {
+                "id": 9200,
+                "name": "CI",
+                "status": "completed",
+                "conclusion": "failure",
+                "head_sha": "sha-9200",
+                "updated_at": "2026-04-17T00:00:00Z",
+            },
+        ]
+    }
+    _write_json_file(runs_file, runs_payload)
+
+    for run_id in (9203, 9202, 9201, 9200):
+        conclusion = "success" if run_id != 9200 else "failure"
+        jobs_payload = {
+            "jobs": (
+                [{"name": job_name, "conclusion": conclusion} for job_name in required_jobs]
+                + [{"name": "Auxiliary Check", "conclusion": "success"}]
+            )
+        }
+        _write_json_file(jobs_dir / f"{run_id}.json", jobs_payload)
+
+
 def _run_json_command(command: list[str]) -> tuple[dict[str, Any], float]:
     started = time.perf_counter()
     completed = subprocess.run(
@@ -69,9 +124,26 @@ def run_canary(
     p0_runbook_contract_report_file = (
         PROJECT_ROOT / ".tmp" / "stability-canary-p0-runbook-contract" / "p0-runbook-contract-check-report.json"
     )
+    p0_burnin_artifacts_dir = PROJECT_ROOT / ".tmp" / "stability-canary-p0-burnin"
+    p0_burnin_report_file = p0_burnin_artifacts_dir / "p0-burnin-consecutive-green-report.json"
+    p0_burnin_fixtures_dir = p0_burnin_artifacts_dir / "fixtures"
+    p0_burnin_runs_file = p0_burnin_fixtures_dir / "runs.json"
+    p0_burnin_jobs_dir = p0_burnin_fixtures_dir / "jobs"
+    p0_closure_report_file = PROJECT_ROOT / ".tmp" / "stability-canary-p0-closure" / "p0-closure-report.json"
     p0_evidence_artifacts_dir = PROJECT_ROOT / ".tmp" / "stability-canary-p0-evidence"
     p0_evidence_bundle_file = p0_evidence_artifacts_dir / "p0-release-evidence-bundle-report.json"
     p0_evidence_bundle_dir = p0_evidence_artifacts_dir / "p0-release-evidence-files"
+    p0_burnin_required_jobs = [
+        "Release Gate (Windows)",
+        "Pytest (Python 3.11)",
+        "Pytest (Python 3.12)",
+        "Desktop Smoke (Windows)",
+    ]
+    _prepare_p0_burnin_fixtures(
+        runs_file=p0_burnin_runs_file,
+        jobs_dir=p0_burnin_jobs_dir,
+        required_jobs=p0_burnin_required_jobs,
+    )
     p0_schema_required_files = ",".join(
         [
             str(safe_mode_report_file),
@@ -82,6 +154,16 @@ def run_canary(
         [
             str(safe_mode_report_file),
             str(a11y_report_file),
+            str(p0_burnin_report_file),
+            str(p0_schema_report_file),
+            str(p0_runbook_contract_report_file),
+        ]
+    )
+    p0_closure_required_evidence_reports = ",".join(
+        [
+            str(safe_mode_report_file),
+            str(a11y_report_file),
+            str(p0_burnin_report_file),
             str(p0_schema_report_file),
             str(p0_runbook_contract_report_file),
         ]
@@ -236,6 +318,30 @@ def run_canary(
             "--output-file",
             str(p0_runbook_contract_report_file),
         ],
+        "p0_burnin_consecutive_green": [
+            sys.executable,
+            str(PROJECT_ROOT / "scripts" / "p0-burnin-consecutive-green.py"),
+            "--label",
+            "stability-canary",
+            "--repo",
+            "donatomaurizio99-collab/GOC",
+            "--branch",
+            "master",
+            "--workflow-name",
+            "CI",
+            "--required-jobs",
+            ",".join(p0_burnin_required_jobs),
+            "--required-consecutive",
+            "3",
+            "--per-page",
+            "10",
+            "--runs-file",
+            str(p0_burnin_runs_file),
+            "--jobs-dir",
+            str(p0_burnin_jobs_dir),
+            "--output-file",
+            str(p0_burnin_report_file),
+        ],
         "p0_release_evidence_bundle": [
             sys.executable,
             str(PROJECT_ROOT / "scripts" / "p0-release-evidence-bundle.py"),
@@ -255,6 +361,26 @@ def run_canary(
             str(p0_evidence_bundle_file),
             "--bundle-dir",
             str(p0_evidence_bundle_dir),
+        ],
+        "p0_closure_report": [
+            sys.executable,
+            str(PROJECT_ROOT / "scripts" / "p0-closure-report.py"),
+            "--label",
+            "stability-canary",
+            "--project-root",
+            str(PROJECT_ROOT),
+            "--required-consecutive",
+            "3",
+            "--required-evidence-reports",
+            p0_closure_required_evidence_reports,
+            "--evidence-bundle-file",
+            str(p0_evidence_bundle_file),
+            "--burnin-file",
+            str(p0_burnin_report_file),
+            "--runbook-contract-file",
+            str(p0_runbook_contract_report_file),
+            "--output-file",
+            str(p0_closure_report_file),
         ],
         "long_soak_budget": [
             sys.executable,

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -2288,6 +2288,8 @@ def test_94_stability_canary_reports_success_with_short_soak():
                     "p0_report_schema_contract": {"baseline_duration_seconds": 0.1},
                     "p0_runbook_contract": {"baseline_duration_seconds": 0.1},
                     "p0_release_evidence_bundle": {"baseline_duration_seconds": 0.1},
+                    "p0_burnin_consecutive_green": {"baseline_duration_seconds": 0.1},
+                    "p0_closure_report": {"baseline_duration_seconds": 0.1},
                     "long_soak_budget": {
                         "baseline_duration_seconds": 0.1,
                         "max_http_429_rate_percent": 1.0,
@@ -2329,6 +2331,8 @@ def test_94_stability_canary_reports_success_with_short_soak():
     assert payload["drills"]["p0_report_schema_contract"]["payload"]["success"] is True
     assert payload["drills"]["p0_runbook_contract"]["payload"]["success"] is True
     assert payload["drills"]["p0_release_evidence_bundle"]["payload"]["success"] is True
+    assert payload["drills"]["p0_burnin_consecutive_green"]["payload"]["success"] is True
+    assert payload["drills"]["p0_closure_report"]["payload"]["success"] is True
     assert report_file.exists()
     shutil.rmtree(workspace, ignore_errors=True)
 
@@ -5271,11 +5275,15 @@ def test_151_stability_canary_baseline_includes_stage_d_drills():
     assert "p0_report_schema_contract" in drills
     assert "p0_runbook_contract" in drills
     assert "p0_release_evidence_bundle" in drills
+    assert "p0_burnin_consecutive_green" in drills
+    assert "p0_closure_report" in drills
     assert float(drills["safe_mode_ux_degradation"]["baseline_duration_seconds"]) > 0
     assert float(drills["a11y_test_harness"]["baseline_duration_seconds"]) > 0
     assert float(drills["p0_report_schema_contract"]["baseline_duration_seconds"]) > 0
     assert float(drills["p0_runbook_contract"]["baseline_duration_seconds"]) > 0
     assert float(drills["p0_release_evidence_bundle"]["baseline_duration_seconds"]) > 0
+    assert float(drills["p0_burnin_consecutive_green"]["baseline_duration_seconds"]) > 0
+    assert float(drills["p0_closure_report"]["baseline_duration_seconds"]) > 0
 
 
 def test_152_stability_canary_fails_when_stage_d_baseline_entries_are_missing():
@@ -5340,6 +5348,8 @@ def test_152_stability_canary_fails_when_stage_d_baseline_entries_are_missing():
     assert "p0_report_schema_contract" in missing_drills
     assert "p0_runbook_contract" in missing_drills
     assert "p0_release_evidence_bundle" in missing_drills
+    assert "p0_burnin_consecutive_green" in missing_drills
+    assert "p0_closure_report" in missing_drills
     shutil.rmtree(workspace, ignore_errors=True)
 
 
@@ -5404,6 +5414,8 @@ def test_153_p0_runbook_contract_check_fails_when_canary_baseline_is_missing_sta
     assert "p0_report_schema_contract" in missing
     assert "p0_runbook_contract" in missing
     assert "p0_release_evidence_bundle" in missing
+    assert "p0_burnin_consecutive_green" in missing
+    assert "p0_closure_report" in missing
 
     shutil.rmtree(workspace, ignore_errors=True)
 


### PR DESCRIPTION
﻿## Summary
- extend scripts/stability-canary.py with deterministic P0 burn-in and closure drills
- add local burn-in fixture data in canary to avoid external gh api dependency
- include burn-in evidence in canary bundle requirements and closure required evidence set
- add baseline entries for p0_burnin_consecutive_green and p0_closure_report
- require both drills in p0-runbook-contract-check.py default canary contract
- update README, production runbook, and canary regression tests

## Validation
- python -m py_compile scripts/stability-canary.py scripts/p0-runbook-contract-check.py scripts/p0-burnin-consecutive-green.py scripts/p0-closure-report.py
- python -m pytest -q tests/test_goal_ops.py -k test_94 or test_110 or test_112 or test_115 or test_151 or test_152 or test_153
