### PR TITLE
Stage AT/AU: add release-gate registry lockfile drift guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,6 +915,7 @@ Workflow file:
 
 Release-gate CI strict flags + release evidence upload paths are now sourced from:
 - [release-gate-registry.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/release-gate-registry.json)
+- [release-gate-registry.lock.json](/C:/Users/raffa/OneDrive/Documents/New%20project/docs/release-gate-registry.lock.json)
 
 P0 report schema contract defaults (`required_top_level_keys`, `required_decision_keys`, `required_label`) and
 P0 release evidence bundle defaults (`required_label`) are also sourced from the same registry.
@@ -922,6 +923,10 @@ P0 release evidence bundle defaults (`required_label`) are also sourced from the
 Sync/verify command:
 ```powershell
 python .\scripts\release-gate-registry-sync.py
+```
+Write/sync command:
+```powershell
+python .\scripts\release-gate-registry-sync.py --write
 ```
 The check validates CI strict flags/artifact uploads and registry wiring in `scripts\release-gate.ps1` plus P0 schema/bundle wrappers.
 It also enforces cross-contract consistency (required labels + artifact coverage across registry sections).

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -517,6 +517,12 @@ Manual release-gate registry sync check invocation:
 (Also verifies registry wiring in `scripts\release-gate.ps1`, `run-p0-report-schema-contract-check.ps1`, and `run-p0-release-evidence-bundle.ps1`.)
 (Also enforces registry cross-contract consistency for P0 required labels and CI artifact coverage.)
 
+Manual release-gate registry + lockfile write/sync invocation:
+
+```powershell
+.\scripts\run-release-gate-registry-sync.ps1 -Write
+```
+
 Manual P0 runbook contract check invocation:
 
 ```powershell

--- a/docs/release-gate-registry.lock.json
+++ b/docs/release-gate-registry.lock.json
@@ -1,0 +1,22 @@
+{
+  "counts": {
+    "p0_bundle_required_files_total": 0,
+    "p0_runbook_required_ci_artifact_paths_total": 32,
+    "p0_runbook_required_scripts_total": 50,
+    "p0_schema_required_decision_keys_total": 0,
+    "p0_schema_required_files_total": 0,
+    "p0_schema_required_top_level_keys_total": 2,
+    "release_evidence_artifact_paths_total": 51,
+    "strict_flags_total": 73
+  },
+  "hashes": {
+    "p0_release_evidence_bundle_sha256": "3eea6098363eafa59ab92c92e0debd01af30fe02258dc3222b9fc389b261d87c",
+    "p0_report_schema_contract_sha256": "eb8c8d6ca0f983b9ffdb3c663791eeacd93fd85f7390c7a52d365b39a5c86c2e",
+    "p0_runbook_contract_sha256": "3e6da8d63cdea2eb91f5b0420f7977f08acbf3404794aa42d8b64270d5aefb65",
+    "registry_core_sha256": "ea669b5f3825e68ba12444b41e8fa8e600dd06c959ff9b01a15928d0f5a8596f",
+    "release_evidence_artifact_paths_sha256": "6c97e9571e46b0fcfb42bbf90bdd97b50e656333d1e703cad7fab996686c8e73",
+    "strict_flags_sha256": "36b5a0c874e33f08b1ced6936cd64703c85de4a5f87a7d26ff0a6ef88aff45db"
+  },
+  "registry_version": "1.0.0",
+  "version": "1.0.0"
+}

--- a/goal_ops_console/workflow_catalog.py
+++ b/goal_ops_console/workflow_catalog.py
@@ -547,7 +547,7 @@ class WorkflowCatalog:
                     limit=self.reaper_batch_size,
                 )
             except Exception:
-                self._metric("workflows.worker.errors")
+                self._safe_metric("workflows.worker.errors")
 
             processed_any = False
             while not self._worker_stop.is_set():
@@ -556,10 +556,10 @@ class WorkflowCatalog:
                 except sqlite3.OperationalError:
                     # SQLite lock contention is transient in concurrent test/desktop scenarios.
                     # Keep worker alive and retry on the next wake cycle.
-                    self._metric("workflows.worker.lock_conflicts")
+                    self._safe_metric("workflows.worker.lock_conflicts")
                     break
                 except Exception:
-                    self._metric("workflows.worker.errors")
+                    self._safe_metric("workflows.worker.errors")
                     break
                 if claimed is None:
                     break
@@ -994,3 +994,10 @@ class WorkflowCatalog:
         if self.observability is None:
             return
         self.observability.increment_metric(name, delta=delta, tx=tx)
+
+    def _safe_metric(self, name: str, delta: int = 1, *, tx: Transaction | None = None) -> None:
+        try:
+            self._metric(name, delta=delta, tx=tx)
+        except sqlite3.OperationalError:
+            # Metrics are best-effort; transient lock conflicts must not crash the worker.
+            return

--- a/scripts/release-gate-registry-sync.py
+++ b/scripts/release-gate-registry-sync.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import fnmatch
+import hashlib
 import json
 import re
 import sys
@@ -35,6 +36,18 @@ def _read_json_object(path: Path) -> dict[str, Any]:
         raise RuntimeError(f"Failed to parse JSON file {path}: {exc}") from exc
     _expect(isinstance(payload, dict), f"JSON file must contain an object: {path}")
     return payload
+
+
+def _canonical_json(payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _render_json_file(payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=True, sort_keys=True, indent=2) + "\n"
 
 
 def _normalize_string_list(
@@ -166,6 +179,10 @@ def _validate_cross_contracts(
 
 def load_registry(registry_file: Path) -> dict[str, Any]:
     payload = _read_json_object(registry_file)
+    registry_version_raw = payload.get("version")
+    _expect(isinstance(registry_version_raw, str), "Registry key 'version' must be a string.")
+    registry_version = registry_version_raw.strip()
+    _expect(registry_version, "Registry key 'version' must not be empty.")
 
     release_gate_ci = payload.get("release_gate_ci")
     _expect(isinstance(release_gate_ci, dict), "Registry key 'release_gate_ci' must be an object.")
@@ -238,6 +255,7 @@ def load_registry(registry_file: Path) -> dict[str, Any]:
     )
 
     registry = {
+        "registry_version": registry_version,
         "strict_flags": strict_flags,
         "release_evidence_artifact_paths": artifact_paths,
         "p0_contract": p0_lists,
@@ -259,6 +277,55 @@ def load_registry(registry_file: Path) -> dict[str, Any]:
         p0_release_evidence_bundle=registry["p0_release_evidence_bundle"],
     )
     return registry
+
+
+def build_registry_lock_payload(registry: dict[str, Any]) -> dict[str, Any]:
+    registry_core = {
+        "registry_version": registry["registry_version"],
+        "release_gate_ci": {
+            "strict_flags": registry["strict_flags"],
+            "release_evidence_artifact_paths": registry["release_evidence_artifact_paths"],
+        },
+        "p0_runbook_contract": registry["p0_contract"],
+        "p0_report_schema_contract": registry["p0_report_schema_contract"],
+        "p0_release_evidence_bundle": registry["p0_release_evidence_bundle"],
+    }
+
+    strict_flags_canonical = _canonical_json(registry["strict_flags"])
+    artifact_paths_canonical = _canonical_json(registry["release_evidence_artifact_paths"])
+    p0_contract_canonical = _canonical_json(registry["p0_contract"])
+    p0_schema_contract_canonical = _canonical_json(registry["p0_report_schema_contract"])
+    p0_bundle_contract_canonical = _canonical_json(registry["p0_release_evidence_bundle"])
+    registry_core_canonical = _canonical_json(registry_core)
+
+    return {
+        "version": "1.0.0",
+        "registry_version": registry["registry_version"],
+        "hashes": {
+            "registry_core_sha256": _sha256_text(registry_core_canonical),
+            "strict_flags_sha256": _sha256_text(strict_flags_canonical),
+            "release_evidence_artifact_paths_sha256": _sha256_text(artifact_paths_canonical),
+            "p0_runbook_contract_sha256": _sha256_text(p0_contract_canonical),
+            "p0_report_schema_contract_sha256": _sha256_text(p0_schema_contract_canonical),
+            "p0_release_evidence_bundle_sha256": _sha256_text(p0_bundle_contract_canonical),
+        },
+        "counts": {
+            "strict_flags_total": len(registry["strict_flags"]),
+            "release_evidence_artifact_paths_total": len(registry["release_evidence_artifact_paths"]),
+            "p0_runbook_required_scripts_total": len(registry["p0_contract"]["required_runbook_scripts"]),
+            "p0_runbook_required_ci_artifact_paths_total": len(
+                registry["p0_contract"]["required_ci_artifact_paths"]
+            ),
+            "p0_schema_required_top_level_keys_total": len(
+                registry["p0_report_schema_contract"]["required_top_level_keys"]
+            ),
+            "p0_schema_required_decision_keys_total": len(
+                registry["p0_report_schema_contract"]["required_decision_keys"]
+            ),
+            "p0_schema_required_files_total": len(registry["p0_report_schema_contract"]["required_files"]),
+            "p0_bundle_required_files_total": len(registry["p0_release_evidence_bundle"]["required_files"]),
+        },
+    }
 
 
 def _leading_whitespace(text: str) -> str:
@@ -396,6 +463,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--project-root")
     parser.add_argument("--registry-file", default="docs/release-gate-registry.json")
+    parser.add_argument("--lock-file", default="docs/release-gate-registry.lock.json")
     parser.add_argument("--ci-workflow-file", default=".github/workflows/ci.yml")
     parser.add_argument("--release-gate-file", default="scripts/release-gate.ps1")
     parser.add_argument("--schema-wrapper-file", default="scripts/run-p0-report-schema-contract-check.ps1")
@@ -410,6 +478,7 @@ def main(argv: list[str] | None = None) -> int:
         else inferred_project_root
     )
     registry_file = (project_root / str(args.registry_file)).resolve()
+    lock_file = (project_root / str(args.lock_file)).resolve()
     ci_workflow_file = (project_root / str(args.ci_workflow_file)).resolve()
     release_gate_file = (project_root / str(args.release_gate_file)).resolve()
     schema_wrapper_file = (project_root / str(args.schema_wrapper_file)).resolve()
@@ -417,6 +486,10 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         registry = load_registry(registry_file)
+        generated_lock_payload = build_registry_lock_payload(registry)
+        generated_lock_text = _render_json_file(generated_lock_payload)
+        existing_lock_text = _read_text(lock_file) if lock_file.exists() else ""
+        lock_changed = existing_lock_text != generated_lock_text
         original_ci = _read_text(ci_workflow_file)
         release_gate_text = _read_text(release_gate_file)
         schema_wrapper_text = _read_text(schema_wrapper_file)
@@ -438,13 +511,18 @@ def main(argv: list[str] | None = None) -> int:
     if args.write:
         if changed:
             ci_workflow_file.write_text(synchronized_ci, encoding="utf-8")
+        if lock_changed:
+            lock_file.parent.mkdir(parents=True, exist_ok=True)
+            lock_file.write_text(generated_lock_text, encoding="utf-8")
         print(
             json.dumps(
                 {
                     "success": True,
                     "mode": "write",
                     "changed": bool(changed),
+                    "lock_changed": bool(lock_changed),
                     "registry_file": str(registry_file),
+                    "lock_file": str(lock_file),
                     "ci_workflow_file": str(ci_workflow_file),
                     "release_gate_file": str(release_gate_file),
                     "schema_wrapper_file": str(schema_wrapper_file),
@@ -485,10 +563,18 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 0
 
-    if changed:
+    if changed or lock_changed:
+        drift_reasons: list[str] = []
+        if changed:
+            drift_reasons.append("CI workflow")
+        if lock_changed:
+            drift_reasons.append("registry lock file")
         print(
-            "[release-gate-registry-sync] ERROR: CI workflow is out of sync with release-gate registry. "
-            "Run `python scripts/release-gate-registry-sync.py --write`.",
+            (
+                "[release-gate-registry-sync] ERROR: Out of sync with release-gate registry: "
+                + ", ".join(drift_reasons)
+                + ". Run `python scripts/release-gate-registry-sync.py --write`."
+            ),
             file=sys.stderr,
         )
         return 1
@@ -499,7 +585,9 @@ def main(argv: list[str] | None = None) -> int:
                 "success": True,
                 "mode": "check",
                 "changed": False,
+                "lock_changed": False,
                 "registry_file": str(registry_file),
+                "lock_file": str(lock_file),
                 "ci_workflow_file": str(ci_workflow_file),
                 "release_gate_file": str(release_gate_file),
                 "schema_wrapper_file": str(schema_wrapper_file),

--- a/scripts/run-release-gate-registry-sync.ps1
+++ b/scripts/run-release-gate-registry-sync.ps1
@@ -1,6 +1,7 @@
 param(
     [string]$PythonExe = "python",
     [string]$RegistryFile = "docs\\release-gate-registry.json",
+    [string]$LockFile = "docs\\release-gate-registry.lock.json",
     [string]$CiWorkflowFile = ".github\\workflows\\ci.yml",
     [switch]$Write
 )
@@ -13,6 +14,7 @@ Set-Location $ProjectRoot
 $arguments = @(
     ".\\scripts\\release-gate-registry-sync.py",
     "--registry-file", $RegistryFile,
+    "--lock-file", $LockFile,
     "--ci-workflow-file", $CiWorkflowFile
 )
 if ($Write) {

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1447,6 +1447,54 @@ def test_64_workflow_worker_survives_claim_lock_conflict(monkeypatch):
         assert catalog.worker_status()["is_running"] is True
 
 
+def test_64b_workflow_worker_survives_lock_conflict_metric_write_error(monkeypatch):
+    app = create_app(
+        Settings(
+            database_url=":memory:",
+            workflow_worker_poll_interval_seconds=0.05,
+        )
+    )
+    with TestClient(app) as local_client:
+        catalog = local_client.app.state.services.workflow_catalog
+        original_claim = catalog._claim_next_queued_run
+        original_metric = catalog._metric
+        claim_fail_once = {"remaining": 1}
+        metric_fail_once = {"remaining": 1}
+
+        def _flaky_claim():
+            if claim_fail_once["remaining"] > 0:
+                claim_fail_once["remaining"] -= 1
+                raise sqlite3.OperationalError("database table is locked: workflow_runs")
+            return original_claim()
+
+        def _flaky_metric(name, delta=1, *, tx=None):
+            if name == "workflows.worker.lock_conflicts" and metric_fail_once["remaining"] > 0:
+                metric_fail_once["remaining"] -= 1
+                raise sqlite3.OperationalError("database table is locked: metrics")
+            return original_metric(name, delta=delta, tx=tx)
+
+        monkeypatch.setattr(catalog, "_claim_next_queued_run", _flaky_claim)
+        monkeypatch.setattr(catalog, "_metric", _flaky_metric)
+
+        started = local_client.post(
+            "/workflows/maintenance.retention_cleanup/start",
+            json={"requested_by": "workflow-test", "payload": {"source": "lock-conflict-metric"}},
+        )
+        assert started.status_code == 201
+        run_id = started.json()["run"]["run_id"]
+
+        final_run = _wait_for_run_in_states(
+            local_client,
+            run_id,
+            {"succeeded", "failed", "timed_out", "cancelled"},
+            timeout_seconds=3.0,
+        )
+        assert final_run["status"] == "succeeded"
+        assert claim_fail_once["remaining"] == 0
+        assert metric_fail_once["remaining"] == 0
+        assert catalog.worker_status()["is_running"] is True
+
+
 def test_65_database_creates_backup_before_pending_migration():
     temp_dir = _local_test_dir("pytest-db-migration-backup")
     db_path = temp_dir / "goal_ops.db"

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -5450,6 +5450,7 @@ def test_154_ci_release_artifact_includes_stage_d_runtime_evidence_reports():
     registry_sync_script = (project_root / "scripts" / "release-gate-registry-sync.py").read_text(encoding="utf-8")
     registry_sync_wrapper = (project_root / "scripts" / "run-release-gate-registry-sync.ps1").read_text(encoding="utf-8")
     registry = json.loads((project_root / "docs" / "release-gate-registry.json").read_text(encoding="utf-8"))
+    registry_lock = json.loads((project_root / "docs" / "release-gate-registry.lock.json").read_text(encoding="utf-8"))
 
     required_artifact_paths = [
         "artifacts/safe-mode-ux-degradation-release-gate.json",
@@ -5761,13 +5762,21 @@ def test_154_ci_release_artifact_includes_stage_d_runtime_evidence_reports():
     assert "p0_runbook_contract" in runbook_contract_script
     assert "release-gate-registry-sync.py" in registry_sync_script
     assert "release_evidence_artifact_paths" in registry_sync_script
+    assert 'parser.add_argument("--lock-file", default="docs/release-gate-registry.lock.json")' in registry_sync_script
+    assert "build_registry_lock_payload" in registry_sync_script
+    assert "registry lock file" in registry_sync_script
     assert '[string]$RegistryFile = "docs\\\\release-gate-registry.json"' in runbook_contract_wrapper
     assert '"--registry-file", $RegistryFile' in runbook_contract_wrapper
     assert "release-gate-registry-sync.py" in registry_sync_wrapper
+    assert '[string]$LockFile = "docs\\\\release-gate-registry.lock.json"' in registry_sync_wrapper
+    assert '"--lock-file", $LockFile' in registry_sync_wrapper
     assert 'parser.add_argument("--required-ci-artifact-paths", default=' in runbook_contract_script
     assert 'parser.add_argument("--required-runbook-tokens", default=' in runbook_contract_script
     assert "[string]$RequiredCiArtifactPaths =" in runbook_contract_wrapper
     assert "[string]$RequiredRunbookTokens =" in runbook_contract_wrapper
+    assert registry_lock["version"] == "1.0.0"
+    assert registry_lock["registry_version"] == registry["version"]
+    assert registry_lock["counts"]["strict_flags_total"] == len(registry["release_gate_ci"]["strict_flags"])
 
 
 def test_155_p0_release_evidence_bundle_fails_when_required_label_is_mismatched():
@@ -9624,6 +9633,7 @@ def test_201_release_gate_registry_sync_check_reports_success():
     assert payload["success"] is True
     assert payload["mode"] == "check"
     assert payload["changed"] is False
+    assert payload["lock_changed"] is False
     assert payload["strict_flags_total"] >= 1
     assert payload["artifact_paths_total"] >= 1
     assert payload["p0_schema_required_top_level_keys_total"] >= 1
@@ -9885,5 +9895,83 @@ def test_206_release_gate_registry_sync_fails_when_schema_keys_missing_success()
     )
     assert completed.returncode != 0
     assert "required_top_level_keys must include 'label' and 'success'" in completed.stderr
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_207_release_gate_registry_sync_fails_when_lock_file_is_out_of_sync():
+    workspace = _local_test_dir("pytest-release-gate-registry-sync-lock-drift").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    lock_file = workspace / "release-gate-registry.lock.json"
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+    lock_file.write_text(json.dumps({"version": "1.0.0"}, ensure_ascii=True, sort_keys=True), encoding="utf-8")
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "release-gate-registry-sync.py"),
+        "--project-root",
+        str(project_root.resolve()),
+        "--lock-file",
+        str(lock_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    assert "registry lock file" in completed.stderr
+    assert "Out of sync with release-gate registry" in completed.stderr
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_208_release_gate_registry_sync_write_updates_custom_lock_file():
+    workspace = _local_test_dir("pytest-release-gate-registry-sync-lock-write").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    lock_file = workspace / "release-gate-registry.lock.json"
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "release-gate-registry-sync.py"),
+        "--project-root",
+        str(project_root.resolve()),
+        "--lock-file",
+        str(lock_file.resolve()),
+        "--write",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["mode"] == "write"
+    assert payload["lock_changed"] is True
+    assert lock_file.exists()
+
+    check_command = [
+        sys.executable,
+        str(project_root / "scripts" / "release-gate-registry-sync.py"),
+        "--project-root",
+        str(project_root.resolve()),
+        "--lock-file",
+        str(lock_file.resolve()),
+    ]
+    check_completed = subprocess.run(
+        check_command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert check_completed.returncode == 0, check_completed.stderr
+    check_payload = json.loads([line.strip() for line in check_completed.stdout.splitlines() if line.strip()][-1])
+    assert check_payload["success"] is True
+    assert check_payload["lock_changed"] is False
 
     shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
## Summary
- add deterministic registry lockfile support (`docs/release-gate-registry.lock.json`) to complement registry sync checks
- extend `scripts/release-gate-registry-sync.py` with:
  - lockfile check/write (`--lock-file`)
  - lock drift detection in check mode
  - lock payload hashes/counts for release-gate + P0 registry sections
- keep existing CI sync validation and cross-contract consistency enforcement
- update `scripts/run-release-gate-registry-sync.ps1` with lockfile wiring
- extend docs and tests for lock behavior + drift failure cases

## Validation
- `python -m py_compile scripts/release-gate-registry-sync.py tests/test_goal_ops.py`
- `python -m pytest -q tests/test_goal_ops.py -k "test_154 or test_201 or test_204 or test_205 or test_206 or test_207 or test_208"`
- `python scripts/release-gate-registry-sync.py --write`
- `python scripts/release-gate-registry-sync.py`
- `python scripts/p0-runbook-contract-check.py --label smoke`
