### PR TITLE
Stage AV/AW: add registry sync report artifact + CI drift guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Verify release-gate registry sync
         shell: pwsh
         run: |
-          python .\scripts\release-gate-registry-sync.py
+          python .\scripts\release-gate-registry-sync.py --output-file "artifacts/release-gate-registry-sync-ci.json"
 
       - name: Run release gate
         shell: pwsh
@@ -93,6 +93,7 @@ jobs:
             artifacts/release-gate-steady-state-certification-release-gate.json
             artifacts/release-gate-post-release-continuity-release-gate.json
             artifacts/release-gate-production-sustainability-certification-release-gate.json
+            artifacts/release-gate-registry-sync-ci.json
             artifacts/security-config-hardening-release-gate.json
             artifacts/audit-trail-hardening-release-gate.json
             artifacts/security-ci-lane-release-gate.json

--- a/README.md
+++ b/README.md
@@ -924,6 +924,10 @@ Sync/verify command:
 ```powershell
 python .\scripts\release-gate-registry-sync.py
 ```
+CI report command (writes an auditable sync report artifact):
+```powershell
+python .\scripts\release-gate-registry-sync.py --output-file artifacts/release-gate-registry-sync-ci.json
+```
 Write/sync command:
 ```powershell
 python .\scripts\release-gate-registry-sync.py --write

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -514,6 +514,11 @@ Manual release-gate registry sync check invocation:
 ```powershell
 .\scripts\run-release-gate-registry-sync.ps1
 ```
+Manual release-gate registry sync check + JSON report artifact:
+
+```powershell
+.\scripts\run-release-gate-registry-sync.ps1 -OutputFile artifacts\release-gate-registry-sync-manual.json
+```
 (Also verifies registry wiring in `scripts\release-gate.ps1`, `run-p0-report-schema-contract-check.ps1`, and `run-p0-release-evidence-bundle.ps1`.)
 (Also enforces registry cross-contract consistency for P0 required labels and CI artifact coverage.)
 

--- a/docs/release-gate-registry.json
+++ b/docs/release-gate-registry.json
@@ -119,6 +119,7 @@
       "artifacts/release-gate-steady-state-certification-release-gate.json",
       "artifacts/release-gate-post-release-continuity-release-gate.json",
       "artifacts/release-gate-production-sustainability-certification-release-gate.json",
+      "artifacts/release-gate-registry-sync-ci.json",
       "artifacts/security-config-hardening-release-gate.json",
       "artifacts/audit-trail-hardening-release-gate.json",
       "artifacts/security-ci-lane-release-gate.json",
@@ -129,7 +130,8 @@
       "artifacts/auto-rollback-policy-release-gate.json",
       "artifacts/canary-guardrails-release-gate.json",
       "artifacts/rto-rpo-assertion-release-gate.json"
-    ]
+    ],
+    "registry_sync_report_path": "artifacts/release-gate-registry-sync-ci.json"
   },
   "p0_runbook_contract": {
     "required_runbook_scripts": [
@@ -179,6 +181,7 @@
       "run-release-gate-steady-state-certification-check.ps1",
       "run-release-gate-post-release-continuity-check.ps1",
       "run-release-gate-production-sustainability-certification-check.ps1",
+      "run-release-gate-registry-sync.ps1",
       "run-p0-burnin-consecutive-green.ps1",
       "run-p0-release-evidence-bundle.ps1",
       "run-p0-report-schema-contract-check.ps1",
@@ -298,7 +301,8 @@
       "artifacts/release-gate-post-release-watch-release-gate.json",
       "artifacts/release-gate-steady-state-certification-release-gate.json",
       "artifacts/release-gate-post-release-continuity-release-gate.json",
-      "artifacts/release-gate-production-sustainability-certification-release-gate.json"
+      "artifacts/release-gate-production-sustainability-certification-release-gate.json",
+      "artifacts/release-gate-registry-sync-ci.json"
     ],
     "required_runbook_tokens": [
       "metrics.label_mismatch_reports=0",

--- a/docs/release-gate-registry.lock.json
+++ b/docs/release-gate-registry.lock.json
@@ -1,20 +1,20 @@
 {
   "counts": {
     "p0_bundle_required_files_total": 0,
-    "p0_runbook_required_ci_artifact_paths_total": 32,
-    "p0_runbook_required_scripts_total": 50,
+    "p0_runbook_required_ci_artifact_paths_total": 33,
+    "p0_runbook_required_scripts_total": 51,
     "p0_schema_required_decision_keys_total": 0,
     "p0_schema_required_files_total": 0,
     "p0_schema_required_top_level_keys_total": 2,
-    "release_evidence_artifact_paths_total": 51,
+    "release_evidence_artifact_paths_total": 52,
     "strict_flags_total": 73
   },
   "hashes": {
     "p0_release_evidence_bundle_sha256": "3eea6098363eafa59ab92c92e0debd01af30fe02258dc3222b9fc389b261d87c",
     "p0_report_schema_contract_sha256": "eb8c8d6ca0f983b9ffdb3c663791eeacd93fd85f7390c7a52d365b39a5c86c2e",
-    "p0_runbook_contract_sha256": "3e6da8d63cdea2eb91f5b0420f7977f08acbf3404794aa42d8b64270d5aefb65",
-    "registry_core_sha256": "ea669b5f3825e68ba12444b41e8fa8e600dd06c959ff9b01a15928d0f5a8596f",
-    "release_evidence_artifact_paths_sha256": "6c97e9571e46b0fcfb42bbf90bdd97b50e656333d1e703cad7fab996686c8e73",
+    "p0_runbook_contract_sha256": "3bc6f8ec473575a8779c0601afd1b713084d1246e0986ee9344fc5f6e1162643",
+    "registry_core_sha256": "7de9932fc508f1a2650b60d4575b225bdf386cfbcaf953cedee5a81c0c300995",
+    "release_evidence_artifact_paths_sha256": "c916b0139bad2eafd496a9c55814537302a1a7156920d9823aecd06024a9a1ec",
     "strict_flags_sha256": "36b5a0c874e33f08b1ced6936cd64703c85de4a5f87a7d26ff0a6ef88aff45db"
   },
   "registry_version": "1.0.0",

--- a/scripts/release-gate-registry-sync.py
+++ b/scripts/release-gate-registry-sync.py
@@ -102,6 +102,7 @@ def _artifact_path_is_covered(path: str, patterns: list[str]) -> bool:
 def _validate_cross_contracts(
     *,
     release_evidence_artifact_paths: list[str],
+    registry_sync_report_path: str,
     p0_runbook_contract: dict[str, list[str]],
     p0_report_schema_contract: dict[str, Any],
     p0_release_evidence_bundle: dict[str, Any],
@@ -139,6 +140,20 @@ def _validate_cross_contracts(
             f"{uncovered_ci_artifact_paths}"
         ),
     )
+    _expect(
+        _artifact_path_is_covered(registry_sync_report_path, release_evidence_artifact_paths),
+        (
+            "Registry contract mismatch: release_gate_ci.registry_sync_report_path is not covered by "
+            "release_gate_ci.release_evidence_artifact_paths."
+        ),
+    )
+    _expect(
+        _artifact_path_is_covered(registry_sync_report_path, p0_runbook_contract["required_ci_artifact_paths"]),
+        (
+            "Registry contract mismatch: release_gate_ci.registry_sync_report_path is not covered by "
+            "p0_runbook_contract.required_ci_artifact_paths."
+        ),
+    )
 
     schema_required_files = list(p0_report_schema_contract["required_files"])
     uncovered_schema_required_files = [
@@ -174,6 +189,7 @@ def _validate_cross_contracts(
         "ci_artifact_paths_checked_total": len(p0_runbook_contract["required_ci_artifact_paths"]),
         "schema_required_files_checked_total": len(schema_required_files),
         "bundle_required_files_checked_total": len(bundle_required_files),
+        "registry_sync_report_path_covered_total": 1,
     }
 
 
@@ -196,6 +212,16 @@ def load_registry(registry_file: Path) -> dict[str, Any]:
         release_gate_ci,
         "release_evidence_artifact_paths",
         context="release_gate_ci",
+    )
+    registry_sync_report_path_raw = release_gate_ci.get("registry_sync_report_path")
+    _expect(
+        isinstance(registry_sync_report_path_raw, str),
+        "Registry key 'registry_sync_report_path' must be a string in release_gate_ci.",
+    )
+    registry_sync_report_path = _normalize_artifact_token(registry_sync_report_path_raw)
+    _expect(
+        registry_sync_report_path,
+        "Registry key 'registry_sync_report_path' must not be empty in release_gate_ci.",
     )
 
     p0_contract = payload.get("p0_runbook_contract")
@@ -258,6 +284,7 @@ def load_registry(registry_file: Path) -> dict[str, Any]:
         "registry_version": registry_version,
         "strict_flags": strict_flags,
         "release_evidence_artifact_paths": artifact_paths,
+        "registry_sync_report_path": registry_sync_report_path,
         "p0_contract": p0_lists,
         "p0_report_schema_contract": {
             "required_top_level_keys": p0_schema_top_level,
@@ -272,6 +299,7 @@ def load_registry(registry_file: Path) -> dict[str, Any]:
     }
     registry["cross_contract_metrics"] = _validate_cross_contracts(
         release_evidence_artifact_paths=registry["release_evidence_artifact_paths"],
+        registry_sync_report_path=registry["registry_sync_report_path"],
         p0_runbook_contract=registry["p0_contract"],
         p0_report_schema_contract=registry["p0_report_schema_contract"],
         p0_release_evidence_bundle=registry["p0_release_evidence_bundle"],
@@ -285,6 +313,7 @@ def build_registry_lock_payload(registry: dict[str, Any]) -> dict[str, Any]:
         "release_gate_ci": {
             "strict_flags": registry["strict_flags"],
             "release_evidence_artifact_paths": registry["release_evidence_artifact_paths"],
+            "registry_sync_report_path": registry["registry_sync_report_path"],
         },
         "p0_runbook_contract": registry["p0_contract"],
         "p0_report_schema_contract": registry["p0_report_schema_contract"],
@@ -344,6 +373,26 @@ def _update_release_gate_command_line(ci_text: str, strict_flags: list[str]) -> 
     index = command_indexes[0]
     indent = _leading_whitespace(lines[index])
     generated = indent + ".\\scripts\\release-gate.ps1 " + " ".join(f"-{flag}" for flag in strict_flags)
+    changed = lines[index] != generated
+    lines[index] = generated
+    return ("\n".join(lines) + ("\n" if ci_text.endswith("\n") else "")), changed
+
+
+def _update_registry_sync_command_line(ci_text: str, registry_sync_report_path: str) -> tuple[str, bool]:
+    lines = ci_text.splitlines()
+    command_indexes = [idx for idx, line in enumerate(lines) if "python .\\scripts\\release-gate-registry-sync.py" in line]
+    _expect(command_indexes, "Unable to find release-gate registry sync command in CI workflow.")
+    _expect(
+        len(command_indexes) == 1,
+        f"Expected exactly one registry sync command in CI workflow, found {len(command_indexes)}.",
+    )
+
+    index = command_indexes[0]
+    indent = _leading_whitespace(lines[index])
+    generated = (
+        indent
+        + f'python .\\scripts\\release-gate-registry-sync.py --output-file "{registry_sync_report_path}"'
+    )
     changed = lines[index] != generated
     lines[index] = generated
     return ("\n".join(lines) + ("\n" if ci_text.endswith("\n") else "")), changed
@@ -448,10 +497,71 @@ def synchronize_ci_workflow(
     *,
     strict_flags: list[str],
     artifact_paths: list[str],
+    registry_sync_report_path: str,
 ) -> tuple[str, bool]:
-    updated_text, changed_command = _update_release_gate_command_line(ci_text, strict_flags)
+    updated_text, changed_registry_sync = _update_registry_sync_command_line(ci_text, registry_sync_report_path)
+    updated_text, changed_command = _update_release_gate_command_line(updated_text, strict_flags)
     updated_text, changed_paths = _update_release_evidence_paths(updated_text, artifact_paths)
-    return updated_text, bool(changed_command or changed_paths)
+    return updated_text, bool(changed_registry_sync or changed_command or changed_paths)
+
+
+def _build_sync_report_payload(
+    *,
+    mode: str,
+    changed: bool,
+    lock_changed: bool,
+    registry: dict[str, Any],
+    registry_file: Path,
+    lock_file: Path,
+    ci_workflow_file: Path,
+    release_gate_file: Path,
+    schema_wrapper_file: Path,
+    bundle_wrapper_file: Path,
+    wiring_metrics: dict[str, int],
+) -> dict[str, Any]:
+    return {
+        "success": True,
+        "mode": mode,
+        "changed": bool(changed),
+        "lock_changed": bool(lock_changed),
+        "registry_file": str(registry_file),
+        "lock_file": str(lock_file),
+        "ci_workflow_file": str(ci_workflow_file),
+        "release_gate_file": str(release_gate_file),
+        "schema_wrapper_file": str(schema_wrapper_file),
+        "bundle_wrapper_file": str(bundle_wrapper_file),
+        "strict_flags_total": len(registry["strict_flags"]),
+        "artifact_paths_total": len(registry["release_evidence_artifact_paths"]),
+        "registry_sync_report_path": registry["registry_sync_report_path"],
+        "p0_schema_required_top_level_keys_total": len(registry["p0_report_schema_contract"]["required_top_level_keys"]),
+        "p0_schema_required_decision_keys_total": len(registry["p0_report_schema_contract"]["required_decision_keys"]),
+        "p0_bundle_required_files_total": len(registry["p0_release_evidence_bundle"]["required_files"]),
+        "ci_artifact_paths_checked_total": registry["cross_contract_metrics"]["ci_artifact_paths_checked_total"],
+        "schema_required_files_checked_total": registry["cross_contract_metrics"]["schema_required_files_checked_total"],
+        "bundle_required_files_checked_total": registry["cross_contract_metrics"]["bundle_required_files_checked_total"],
+        "registry_sync_report_path_covered_total": registry["cross_contract_metrics"][
+            "registry_sync_report_path_covered_total"
+        ],
+        "release_gate_registry_argument_occurrences": wiring_metrics["release_gate_registry_argument_occurrences"],
+        "schema_wrapper_registry_argument_occurrences": wiring_metrics["schema_wrapper_registry_argument_occurrences"],
+        "bundle_wrapper_registry_argument_occurrences": wiring_metrics["bundle_wrapper_registry_argument_occurrences"],
+    }
+
+
+def _resolve_output_file(project_root: Path, output_file_arg: str | None) -> Path | None:
+    if output_file_arg is None:
+        return None
+    candidate = Path(output_file_arg).expanduser()
+    if not candidate.is_absolute():
+        candidate = project_root / candidate
+    return candidate.resolve()
+
+
+def _write_optional_output_file(output_file: Path | None, payload: dict[str, Any]) -> None:
+    if output_file is None:
+        return
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(_render_json_file(payload), encoding="utf-8")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -468,6 +578,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--release-gate-file", default="scripts/release-gate.ps1")
     parser.add_argument("--schema-wrapper-file", default="scripts/run-p0-report-schema-contract-check.ps1")
     parser.add_argument("--bundle-wrapper-file", default="scripts/run-p0-release-evidence-bundle.ps1")
+    parser.add_argument("--output-file")
     parser.add_argument("--write", action="store_true")
     args = parser.parse_args(argv)
 
@@ -483,6 +594,7 @@ def main(argv: list[str] | None = None) -> int:
     release_gate_file = (project_root / str(args.release_gate_file)).resolve()
     schema_wrapper_file = (project_root / str(args.schema_wrapper_file)).resolve()
     bundle_wrapper_file = (project_root / str(args.bundle_wrapper_file)).resolve()
+    output_file = _resolve_output_file(project_root, args.output_file)
 
     try:
         registry = load_registry(registry_file)
@@ -503,6 +615,7 @@ def main(argv: list[str] | None = None) -> int:
             original_ci,
             strict_flags=registry["strict_flags"],
             artifact_paths=registry["release_evidence_artifact_paths"],
+            registry_sync_report_path=registry["registry_sync_report_path"],
         )
     except Exception as exc:
         print(f"[release-gate-registry-sync] ERROR: {exc}", file=sys.stderr)
@@ -514,49 +627,23 @@ def main(argv: list[str] | None = None) -> int:
         if lock_changed:
             lock_file.parent.mkdir(parents=True, exist_ok=True)
             lock_file.write_text(generated_lock_text, encoding="utf-8")
+        payload = _build_sync_report_payload(
+            mode="write",
+            changed=bool(changed),
+            lock_changed=bool(lock_changed),
+            registry=registry,
+            registry_file=registry_file,
+            lock_file=lock_file,
+            ci_workflow_file=ci_workflow_file,
+            release_gate_file=release_gate_file,
+            schema_wrapper_file=schema_wrapper_file,
+            bundle_wrapper_file=bundle_wrapper_file,
+            wiring_metrics=wiring_metrics,
+        )
+        _write_optional_output_file(output_file, payload)
         print(
             json.dumps(
-                {
-                    "success": True,
-                    "mode": "write",
-                    "changed": bool(changed),
-                    "lock_changed": bool(lock_changed),
-                    "registry_file": str(registry_file),
-                    "lock_file": str(lock_file),
-                    "ci_workflow_file": str(ci_workflow_file),
-                    "release_gate_file": str(release_gate_file),
-                    "schema_wrapper_file": str(schema_wrapper_file),
-                    "bundle_wrapper_file": str(bundle_wrapper_file),
-                    "strict_flags_total": len(registry["strict_flags"]),
-                    "artifact_paths_total": len(registry["release_evidence_artifact_paths"]),
-                    "p0_schema_required_top_level_keys_total": len(
-                        registry["p0_report_schema_contract"]["required_top_level_keys"]
-                    ),
-                    "p0_schema_required_decision_keys_total": len(
-                        registry["p0_report_schema_contract"]["required_decision_keys"]
-                    ),
-                    "p0_bundle_required_files_total": len(
-                        registry["p0_release_evidence_bundle"]["required_files"]
-                    ),
-                    "ci_artifact_paths_checked_total": registry["cross_contract_metrics"][
-                        "ci_artifact_paths_checked_total"
-                    ],
-                    "schema_required_files_checked_total": registry["cross_contract_metrics"][
-                        "schema_required_files_checked_total"
-                    ],
-                    "bundle_required_files_checked_total": registry["cross_contract_metrics"][
-                        "bundle_required_files_checked_total"
-                    ],
-                    "release_gate_registry_argument_occurrences": wiring_metrics[
-                        "release_gate_registry_argument_occurrences"
-                    ],
-                    "schema_wrapper_registry_argument_occurrences": wiring_metrics[
-                        "schema_wrapper_registry_argument_occurrences"
-                    ],
-                    "bundle_wrapper_registry_argument_occurrences": wiring_metrics[
-                        "bundle_wrapper_registry_argument_occurrences"
-                    ],
-                },
+                payload,
                 ensure_ascii=True,
                 sort_keys=True,
             )
@@ -579,49 +666,23 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
+    payload = _build_sync_report_payload(
+        mode="check",
+        changed=False,
+        lock_changed=False,
+        registry=registry,
+        registry_file=registry_file,
+        lock_file=lock_file,
+        ci_workflow_file=ci_workflow_file,
+        release_gate_file=release_gate_file,
+        schema_wrapper_file=schema_wrapper_file,
+        bundle_wrapper_file=bundle_wrapper_file,
+        wiring_metrics=wiring_metrics,
+    )
+    _write_optional_output_file(output_file, payload)
     print(
         json.dumps(
-            {
-                "success": True,
-                "mode": "check",
-                "changed": False,
-                "lock_changed": False,
-                "registry_file": str(registry_file),
-                "lock_file": str(lock_file),
-                "ci_workflow_file": str(ci_workflow_file),
-                "release_gate_file": str(release_gate_file),
-                "schema_wrapper_file": str(schema_wrapper_file),
-                "bundle_wrapper_file": str(bundle_wrapper_file),
-                "strict_flags_total": len(registry["strict_flags"]),
-                "artifact_paths_total": len(registry["release_evidence_artifact_paths"]),
-                "p0_schema_required_top_level_keys_total": len(
-                    registry["p0_report_schema_contract"]["required_top_level_keys"]
-                ),
-                "p0_schema_required_decision_keys_total": len(
-                    registry["p0_report_schema_contract"]["required_decision_keys"]
-                ),
-                "p0_bundle_required_files_total": len(
-                    registry["p0_release_evidence_bundle"]["required_files"]
-                ),
-                "ci_artifact_paths_checked_total": registry["cross_contract_metrics"][
-                    "ci_artifact_paths_checked_total"
-                ],
-                "schema_required_files_checked_total": registry["cross_contract_metrics"][
-                    "schema_required_files_checked_total"
-                ],
-                "bundle_required_files_checked_total": registry["cross_contract_metrics"][
-                    "bundle_required_files_checked_total"
-                ],
-                "release_gate_registry_argument_occurrences": wiring_metrics[
-                    "release_gate_registry_argument_occurrences"
-                ],
-                "schema_wrapper_registry_argument_occurrences": wiring_metrics[
-                    "schema_wrapper_registry_argument_occurrences"
-                ],
-                "bundle_wrapper_registry_argument_occurrences": wiring_metrics[
-                    "bundle_wrapper_registry_argument_occurrences"
-                ],
-            },
+            payload,
             ensure_ascii=True,
             sort_keys=True,
         )

--- a/scripts/run-release-gate-registry-sync.ps1
+++ b/scripts/run-release-gate-registry-sync.ps1
@@ -3,6 +3,7 @@ param(
     [string]$RegistryFile = "docs\\release-gate-registry.json",
     [string]$LockFile = "docs\\release-gate-registry.lock.json",
     [string]$CiWorkflowFile = ".github\\workflows\\ci.yml",
+    [string]$OutputFile = "",
     [switch]$Write
 )
 
@@ -17,6 +18,9 @@ $arguments = @(
     "--lock-file", $LockFile,
     "--ci-workflow-file", $CiWorkflowFile
 )
+if ($OutputFile) {
+    $arguments += @("--output-file", $OutputFile)
+}
 if ($Write) {
     $arguments += "--write"
 }

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -5535,16 +5535,21 @@ def test_154_ci_release_artifact_includes_stage_d_runtime_evidence_reports():
         "artifacts/release-gate-steady-state-certification-release-gate.json",
         "artifacts/release-gate-post-release-continuity-release-gate.json",
         "artifacts/release-gate-production-sustainability-certification-release-gate.json",
+        "artifacts/release-gate-registry-sync-ci.json",
     ]
     for artifact_path in required_artifact_paths:
         assert artifact_path in ci_workflow
 
     assert "Verify release-gate registry sync" in ci_workflow
-    assert "python .\\scripts\\release-gate-registry-sync.py" in ci_workflow
+    assert (
+        'python .\\scripts\\release-gate-registry-sync.py --output-file '
+        '"artifacts/release-gate-registry-sync-ci.json"'
+    ) in ci_workflow
     assert "release_gate_ci" in registry
     assert "p0_runbook_contract" in registry
     assert "p0_report_schema_contract" in registry
     assert "p0_release_evidence_bundle" in registry
+    assert registry["release_gate_ci"]["registry_sync_report_path"] == "artifacts/release-gate-registry-sync-ci.json"
     assert "StrictReleaseGatePostReleaseContinuityCheck" in registry["release_gate_ci"]["strict_flags"]
     assert "StrictReleaseGateProductionSustainabilityCertificationCheck" in registry["release_gate_ci"]["strict_flags"]
     assert (
@@ -5555,10 +5560,13 @@ def test_154_ci_release_artifact_includes_stage_d_runtime_evidence_reports():
         "artifacts/release-gate-production-sustainability-certification-release-gate.json"
         in registry["release_gate_ci"]["release_evidence_artifact_paths"]
     )
+    assert "artifacts/release-gate-registry-sync-ci.json" in registry["release_gate_ci"]["release_evidence_artifact_paths"]
     assert "required_runbook_scripts" in registry["p0_runbook_contract"]
     assert "required_release_gate_tokens" in registry["p0_runbook_contract"]
     assert "required_ci_artifact_paths" in registry["p0_runbook_contract"]
     assert "required_runbook_tokens" in registry["p0_runbook_contract"]
+    assert "run-release-gate-registry-sync.ps1" in registry["p0_runbook_contract"]["required_runbook_scripts"]
+    assert "artifacts/release-gate-registry-sync-ci.json" in registry["p0_runbook_contract"]["required_ci_artifact_paths"]
     assert registry["p0_report_schema_contract"]["required_top_level_keys"] == ["label", "success"]
     assert registry["p0_report_schema_contract"]["required_label"] == "release-gate"
     assert registry["p0_release_evidence_bundle"]["required_label"] == "release-gate"
@@ -5811,13 +5819,17 @@ def test_154_ci_release_artifact_includes_stage_d_runtime_evidence_reports():
     assert "release-gate-registry-sync.py" in registry_sync_script
     assert "release_evidence_artifact_paths" in registry_sync_script
     assert 'parser.add_argument("--lock-file", default="docs/release-gate-registry.lock.json")' in registry_sync_script
+    assert 'parser.add_argument("--output-file")' in registry_sync_script
+    assert "_update_registry_sync_command_line" in registry_sync_script
     assert "build_registry_lock_payload" in registry_sync_script
     assert "registry lock file" in registry_sync_script
     assert '[string]$RegistryFile = "docs\\\\release-gate-registry.json"' in runbook_contract_wrapper
     assert '"--registry-file", $RegistryFile' in runbook_contract_wrapper
     assert "release-gate-registry-sync.py" in registry_sync_wrapper
     assert '[string]$LockFile = "docs\\\\release-gate-registry.lock.json"' in registry_sync_wrapper
+    assert '[string]$OutputFile = ""' in registry_sync_wrapper
     assert '"--lock-file", $LockFile' in registry_sync_wrapper
+    assert '@("--output-file", $OutputFile)' in registry_sync_wrapper
     assert 'parser.add_argument("--required-ci-artifact-paths", default=' in runbook_contract_script
     assert 'parser.add_argument("--required-runbook-tokens", default=' in runbook_contract_script
     assert "[string]$RequiredCiArtifactPaths =" in runbook_contract_wrapper
@@ -9690,6 +9702,8 @@ def test_201_release_gate_registry_sync_check_reports_success():
     assert payload["ci_artifact_paths_checked_total"] >= 1
     assert payload["schema_required_files_checked_total"] >= 0
     assert payload["bundle_required_files_checked_total"] >= 0
+    assert payload["registry_sync_report_path"] == "artifacts/release-gate-registry-sync-ci.json"
+    assert payload["registry_sync_report_path_covered_total"] == 1
     assert payload["release_gate_registry_argument_occurrences"] >= 2
     assert payload["schema_wrapper_registry_argument_occurrences"] >= 1
     assert payload["bundle_wrapper_registry_argument_occurrences"] >= 1
@@ -10021,5 +10035,39 @@ def test_208_release_gate_registry_sync_write_updates_custom_lock_file():
     check_payload = json.loads([line.strip() for line in check_completed.stdout.splitlines() if line.strip()][-1])
     assert check_payload["success"] is True
     assert check_payload["lock_changed"] is False
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_209_release_gate_registry_sync_check_writes_output_file():
+    workspace = _local_test_dir("pytest-release-gate-registry-sync-output-file").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    output_file = workspace / "artifacts" / "release-gate-registry-sync-check.json"
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "release-gate-registry-sync.py"),
+        "--project-root",
+        str(project_root.resolve()),
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["mode"] == "check"
+    assert payload["registry_sync_report_path"] == "artifacts/release-gate-registry-sync-ci.json"
+    assert output_file.exists()
+
+    written_payload = json.loads(output_file.read_text(encoding="utf-8"))
+    assert written_payload["success"] is True
+    assert written_payload["mode"] == "check"
+    assert written_payload["registry_sync_report_path"] == "artifacts/release-gate-registry-sync-ci.json"
 
     shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
﻿## Summary
- add `release_gate_ci.registry_sync_report_path` to the registry source-of-truth
- enforce coverage of that report path across CI upload paths and runbook required CI artifacts
- extend `release-gate-registry-sync.py` to synchronize the CI verify command to emit `--output-file` report artifacts
- add optional `--output-file` support to sync script and wrapper (`run-release-gate-registry-sync.ps1`)
- update README/runbook docs and tests for the new report artifact contract

## Validation
- `python -m py_compile scripts/release-gate-registry-sync.py tests/test_goal_ops.py`
- `python -m pytest -q tests/test_goal_ops.py -k "test_154 or test_201 or test_204 or test_205 or test_206 or test_207 or test_208 or test_209 or test_64b"`
- `python scripts/release-gate-registry-sync.py --write`
- `python scripts/release-gate-registry-sync.py`
- `python scripts/release-gate-registry-sync.py --output-file artifacts/release-gate-registry-sync-local.json`
