### PR TITLE
Stage BH/BI: CI-check dedupe and required-check hardening

### DIFF
--- a/.github/workflows/master-release-gate-burnin.yml
+++ b/.github/workflows/master-release-gate-burnin.yml
@@ -52,7 +52,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --branch master \
             --workflow-name "CI" \
-            --required-jobs "Release Gate (Windows),Pytest (Python 3.11),Pytest (Python 3.12),Desktop Smoke (Windows)" \
+            --required-jobs "Release Gate (Windows),Security CI Lane,Pytest (Python 3.11),Pytest (Python 3.12),Desktop Smoke (Windows)" \
             --required-consecutive "$TARGET_CONSECUTIVE" \
             --per-page "$PER_PAGE" \
             --output-file ./artifacts/p0-burnin-consecutive-green-release-gate.json \

--- a/.github/workflows/p0-burnin-monitor.yml
+++ b/.github/workflows/p0-burnin-monitor.yml
@@ -43,7 +43,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --branch master \
             --workflow-name "CI" \
-            --required-jobs "Release Gate (Windows),Pytest (Python 3.11),Pytest (Python 3.12),Desktop Smoke (Windows)" \
+            --required-jobs "Release Gate (Windows),Security CI Lane,Pytest (Python 3.11),Pytest (Python 3.12),Desktop Smoke (Windows)" \
             --required-consecutive "$REQUIRED_CONSECUTIVE" \
             --per-page 50 \
             --output-file ./artifacts/p0-burnin-consecutive-green-report.json \

--- a/README.md
+++ b/README.md
@@ -942,6 +942,7 @@ It also enforces strict-flag parity between registry `release_gate_ci.strict_fla
 It also enforces that each declared release-gate strict switch has runtime usage beyond its declaration.
 It also enforces that `p0_runbook_contract` registry lists stay in lockstep with `DEFAULT_REQUIRED_*` list constants in `scripts\p0-runbook-contract-check.py`.
 It also enforces registry attestation-gate invariants over sync-report mode/drift fields and lock payload integrity.
+P0 burn-in CI-check evaluation now dedupes duplicate check names per run and keeps failure-biased conclusions for stability-first gating.
 
 Release Gate workflow artifact includes `p0-release-evidence-bundle` (manifest + copied evidence reports, including safe-mode/A11y/runtime/flake stage outputs, + closure report), Stage-L/M evidence artifacts (`release-gate-evidence-freshness-release-gate.json`, `release-gate-evidence-hash-manifest-release-gate.json`, `release-gate-evidence-manifest-release-gate.json`), Stage-N/O timing-history artifacts (`release-gate-step-timing-schema-release-gate.json`, `release-gate-performance-history-release-gate.json`), Stage-K/P artifacts (`release-gate-step-timings-release-gate.json`, `release-gate-performance-budget-release-gate.json`, `release-gate-stability-final-readiness-release-gate.json`), Stage-Q/R readiness artifacts (`release-gate-staging-soak-readiness-release-gate.json`, `release-gate-rc-canary-rollout-release-gate.json`), Stage-S/T readiness artifacts (`release-gate-evidence-lineage-release-gate.json`, `release-gate-production-readiness-certification-release-gate.json`), Stage-U/AB expanded readiness artifacts (`release-gate-slo-burn-rate-v2-release-gate.json`, `release-gate-deploy-rehearsal-release-gate.json`, `release-gate-chaos-matrix-continuous-release-gate.json`, `release-gate-supply-chain-artifact-trust-release-gate.json`, `release-gate-operations-handoff-readiness-release-gate.json`, `release-gate-evidence-attestation-release-gate.json`, `release-gate-release-train-readiness-release-gate.json`, `release-gate-production-final-attestation-release-gate.json`), Stage-AC/AJ cutover-to-sustainability artifacts (`release-gate-production-cutover-readiness-release-gate.json`, `release-gate-hypercare-activation-release-gate.json`, `release-gate-rollback-trigger-integrity-release-gate.json`, `release-gate-post-cutover-finalization-release-gate.json`, `release-gate-post-release-watch-release-gate.json`, `release-gate-steady-state-certification-release-gate.json`, `release-gate-post-release-continuity-release-gate.json`, `release-gate-production-sustainability-certification-release-gate.json`), and registry attestation artifacts (`release-gate-registry-sync-ci.json`, `release-gate-registry-attestation-gate-ci.json`).
 
@@ -967,9 +968,10 @@ Recommended branch protection on `master`:
 3. Add/update rule for `master`:
 4. Enable `Require a pull request before merging`.
 5. Enable `Require status checks to pass before merging`.
-6. Select required check: `Pytest (Python 3.11)` and `Pytest (Python 3.12)`.
-7. Select required check: `Desktop Smoke (Windows)`.
-8. Select required check: `Release Gate (Windows)`.
+6. Select required check: `Release Gate (Windows)`.
+7. Select required check: `Security CI Lane`.
+8. Select required check: `Pytest (Python 3.11)` and `Pytest (Python 3.12)`.
+9. Select required check: `Desktop Smoke (Windows)`.
 
 Local desktop smoke command:
 

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -566,6 +566,7 @@ Manual P0 closure report invocation:
 Verify before release:
 - CI checks green:
   - `Release Gate (Windows)`
+  - `Security CI Lane`
   - `Pytest (Python 3.11)`
   - `Pytest (Python 3.12)`
   - `Desktop Smoke (Windows)`

--- a/scripts/p0-burnin-consecutive-green.py
+++ b/scripts/p0-burnin-consecutive-green.py
@@ -11,10 +11,21 @@ from typing import Any
 
 DEFAULT_REQUIRED_JOBS = [
     "Release Gate (Windows)",
+    "Security CI Lane",
     "Pytest (Python 3.11)",
     "Pytest (Python 3.12)",
     "Desktop Smoke (Windows)",
 ]
+
+CONCLUSION_SEVERITY = {
+    "success": 0,
+    "neutral": 1,
+    "skipped": 1,
+    "cancelled": 2,
+    "timed_out": 3,
+    "failure": 4,
+    "action_required": 5,
+}
 
 
 def _expect(condition: bool, message: str) -> None:
@@ -45,6 +56,50 @@ def _parse_required_jobs(text: str) -> list[str]:
     jobs = [item.strip() for item in str(text).split(",") if item.strip()]
     _expect(jobs, "At least one required job must be configured.")
     return jobs
+
+
+def _dedupe_ordered_strings(values: list[str]) -> tuple[list[str], list[str]]:
+    deduped: list[str] = []
+    duplicates: list[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        token = str(raw).strip()
+        if not token:
+            continue
+        if token in seen:
+            duplicates.append(token)
+            continue
+        seen.add(token)
+        deduped.append(token)
+    return deduped, duplicates
+
+
+def _collapse_job_conclusion(conclusions: list[str]) -> str:
+    normalized = [str(item).strip().lower() for item in conclusions if str(item).strip()]
+    if not normalized:
+        return ""
+    return max(normalized, key=lambda item: CONCLUSION_SEVERITY.get(item, 6))
+
+
+def _build_job_conclusion_map(jobs: list[dict[str, Any]]) -> tuple[dict[str, str], list[str], int, int]:
+    conclusions_by_name: dict[str, list[str]] = {}
+    named_job_entries_total = 0
+    for job in jobs:
+        name = str(job.get("name") or "").strip()
+        if not name:
+            continue
+        named_job_entries_total += 1
+        conclusions_by_name.setdefault(name, []).append(str(job.get("conclusion") or ""))
+
+    job_map: dict[str, str] = {}
+    duplicate_job_names: list[str] = []
+    for name, conclusions in conclusions_by_name.items():
+        if len(conclusions) > 1:
+            duplicate_job_names.append(name)
+        job_map[name] = _collapse_job_conclusion(conclusions)
+
+    duplicate_job_entries_dropped = max(0, named_job_entries_total - len(job_map))
+    return job_map, sorted(duplicate_job_names), named_job_entries_total, duplicate_job_entries_dropped
 
 
 def _fetch_workflow_id(*, repo: str, workflow_name: str) -> int:
@@ -112,12 +167,9 @@ def _evaluate_run(
     run_head_sha = str(run.get("head_sha") or "")
     run_updated_at = str(run.get("updated_at") or "")
 
-    job_map: dict[str, str] = {}
-    for job in jobs:
-        name = str(job.get("name") or "")
-        if not name:
-            continue
-        job_map[name] = str(job.get("conclusion") or "")
+    job_map, duplicate_job_names, named_job_entries_total, duplicate_job_entries_dropped = _build_job_conclusion_map(
+        jobs
+    )
 
     missing_jobs = [job_name for job_name in required_jobs if job_name not in job_map]
     failing_jobs = [
@@ -141,6 +193,13 @@ def _evaluate_run(
         "head_sha": run_head_sha,
         "updated_at": run_updated_at,
         "required_jobs": {name: job_map.get(name, "") for name in required_jobs},
+        "job_dedupe": {
+            "named_job_entries_total": int(named_job_entries_total),
+            "unique_job_names_total": int(len(job_map)),
+            "duplicate_job_name_total": int(len(duplicate_job_names)),
+            "duplicate_job_entries_dropped": int(duplicate_job_entries_dropped),
+            "duplicate_job_names": duplicate_job_names,
+        },
         "missing_jobs": missing_jobs,
         "failing_jobs": failing_jobs,
         "is_green": bool(is_green),
@@ -164,6 +223,8 @@ def run_burnin_check(
     _expect(required_consecutive > 0, "required_consecutive must be > 0.")
     _expect(per_page > 0, "per_page must be > 0.")
     _expect(per_page >= required_consecutive, "per_page should be >= required_consecutive.")
+    resolved_required_jobs, duplicate_required_jobs = _dedupe_ordered_strings(required_jobs)
+    _expect(resolved_required_jobs, "At least one required job must be configured.")
 
     started = time.perf_counter()
     if runs_file is not None:
@@ -193,7 +254,7 @@ def run_burnin_check(
             jobs = _fetch_run_jobs_from_github(repo=repo, run_id=run_id)
         evaluation = _evaluate_run(
             run=run,
-            required_jobs=required_jobs,
+            required_jobs=resolved_required_jobs,
             jobs=jobs,
             ignore_run_conclusion=bool(ignore_run_conclusion),
         )
@@ -207,6 +268,19 @@ def run_burnin_check(
             break
 
     success = consecutive_green >= required_consecutive
+    duplicate_job_name_observations = sum(
+        int(((evaluation.get("job_dedupe") or {}).get("duplicate_job_name_total") or 0))
+        for evaluation in evaluations
+    )
+    duplicate_job_entries_dropped_total = sum(
+        int(((evaluation.get("job_dedupe") or {}).get("duplicate_job_entries_dropped") or 0))
+        for evaluation in evaluations
+    )
+    evaluated_runs_with_duplicate_job_names = sum(
+        1
+        for evaluation in evaluations
+        if int(((evaluation.get("job_dedupe") or {}).get("duplicate_job_name_total") or 0)) > 0
+    )
     report = {
         "label": label,
         "success": bool(success),
@@ -214,7 +288,10 @@ def run_burnin_check(
             "repo": repo,
             "branch": branch,
             "workflow_name": workflow_name,
-            "required_jobs": required_jobs,
+            "required_jobs": resolved_required_jobs,
+            "required_jobs_declared_total": int(len(required_jobs)),
+            "required_jobs_unique_total": int(len(resolved_required_jobs)),
+            "required_jobs_duplicates_removed": duplicate_required_jobs,
             "required_consecutive": int(required_consecutive),
             "per_page": int(per_page),
             "allow_not_met": bool(allow_not_met),
@@ -226,6 +303,10 @@ def run_burnin_check(
             "consecutive_green": int(consecutive_green),
             "required_consecutive": int(required_consecutive),
             "evaluated_runs": int(len(evaluations)),
+            "required_jobs_duplicates_removed_total": int(len(duplicate_required_jobs)),
+            "duplicate_job_name_observations": int(duplicate_job_name_observations),
+            "duplicate_job_entries_dropped_total": int(duplicate_job_entries_dropped_total),
+            "evaluated_runs_with_duplicate_job_names": int(evaluated_runs_with_duplicate_job_names),
         },
         "first_non_green": first_non_green,
         "evaluations": evaluations,

--- a/scripts/run-p0-burnin-consecutive-green.ps1
+++ b/scripts/run-p0-burnin-consecutive-green.ps1
@@ -3,7 +3,7 @@ param(
     [string]$Repo = "donatomaurizio99-collab/GOC",
     [string]$Branch = "master",
     [string]$WorkflowName = "CI",
-    [string]$RequiredJobs = "Release Gate (Windows),Pytest (Python 3.11),Pytest (Python 3.12),Desktop Smoke (Windows)",
+    [string]$RequiredJobs = "Release Gate (Windows),Security CI Lane,Pytest (Python 3.11),Pytest (Python 3.12),Desktop Smoke (Windows)",
     [int]$RequiredConsecutive = 10,
     [int]$PerPage = 50,
     [string]$OutputFile = "artifacts\\p0-burnin-consecutive-green-report.json",

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -10369,3 +10369,201 @@ def test_215_release_gate_registry_attestation_gate_fails_when_sync_report_decla
     assert "report_changed_false" in payload["failed_checks"]
 
     shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_216_p0_burnin_consecutive_green_dedupes_required_jobs_input():
+    workspace = _local_test_dir("pytest-p0-burnin-required-jobs-dedupe").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    runs_file = workspace / "runs.json"
+    jobs_dir = workspace / "jobs"
+    output_file = workspace / "p0-burnin-report.json"
+    jobs_dir.mkdir(parents=True, exist_ok=True)
+
+    run_id = 6101
+    runs_file.write_text(
+        json.dumps(
+            {
+                "workflow_runs": [
+                    {
+                        "id": run_id,
+                        "name": "CI",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "head_sha": "sha-6101",
+                        "updated_at": "2026-04-18T14:00:00Z",
+                    }
+                ]
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (jobs_dir / f"{run_id}.json").write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {"name": "Release Gate (Windows)", "conclusion": "success"},
+                    {"name": "Security CI Lane", "conclusion": "success"},
+                    {"name": "Pytest (Python 3.11)", "conclusion": "success"},
+                    {"name": "Pytest (Python 3.12)", "conclusion": "success"},
+                    {"name": "Desktop Smoke (Windows)", "conclusion": "success"},
+                ]
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "p0-burnin-consecutive-green.py"),
+        "--label",
+        "pytest-drill",
+        "--runs-file",
+        str(runs_file.resolve()),
+        "--jobs-dir",
+        str(jobs_dir.resolve()),
+        "--required-jobs",
+        (
+            "Release Gate (Windows),Security CI Lane,Pytest (Python 3.11),"
+            "Pytest (Python 3.12),Desktop Smoke (Windows),Security CI Lane,Pytest (Python 3.12)"
+        ),
+        "--required-consecutive",
+        "1",
+        "--per-page",
+        "5",
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["config"]["required_jobs"] == [
+        "Release Gate (Windows)",
+        "Security CI Lane",
+        "Pytest (Python 3.11)",
+        "Pytest (Python 3.12)",
+        "Desktop Smoke (Windows)",
+    ]
+    assert payload["metrics"]["required_jobs_duplicates_removed_total"] == 2
+    assert payload["metrics"]["duplicate_job_name_observations"] == 0
+    assert output_file.exists()
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_217_p0_burnin_consecutive_green_hardens_duplicate_job_entries():
+    workspace = _local_test_dir("pytest-p0-burnin-duplicate-job-hardening").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    runs_file = workspace / "runs.json"
+    jobs_dir = workspace / "jobs"
+    jobs_dir.mkdir(parents=True, exist_ok=True)
+
+    run_id = 6201
+    runs_file.write_text(
+        json.dumps(
+            {
+                "workflow_runs": [
+                    {
+                        "id": run_id,
+                        "name": "CI",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "head_sha": "sha-6201",
+                        "updated_at": "2026-04-18T14:10:00Z",
+                    }
+                ]
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (jobs_dir / f"{run_id}.json").write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {"name": "Release Gate (Windows)", "conclusion": "success"},
+                    {"name": "Security CI Lane", "conclusion": "success"},
+                    {"name": "Security CI Lane", "conclusion": "failure"},
+                    {"name": "Pytest (Python 3.11)", "conclusion": "success"},
+                    {"name": "Pytest (Python 3.12)", "conclusion": "success"},
+                    {"name": "Desktop Smoke (Windows)", "conclusion": "success"},
+                ]
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "p0-burnin-consecutive-green.py"),
+        "--label",
+        "pytest-drill",
+        "--runs-file",
+        str(runs_file.resolve()),
+        "--jobs-dir",
+        str(jobs_dir.resolve()),
+        "--required-jobs",
+        "Release Gate (Windows),Security CI Lane,Pytest (Python 3.11),Pytest (Python 3.12),Desktop Smoke (Windows)",
+        "--required-consecutive",
+        "1",
+        "--per-page",
+        "5",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "P0 burn-in consecutive-green check not met: "
+    assert marker in completed.stderr
+    payload = json.loads(completed.stderr.split(marker, 1)[1].strip())
+    assert payload["success"] is False
+    assert payload["metrics"]["duplicate_job_name_observations"] == 1
+    assert payload["first_non_green"]["job_dedupe"]["duplicate_job_name_total"] == 1
+    failing_job_names = [item["name"] for item in payload["first_non_green"]["failing_jobs"]]
+    assert "Security CI Lane" in failing_job_names
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_218_required_checks_hardened_in_burnin_workflows_and_branch_protection_docs():
+    project_root = Path(__file__).resolve().parents[1]
+    burnin_workflow = (project_root / ".github" / "workflows" / "p0-burnin-monitor.yml").read_text(encoding="utf-8")
+    master_burnin_workflow = (
+        project_root / ".github" / "workflows" / "master-release-gate-burnin.yml"
+    ).read_text(encoding="utf-8")
+    readme = (project_root / "README.md").read_text(encoding="utf-8")
+    expected_checks = "Release Gate (Windows),Security CI Lane,Pytest (Python 3.11),Pytest (Python 3.12),Desktop Smoke (Windows)"
+
+    assert expected_checks in burnin_workflow
+    assert expected_checks in master_burnin_workflow
+    assert "Select required check: `Security CI Lane`." in readme
+
+    required_jobs_marker = '--required-jobs "'
+    burnin_jobs_start = burnin_workflow.find(required_jobs_marker)
+    master_jobs_start = master_burnin_workflow.find(required_jobs_marker)
+    assert burnin_jobs_start >= 0
+    assert master_jobs_start >= 0
+
+    burnin_jobs_fragment = burnin_workflow[burnin_jobs_start + len(required_jobs_marker) :]
+    master_jobs_fragment = master_burnin_workflow[master_jobs_start + len(required_jobs_marker) :]
+    burnin_jobs_csv = burnin_jobs_fragment.split('"', 1)[0]
+    master_jobs_csv = master_jobs_fragment.split('"', 1)[0]
+    burnin_jobs = [item.strip() for item in burnin_jobs_csv.split(",") if item.strip()]
+    master_jobs = [item.strip() for item in master_jobs_csv.split(",") if item.strip()]
+    assert len(burnin_jobs) == len(set(burnin_jobs))
+    assert len(master_jobs) == len(set(master_jobs))


### PR DESCRIPTION
﻿## Summary
- dedupe required-job input in `p0-burnin-consecutive-green` while preserving declared order
- harden per-run duplicate job-name handling with failure-biased conclusion collapsing
- add `Security CI Lane` to burn-in required checks (script defaults + workflows + docs)
- add focused tests for required-jobs dedupe, duplicate job hardening, and workflow/docs required-check wiring

## Validation
- `python -m py_compile scripts\\p0-burnin-consecutive-green.py tests\\test_goal_ops.py`
- `python -m pytest -q tests\\test_goal_ops.py -k "test_110 or test_111 or test_112 or test_178 or test_216 or test_217 or test_218"`
- `python .\\scripts\\p0-runbook-contract-check.py --label local-bh-bi-check --project-root .`
