### PR TITLE
Add runtime alert-age SLO guard for CI alert issues

### DIFF
--- a/.github/workflows/master-release-gate-runtime-early-warning.yml
+++ b/.github/workflows/master-release-gate-runtime-early-warning.yml
@@ -29,6 +29,10 @@ on:
         description: "Healthy nightly runs required before auto-closing an open runtime warning issue"
         required: false
         default: "2"
+      alert_age_hours:
+        description: "Open-issue age SLO (hours) for escalating sustained runtime warning incidents"
+        required: false
+        default: "72"
 
 permissions:
   contents: read
@@ -88,6 +92,25 @@ jobs:
             -RecoveryThreshold "$env:RECOVERY_THRESHOLD" `
             -OutputFile "artifacts\release-gate-runtime-early-warning-issue-upsert.json"
 
+      - name: Upsert runtime alert-age SLO issue
+        if: always()
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_FULL: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RECOVERY_THRESHOLD: ${{ github.event.inputs.recovery_threshold || '2' }}
+          ALERT_AGE_HOURS: ${{ github.event.inputs.alert_age_hours || '72' }}
+        run: |
+          .\scripts\run-ci-alert-issue-upsert.ps1 `
+            -SignalId "release-gate-runtime-alert-age-slo" `
+            -Repo "$env:REPO_FULL" `
+            -ReportFile "artifacts\release-gate-runtime-early-warning.json" `
+            -RunUrl "$env:RUN_URL" `
+            -RecoveryThreshold "$env:RECOVERY_THRESHOLD" `
+            -AlertAgeHours "$env:ALERT_AGE_HOURS" `
+            -OutputFile "artifacts\release-gate-runtime-alert-age-slo-issue-upsert.json"
+
       - name: Upload runtime early warning report
         if: always()
         uses: actions/upload-artifact@v4
@@ -102,4 +125,12 @@ jobs:
         with:
           name: release-gate-runtime-early-warning-issue-upsert
           path: artifacts/release-gate-runtime-early-warning-issue-upsert.json
+          if-no-files-found: error
+
+      - name: Upload runtime alert-age SLO issue upsert report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-gate-runtime-alert-age-slo-issue-upsert
+          path: artifacts/release-gate-runtime-alert-age-slo-issue-upsert.json
           if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -945,7 +945,7 @@ It also enforces registry attestation-gate invariants over sync-report mode/drif
 P0 burn-in CI-check evaluation now dedupes duplicate check names per run and keeps failure-biased conclusions for stability-first gating.
 Nightly master required-checks monitoring now hard-fails on non-green required CI checks in the last 24h (with duplicate-check-name handling).
 Nightly branch-protection drift guard now verifies that `master` keeps exactly the 5 required checks (no missing or unexpected status contexts).
-Nightly release-gate runtime early warning now flags sustained runtime slowdown (default: 3 consecutive runs >= 540s) before it escalates into flaky failures.
+Nightly release-gate runtime early warning now flags sustained runtime slowdown (default: 3 consecutive runs >= 540s) before it escalates into flaky failures, and escalates when an active runtime warning issue stays open beyond the alert-age SLO (default: 72h).
 Nightly drift/warning workflows now upsert deduplicated GitHub issues (labels: `ci-drift` + signal label), enforce the invariant of at most one open issue per signal, reset recovery streak on active alerts, and auto-close recovered issues after 2 healthy nightly runs (configurable threshold).
 
 Release Gate workflow artifact includes `p0-release-evidence-bundle` (manifest + copied evidence reports, including safe-mode/A11y/runtime/flake stage outputs, + closure report), Stage-L/M evidence artifacts (`release-gate-evidence-freshness-release-gate.json`, `release-gate-evidence-hash-manifest-release-gate.json`, `release-gate-evidence-manifest-release-gate.json`), Stage-N/O timing-history artifacts (`release-gate-step-timing-schema-release-gate.json`, `release-gate-performance-history-release-gate.json`), Stage-K/P artifacts (`release-gate-step-timings-release-gate.json`, `release-gate-performance-budget-release-gate.json`, `release-gate-stability-final-readiness-release-gate.json`), Stage-Q/R readiness artifacts (`release-gate-staging-soak-readiness-release-gate.json`, `release-gate-rc-canary-rollout-release-gate.json`), Stage-S/T readiness artifacts (`release-gate-evidence-lineage-release-gate.json`, `release-gate-production-readiness-certification-release-gate.json`), Stage-U/AB expanded readiness artifacts (`release-gate-slo-burn-rate-v2-release-gate.json`, `release-gate-deploy-rehearsal-release-gate.json`, `release-gate-chaos-matrix-continuous-release-gate.json`, `release-gate-supply-chain-artifact-trust-release-gate.json`, `release-gate-operations-handoff-readiness-release-gate.json`, `release-gate-evidence-attestation-release-gate.json`, `release-gate-release-train-readiness-release-gate.json`, `release-gate-production-final-attestation-release-gate.json`), Stage-AC/AJ cutover-to-sustainability artifacts (`release-gate-production-cutover-readiness-release-gate.json`, `release-gate-hypercare-activation-release-gate.json`, `release-gate-rollback-trigger-integrity-release-gate.json`, `release-gate-post-cutover-finalization-release-gate.json`, `release-gate-post-release-watch-release-gate.json`, `release-gate-steady-state-certification-release-gate.json`, `release-gate-post-release-continuity-release-gate.json`, `release-gate-production-sustainability-certification-release-gate.json`), and registry attestation artifacts (`release-gate-registry-sync-ci.json`, `release-gate-registry-attestation-gate-ci.json`).
@@ -1006,6 +1006,13 @@ Local alert-to-action issue upsert command (dry run example):
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-ci-alert-issue-upsert.ps1 -SignalId "release-gate-runtime-early-warning" -ReportFile "artifacts\release-gate-runtime-early-warning.json" -RecoveryThreshold 2 -DryRun
+```
+
+Local runtime alert-age SLO guard command (dry run example):
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-ci-alert-issue-upsert.ps1 -SignalId "release-gate-runtime-alert-age-slo" -ReportFile "artifacts\release-gate-runtime-early-warning.json" -AlertAgeHours 72 -RecoveryThreshold 2 -DryRun
 ```
 
 Local desktop smoke command:

--- a/scripts/ci-alert-issue-upsert.py
+++ b/scripts/ci-alert-issue-upsert.py
@@ -6,6 +6,7 @@ import re
 import subprocess
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +19,10 @@ SIGNAL_SPECS: dict[str, dict[str, Any]] = {
     "release-gate-runtime-early-warning": {
         "title": "[Release Gate Runtime] sustained runtime warning on master",
         "labels": ["ci-drift", "release-gate-runtime"],
+    },
+    "release-gate-runtime-alert-age-slo": {
+        "title": "[Release Gate Runtime] alert issue age SLO breached on master",
+        "labels": ["ci-drift", "release-gate-runtime", "alert-age-slo"],
     },
 }
 
@@ -34,6 +39,10 @@ LABEL_DEFINITIONS: dict[str, dict[str, str]] = {
         "color": "0E8A16",
         "description": "Sustained Release Gate runtime warning on master CI",
     },
+    "alert-age-slo": {
+        "color": "FBCA04",
+        "description": "Runtime warning alert-issue age exceeds SLO threshold",
+    },
 }
 
 RECOVERY_STREAK_PATTERN = re.compile(r"<!--\s*ci-alert-recovery-streak:(\d+)\s*-->")
@@ -46,6 +55,26 @@ def _expect(condition: bool, message: str) -> None:
 
 def _utc_now_text() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _parse_utc_timestamp(value: str) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _hours_between(started_at: datetime | None, ended_at: datetime | None) -> float | None:
+    if started_at is None or ended_at is None:
+        return None
+    return max(0.0, float((ended_at - started_at).total_seconds()) / 3600.0)
 
 
 def _load_json_file(path: Path) -> Any:
@@ -153,7 +182,14 @@ def _load_issues(*, repo: str, state: str, issues_file: Path | None, dry_run: bo
     return issues
 
 
-def _signal_alert_state(*, signal_id: str, report: dict[str, Any]) -> tuple[bool, list[str], str]:
+def _signal_alert_state(
+    *,
+    signal_id: str,
+    report: dict[str, Any],
+    repo: str,
+    issues: list[dict[str, Any]],
+    alert_age_hours: float,
+) -> tuple[bool, list[str], str]:
     config = report.get("config") if isinstance(report.get("config"), dict) else {}
     branch = str(config.get("branch") or "master")
 
@@ -191,6 +227,67 @@ def _signal_alert_state(*, signal_id: str, report: dict[str, Any]) -> tuple[bool
                 f"(threshold={threshold_seconds}s, sustained_runs={sustained_runs})"
             ),
             f"- Recommended action: {decision.get('recommended_action') or 'runtime_within_warning_budget'}",
+        ]
+        return alert_triggered, summary, branch
+
+    if signal_id == "release-gate-runtime-alert-age-slo":
+        decision = report.get("decision") if isinstance(report.get("decision"), dict) else {}
+        warning_triggered = bool(decision.get("warning_triggered"))
+        evaluation_now = _parse_utc_timestamp(str(report.get("generated_at_utc") or "")) or datetime.now(timezone.utc)
+
+        runtime_signal_id = "release-gate-runtime-early-warning"
+        runtime_signal_spec = SIGNAL_SPECS[runtime_signal_id]
+        runtime_title = str(runtime_signal_spec["title"])
+        runtime_marker = _build_issue_marker(signal_id=runtime_signal_id, repo=repo, branch=branch)
+        runtime_open_matches = _matching_issues(
+            issues=[item for item in issues if _issue_state(item) == "open"],
+            marker=runtime_marker,
+            title=runtime_title,
+        )
+        if len(runtime_open_matches) > 1:
+            runtime_open_numbers = [int(item.get("number") or 0) for item in runtime_open_matches]
+            raise RuntimeError(
+                "Runtime warning issue invariant violated for alert-age SLO evaluation on branch "
+                f"'{branch}': expected at most 1 open runtime warning issue, "
+                f"found {len(runtime_open_matches)} ({runtime_open_numbers})"
+            )
+        runtime_open_issue = runtime_open_matches[0] if runtime_open_matches else None
+        runtime_issue_number = int(runtime_open_issue.get("number") or 0) if runtime_open_issue else None
+        runtime_issue_created_at = (
+            _parse_utc_timestamp(str(runtime_open_issue.get("created_at") or "")) if runtime_open_issue else None
+        )
+        runtime_issue_age_hours = _hours_between(runtime_issue_created_at, evaluation_now)
+        age_known = runtime_issue_age_hours is not None
+
+        alert_triggered = bool(
+            warning_triggered
+            and runtime_open_issue is not None
+            and age_known
+            and float(runtime_issue_age_hours or 0.0) >= float(alert_age_hours)
+        )
+
+        if alert_triggered:
+            recommended_action = "runtime_alert_issue_age_slo_breached"
+        elif not warning_triggered:
+            recommended_action = "runtime_warning_not_active"
+        elif runtime_open_issue is None:
+            recommended_action = "runtime_warning_issue_not_open"
+        elif not age_known:
+            recommended_action = "runtime_warning_issue_age_unavailable"
+        else:
+            recommended_action = "runtime_alert_issue_age_within_slo"
+
+        runtime_issue_text = "none"
+        if runtime_open_issue is not None:
+            age_text = f"{float(runtime_issue_age_hours):.2f}h" if age_known else "unknown"
+            runtime_issue_text = (
+                f"#{runtime_issue_number} (age={age_text}, threshold={float(alert_age_hours):.2f}h)"
+            )
+
+        summary = [
+            f"- Runtime warning currently active: {'yes' if warning_triggered else 'no'}",
+            f"- Runtime warning open issue: {runtime_issue_text}",
+            f"- Recommended action: {recommended_action}",
         ]
         return alert_triggered, summary, branch
 
@@ -345,20 +442,16 @@ def run_issue_upsert(
     issue_oplog_file: Path | None,
     dry_run: bool,
     recovery_threshold: int,
+    alert_age_hours: float,
     output_file: Path,
 ) -> dict[str, Any]:
     started = time.perf_counter()
     _expect(signal_id in SIGNAL_SPECS, f"Unsupported --signal-id: {signal_id}")
     _expect(int(recovery_threshold) > 0, "recovery_threshold must be > 0")
+    _expect(float(alert_age_hours) > 0, "alert_age_hours must be > 0")
 
     report_payload = _load_json_file(report_file)
     _expect(isinstance(report_payload, dict), f"Expected JSON object in report file: {report_file}")
-
-    alert_triggered, summary_lines, branch = _signal_alert_state(signal_id=signal_id, report=report_payload)
-    signal_spec = SIGNAL_SPECS[signal_id]
-    title = str(signal_spec["title"])
-    labels = [str(item) for item in signal_spec["labels"]]
-    marker = _build_issue_marker(signal_id=signal_id, repo=repo, branch=branch)
 
     issue_action = "none"
     issue_deduped = False
@@ -369,6 +462,17 @@ def run_issue_upsert(
     actions: list[dict[str, Any]] = []
 
     all_issues = _load_issues(repo=repo, state="all", issues_file=issues_file, dry_run=dry_run)
+    alert_triggered, summary_lines, branch = _signal_alert_state(
+        signal_id=signal_id,
+        report=report_payload,
+        repo=repo,
+        issues=all_issues,
+        alert_age_hours=float(alert_age_hours),
+    )
+    signal_spec = SIGNAL_SPECS[signal_id]
+    title = str(signal_spec["title"])
+    labels = [str(item) for item in signal_spec["labels"]]
+    marker = _build_issue_marker(signal_id=signal_id, repo=repo, branch=branch)
     open_matches = _matching_issues(
         issues=[item for item in all_issues if _issue_state(item) == "open"],
         marker=marker,
@@ -604,6 +708,7 @@ def run_issue_upsert(
             "issue_oplog_file": str(issue_oplog_file) if issue_oplog_file is not None else None,
             "dry_run": bool(dry_run),
             "recovery_threshold": int(recovery_threshold),
+            "alert_age_hours": float(alert_age_hours),
             "open_issue_invariant_max": 1,
             "output_file": str(output_file),
         },
@@ -653,8 +758,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--issue-oplog-file")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--recovery-threshold", type=int, default=2)
+    parser.add_argument("--alert-age-hours", type=float, default=72.0)
     parser.add_argument("--output-file", default="artifacts/ci-alert-issue-upsert.json")
     args = parser.parse_args(argv)
+
+    if float(args.alert_age_hours) <= 0:
+        print("[ci-alert-issue-upsert] ERROR: --alert-age-hours must be > 0.", file=sys.stderr)
+        return 2
 
     try:
         report = run_issue_upsert(
@@ -667,6 +777,7 @@ def main(argv: list[str] | None = None) -> int:
             issue_oplog_file=Path(str(args.issue_oplog_file)).expanduser() if args.issue_oplog_file else None,
             dry_run=bool(args.dry_run),
             recovery_threshold=int(args.recovery_threshold),
+            alert_age_hours=float(args.alert_age_hours),
             output_file=Path(str(args.output_file)).expanduser(),
         )
     except Exception as exc:

--- a/scripts/run-ci-alert-issue-upsert.ps1
+++ b/scripts/run-ci-alert-issue-upsert.ps1
@@ -1,6 +1,6 @@
 ﻿param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("master-branch-protection-drift", "release-gate-runtime-early-warning")]
+    [ValidateSet("master-branch-protection-drift", "release-gate-runtime-early-warning", "release-gate-runtime-alert-age-slo")]
     [string]$SignalId,
     [Parameter(Mandatory = $true)]
     [string]$ReportFile,
@@ -10,6 +10,7 @@
     [string]$IssuesFile = "",
     [string]$IssueOplogFile = "",
     [int]$RecoveryThreshold = 2,
+    [double]$AlertAgeHours = 72,
     [string]$OutputFile = "artifacts\\ci-alert-issue-upsert.json",
     [switch]$DryRun
 )
@@ -26,6 +27,7 @@ $args = @(
     "--repo", $Repo,
     "--report-file", $ReportFile,
     "--recovery-threshold", [string]$RecoveryThreshold,
+    "--alert-age-hours", [string]$AlertAgeHours,
     "--output-file", $OutputFile
 )
 if ($RunUrl) {

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -11365,9 +11365,11 @@ def test_231_ci_alert_issue_upsert_workflow_wrapper_and_docs_wiring():
     assert "--signal-id" in wrapper
     assert "--report-file" in wrapper
     assert "--recovery-threshold" in wrapper
+    assert "--alert-age-hours" in wrapper
     assert "--dry-run" in wrapper
     assert "master-branch-protection-drift" in wrapper
     assert "release-gate-runtime-early-warning" in wrapper
+    assert "release-gate-runtime-alert-age-slo" in wrapper
 
     assert "issues: write" in branch_workflow
     assert ".\\scripts\\run-ci-alert-issue-upsert.ps1" in branch_workflow
@@ -11377,12 +11379,16 @@ def test_231_ci_alert_issue_upsert_workflow_wrapper_and_docs_wiring():
     assert "issues: write" in runtime_workflow
     assert ".\\scripts\\run-ci-alert-issue-upsert.ps1" in runtime_workflow
     assert "release-gate-runtime-early-warning-issue-upsert.json" in runtime_workflow
+    assert "release-gate-runtime-alert-age-slo-issue-upsert.json" in runtime_workflow
     assert "recovery_threshold" in runtime_workflow
+    assert "alert_age_hours" in runtime_workflow
 
     assert "run-ci-alert-issue-upsert.ps1" in readme
     assert "labels: `ci-drift` + signal label" in readme
     assert "auto-close recovered issues after 2 healthy nightly runs" in readme
     assert "at most one open issue per signal" in readme
+    assert "stays open beyond the alert-age SLO" in readme
+    assert "release-gate-runtime-alert-age-slo" in readme
 
 
 def test_232_ci_alert_issue_upsert_auto_closes_after_recovery_threshold():
@@ -11805,5 +11811,217 @@ def test_235_ci_alert_issue_invariant_fails_with_multiple_open_issues():
     assert completed.returncode != 0
     assert "Issue state invariant violated" in completed.stderr
     assert "expected at most 1 open issue" in completed.stderr
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_236_ci_alert_issue_upsert_alert_age_slo_breach_creates_escalation_issue():
+    workspace = _local_test_dir("pytest-ci-alert-issue-upsert-alert-age-slo-breach").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    report_file = workspace / "release-gate-runtime-early-warning.json"
+    issues_file = workspace / "issues.json"
+    issue_oplog_file = workspace / "issue-oplog.json"
+    output_file = workspace / "ci-alert-issue-upsert.json"
+
+    report_file.write_text(
+        json.dumps(
+            {
+                "label": "pytest-runtime-warning-active",
+                "config": {
+                    "branch": "master",
+                    "threshold_seconds": 540,
+                    "sustained_runs": 3,
+                },
+                "decision": {
+                    "warning_triggered": True,
+                    "recommended_action": "investigate_release_gate_runtime_regression",
+                },
+                "generated_at_utc": "2026-04-18T12:00:00Z",
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    issues_file.write_text(
+        json.dumps(
+            [
+                {
+                    "number": 321,
+                    "state": "open",
+                    "title": "[Release Gate Runtime] sustained runtime warning on master",
+                    "html_url": "https://github.com/donatomaurizio99-collab/GOC/issues/321",
+                    "created_at": "2026-04-14T00:00:00Z",
+                    "body": (
+                        "managed issue\\n"
+                        "<!-- ci-alert-key:release-gate-runtime-early-warning:"
+                        "donatomaurizio99-collab/GOC:master -->"
+                    ),
+                }
+            ],
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "ci-alert-issue-upsert.py"),
+        "--label",
+        "pytest-alert-age-slo-breach",
+        "--signal-id",
+        "release-gate-runtime-alert-age-slo",
+        "--repo",
+        "donatomaurizio99-collab/GOC",
+        "--report-file",
+        str(report_file.resolve()),
+        "--issues-file",
+        str(issues_file.resolve()),
+        "--issue-oplog-file",
+        str(issue_oplog_file.resolve()),
+        "--alert-age-hours",
+        "72",
+        "--dry-run",
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["decision"]["alert_triggered"] is True
+    assert payload["decision"]["issue_action"] == "created"
+    assert payload["decision"]["issue_deduped"] is False
+    assert "alert-age-slo" in payload["issue"]["labels"]
+    assert "ci-alert-key:release-gate-runtime-alert-age-slo:donatomaurizio99-collab/GOC:master" in payload["issue"]["marker"]
+    assert output_file.exists()
+
+    issue_oplog = json.loads(issue_oplog_file.read_text(encoding="utf-8"))
+    assert len(issue_oplog["actions"]) == 1
+    assert issue_oplog["actions"][0]["action"] == "create_issue"
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_237_ci_alert_issue_upsert_alert_age_slo_no_breach_keeps_idle():
+    workspace = _local_test_dir("pytest-ci-alert-issue-upsert-alert-age-slo-idle").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    report_file = workspace / "release-gate-runtime-early-warning.json"
+    issues_file = workspace / "issues.json"
+    issue_oplog_file = workspace / "issue-oplog.json"
+    output_file = workspace / "ci-alert-issue-upsert.json"
+
+    report_file.write_text(
+        json.dumps(
+            {
+                "label": "pytest-runtime-warning-active",
+                "config": {
+                    "branch": "master",
+                    "threshold_seconds": 540,
+                    "sustained_runs": 3,
+                },
+                "decision": {
+                    "warning_triggered": True,
+                    "recommended_action": "investigate_release_gate_runtime_regression",
+                },
+                "generated_at_utc": "2026-04-18T12:00:00Z",
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    issues_file.write_text(
+        json.dumps(
+            [
+                {
+                    "number": 322,
+                    "state": "open",
+                    "title": "[Release Gate Runtime] sustained runtime warning on master",
+                    "html_url": "https://github.com/donatomaurizio99-collab/GOC/issues/322",
+                    "created_at": "2026-04-18T10:30:00Z",
+                    "body": (
+                        "managed issue\\n"
+                        "<!-- ci-alert-key:release-gate-runtime-early-warning:"
+                        "donatomaurizio99-collab/GOC:master -->"
+                    ),
+                }
+            ],
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "ci-alert-issue-upsert.py"),
+        "--label",
+        "pytest-alert-age-slo-idle",
+        "--signal-id",
+        "release-gate-runtime-alert-age-slo",
+        "--repo",
+        "donatomaurizio99-collab/GOC",
+        "--report-file",
+        str(report_file.resolve()),
+        "--issues-file",
+        str(issues_file.resolve()),
+        "--issue-oplog-file",
+        str(issue_oplog_file.resolve()),
+        "--alert-age-hours",
+        "72",
+        "--dry-run",
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["decision"]["alert_triggered"] is False
+    assert payload["decision"]["issue_action"] == "none"
+    assert payload["decision"]["issue_deduped"] is False
+    assert payload["issue"]["number"] is None
+    assert output_file.exists()
+
+    issue_oplog = json.loads(issue_oplog_file.read_text(encoding="utf-8"))
+    assert issue_oplog["actions"] == []
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_238_ci_alert_issue_upsert_rejects_non_positive_alert_age_hours():
+    workspace = _local_test_dir("pytest-ci-alert-issue-upsert-alert-age-slo-invalid-hours").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "ci-alert-issue-upsert.py"),
+        "--signal-id",
+        "master-branch-protection-drift",
+        "--report-file",
+        str((workspace / "unused-report.json").resolve()),
+        "--alert-age-hours",
+        "0",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 2
+    assert "--alert-age-hours must be > 0." in completed.stderr
 
     shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
## Summary
- add new `release-gate-runtime-alert-age-slo` signal to `ci-alert-issue-upsert.py`
- escalate when runtime warning stays active and the runtime warning issue age breaches configurable SLO hours
- wire new guard into nightly runtime-early-warning workflow with `alert_age_hours` input and artifact upload
- extend wrapper (`run-ci-alert-issue-upsert.ps1`) with `-AlertAgeHours`
- add tests for breach/no-breach behavior, CLI validation, and workflow/docs wiring
- document local dry-run command in README

## Local validation
- `python -m py_compile scripts\ci-alert-issue-upsert.py tests\test_goal_ops.py`
- `python -m pytest -q tests\test_goal_ops.py -k "test_229 or test_230 or test_231 or test_232 or test_233 or test_234 or test_235 or test_236 or test_237 or test_238"`
- `python .\scripts\p0-runbook-contract-check.py --label local-alert-age-slo-guard --project-root .`
- `./scripts/run-ci-alert-issue-upsert.ps1 -SignalId "release-gate-runtime-alert-age-slo" ... -DryRun`
