### PR TITLE
Add master guard-workflow health watchdog

### DIFF
--- a/.github/workflows/master-guard-workflow-health.yml
+++ b/.github/workflows/master-guard-workflow-health.yml
@@ -1,0 +1,93 @@
+name: Master Guard Workflow Health
+
+on:
+  schedule:
+    - cron: "35 3 * * *"
+  workflow_dispatch:
+    inputs:
+      lookback_hours:
+        description: "Hours of guard-workflow history to inspect"
+        required: false
+        default: "30"
+      per_page:
+        description: "Maximum completed runs fetched per guard workflow"
+        required: false
+        default: "50"
+      allow_degraded:
+        description: "Do not fail workflow when guard workflow health is degraded"
+        required: false
+        default: "false"
+      recovery_threshold:
+        description: "Healthy nightly runs required before auto-closing an open guard-health issue"
+        required: false
+        default: "2"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  guard-workflow-health:
+    name: Guard Workflow Health
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Run guard-workflow health watchdog
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LOOKBACK_HOURS: ${{ github.event.inputs.lookback_hours || '30' }}
+          PER_PAGE: ${{ github.event.inputs.per_page || '50' }}
+          ALLOW_DEGRADED: ${{ github.event.inputs.allow_degraded || 'false' }}
+        run: |
+          $arguments = @(
+            "-LookbackHours", "$env:LOOKBACK_HOURS",
+            "-PerPage", "$env:PER_PAGE",
+            "-OutputFile", "artifacts\\master-guard-workflow-health-check.json"
+          )
+          if ($env:ALLOW_DEGRADED -eq "true") {
+            $arguments += "-AllowDegraded"
+          }
+          .\scripts\run-master-guard-workflow-health-check.ps1 @arguments
+
+      - name: Upsert guard-health alert issue
+        if: always()
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_FULL: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RECOVERY_THRESHOLD: ${{ github.event.inputs.recovery_threshold || '2' }}
+        run: |
+          .\scripts\run-ci-alert-issue-upsert.ps1 `
+            -SignalId "master-guard-workflow-health" `
+            -Repo "$env:REPO_FULL" `
+            -ReportFile "artifacts\master-guard-workflow-health-check.json" `
+            -RunUrl "$env:RUN_URL" `
+            -RecoveryThreshold "$env:RECOVERY_THRESHOLD" `
+            -OutputFile "artifacts\master-guard-workflow-health-issue-upsert.json"
+
+      - name: Upload guard-workflow health report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: master-guard-workflow-health-check
+          path: artifacts/master-guard-workflow-health-check.json
+          if-no-files-found: error
+
+      - name: Upload guard-workflow health issue upsert report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: master-guard-workflow-health-issue-upsert
+          path: artifacts/master-guard-workflow-health-issue-upsert.json
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -945,6 +945,7 @@ It also enforces registry attestation-gate invariants over sync-report mode/drif
 P0 burn-in CI-check evaluation now dedupes duplicate check names per run and keeps failure-biased conclusions for stability-first gating.
 Nightly master required-checks monitoring now hard-fails on non-green required CI checks in the last 24h (with duplicate-check-name handling).
 Nightly branch-protection drift guard now verifies that `master` keeps exactly the 5 required checks (no missing or unexpected status contexts).
+Nightly guard-workflow health watchdog now verifies that the guard workflows themselves run successfully on `master` and publish their expected artifacts.
 Nightly release-gate runtime early warning now flags sustained runtime slowdown (default: 3 consecutive runs >= 540s) before it escalates into flaky failures, and escalates when an active runtime warning issue stays open beyond the alert-age SLO (default: 72h).
 Nightly drift/warning workflows now upsert deduplicated GitHub issues (labels: `ci-drift` + signal label), enforce the invariant of at most one open issue per signal, reset recovery streak on active alerts, and auto-close recovered issues after 2 healthy nightly runs (configurable threshold). The runtime alert-age SLO escalation issue now carries a mandatory parent runtime-warning reference in its issue body and closes immediately when parent-coupled escalation criteria are no longer met.
 
@@ -967,6 +968,9 @@ Nightly master required-checks workflow:
 
 Nightly branch-protection drift guard workflow:
 [master-branch-protection-drift-guard.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/master-branch-protection-drift-guard.yml)
+
+Nightly guard-workflow health watchdog:
+[master-guard-workflow-health.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/master-guard-workflow-health.yml)
 
 Nightly release-gate runtime early warning workflow:
 [master-release-gate-runtime-early-warning.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/master-release-gate-runtime-early-warning.yml)
@@ -992,6 +996,13 @@ Local branch-protection drift guard command:
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-master-branch-protection-drift-guard.ps1
+```
+
+Local guard-workflow health watchdog command:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-master-guard-workflow-health-check.ps1 -LookbackHours 30 -PerPage 50
 ```
 
 Local release-gate runtime early warning command:

--- a/scripts/ci-alert-issue-upsert.py
+++ b/scripts/ci-alert-issue-upsert.py
@@ -16,6 +16,10 @@ SIGNAL_SPECS: dict[str, dict[str, Any]] = {
         "title": "[CI Drift] master branch protection required checks drift",
         "labels": ["ci-drift", "branch-protection"],
     },
+    "master-guard-workflow-health": {
+        "title": "[CI Drift] master guard workflow health degraded",
+        "labels": ["ci-drift", "guard-workflow-health"],
+    },
     "release-gate-runtime-early-warning": {
         "title": "[Release Gate Runtime] sustained runtime warning on master",
         "labels": ["ci-drift", "release-gate-runtime"],
@@ -34,6 +38,10 @@ LABEL_DEFINITIONS: dict[str, dict[str, str]] = {
     "branch-protection": {
         "color": "1D76DB",
         "description": "master branch-protection required-check drift",
+    },
+    "guard-workflow-health": {
+        "color": "D93F0B",
+        "description": "Nightly guard-workflow watchdog detected degraded health",
     },
     "release-gate-runtime": {
         "color": "0E8A16",
@@ -207,6 +215,30 @@ def _signal_alert_state(
             f"- Missing required checks: {', '.join(str(item) for item in missing) if missing else 'none'}",
             f"- Unexpected required checks: {', '.join(str(item) for item in unexpected) if unexpected else 'none'}",
             f"- Recommended action: {decision.get('recommended_action') or 'branch_protection_in_sync'}",
+        ]
+        return alert_triggered, summary, branch, {}
+
+    if signal_id == "master-guard-workflow-health":
+        decision = report.get("decision") if isinstance(report.get("decision"), dict) else {}
+        metrics = report.get("metrics") if isinstance(report.get("metrics"), dict) else {}
+        degraded_workflows = (
+            report.get("degraded_workflow_names") if isinstance(report.get("degraded_workflow_names"), list) else []
+        )
+        missing_required_artifacts_total = int(metrics.get("missing_required_artifacts_total") or 0)
+        alert_triggered = bool(decision.get("guard_workflow_health_degraded"))
+        summary = [
+            (
+                f"- Degraded guard workflows: {', '.join(str(item) for item in degraded_workflows)}"
+                if degraded_workflows
+                else "- Degraded guard workflows: none"
+            ),
+            (
+                "- Guard workflows degraded total: "
+                f"{metrics.get('guard_workflows_degraded_total', 0)} "
+                f"(total={metrics.get('guard_workflows_total', 0)})"
+            ),
+            f"- Missing required artifacts total: {missing_required_artifacts_total}",
+            f"- Recommended action: {decision.get('recommended_action') or 'guard_workflow_health_green'}",
         ]
         return alert_triggered, summary, branch, {}
 

--- a/scripts/master-guard-workflow-health-check.py
+++ b/scripts/master-guard-workflow-health-check.py
@@ -1,0 +1,442 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_GUARD_WORKFLOW_SPECS = [
+    {
+        "workflow_name": "Master Required Checks 24h",
+        "required_artifacts": ["master-required-checks-24h-report"],
+    },
+    {
+        "workflow_name": "Master Branch Protection Drift Guard",
+        "required_artifacts": [
+            "master-branch-protection-drift-guard",
+            "master-branch-protection-drift-issue-upsert",
+        ],
+    },
+    {
+        "workflow_name": "Master Release Gate Runtime Early Warning",
+        "required_artifacts": [
+            "release-gate-runtime-early-warning",
+            "release-gate-runtime-early-warning-issue-upsert",
+            "release-gate-runtime-alert-age-slo-issue-upsert",
+        ],
+    },
+]
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _run_gh_api(path: str) -> dict[str, Any]:
+    command = ["gh", "api", path]
+    completed = subprocess.run(command, capture_output=True, text=True)
+    _expect(
+        completed.returncode == 0,
+        f"gh api failed ({completed.returncode}) for '{path}': {completed.stderr.strip()}",
+    )
+    payload = json.loads(completed.stdout)
+    _expect(isinstance(payload, dict), f"Expected JSON object from gh api path '{path}'.")
+    return payload
+
+
+def _load_json_file(path: Path) -> dict[str, Any]:
+    _expect(path.exists(), f"JSON file not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    _expect(isinstance(payload, dict), f"Expected JSON object in file: {path}")
+    return payload
+
+
+def _parse_utc_timestamp(value: str) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _format_utc(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _resolve_now_utc(now_utc_text: str | None) -> datetime:
+    if not now_utc_text:
+        return datetime.now(timezone.utc)
+    parsed = _parse_utc_timestamp(now_utc_text)
+    _expect(parsed is not None, f"Invalid --now-utc timestamp: {now_utc_text}")
+    return parsed
+
+
+def _fetch_workflow_id(*, repo: str, workflow_name: str) -> int:
+    payload = _run_gh_api(f"repos/{repo}/actions/workflows?per_page=100")
+    workflows = payload.get("workflows") or []
+    _expect(isinstance(workflows, list), "Invalid workflows payload format.")
+    for workflow in workflows:
+        if not isinstance(workflow, dict):
+            continue
+        if str(workflow.get("name") or "").strip() == workflow_name:
+            workflow_id = int(workflow.get("id") or 0)
+            _expect(workflow_id > 0, f"Workflow '{workflow_name}' has invalid id.")
+            return workflow_id
+    raise RuntimeError(f"Workflow '{workflow_name}' not found in repo '{repo}'.")
+
+
+def _fetch_runs_from_github(
+    *,
+    repo: str,
+    branch: str,
+    workflow_name: str,
+    per_page: int,
+) -> list[dict[str, Any]]:
+    workflow_id = _fetch_workflow_id(repo=repo, workflow_name=workflow_name)
+    payload = _run_gh_api(
+        f"repos/{repo}/actions/workflows/{workflow_id}/runs?branch={branch}&status=completed&per_page={per_page}"
+    )
+    runs = payload.get("workflow_runs") or []
+    _expect(isinstance(runs, list), f"Invalid workflow runs payload for workflow '{workflow_name}'.")
+    return [item for item in runs if isinstance(item, dict)]
+
+
+def _fetch_run_artifacts_from_github(*, repo: str, run_id: int) -> list[dict[str, Any]]:
+    payload = _run_gh_api(f"repos/{repo}/actions/runs/{run_id}/artifacts?per_page=100")
+    artifacts = payload.get("artifacts") or []
+    _expect(isinstance(artifacts, list), f"Invalid artifacts payload for run {run_id}.")
+    return [item for item in artifacts if isinstance(item, dict)]
+
+
+def _load_fixture_runs(*, fixtures_payload: dict[str, Any], workflow_name: str) -> list[dict[str, Any]]:
+    workflow_runs = fixtures_payload.get("workflow_runs")
+    _expect(isinstance(workflow_runs, dict), "fixtures file must include object field 'workflow_runs'.")
+    runs = workflow_runs.get(workflow_name) or []
+    _expect(
+        isinstance(runs, list),
+        f"fixtures.workflow_runs['{workflow_name}'] must be a list when present.",
+    )
+    return [item for item in runs if isinstance(item, dict)]
+
+
+def _load_fixture_artifacts(*, fixtures_payload: dict[str, Any], run_id: int) -> list[dict[str, Any]]:
+    run_artifacts = fixtures_payload.get("run_artifacts")
+    _expect(isinstance(run_artifacts, dict), "fixtures file must include object field 'run_artifacts'.")
+    value = run_artifacts.get(str(run_id))
+    if value is None:
+        return []
+    if isinstance(value, dict):
+        artifacts = value.get("artifacts") or []
+    else:
+        artifacts = value
+    _expect(isinstance(artifacts, list), f"fixtures.run_artifacts['{run_id}'] must resolve to a list.")
+    return [item for item in artifacts if isinstance(item, dict)]
+
+
+def _extract_artifact_names(artifacts: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
+    available: list[str] = []
+    expired: list[str] = []
+    for artifact in artifacts:
+        name = str(artifact.get("name") or "").strip()
+        if not name:
+            continue
+        if bool(artifact.get("expired")):
+            expired.append(name)
+        else:
+            available.append(name)
+    return available, expired
+
+
+def _evaluate_guard_workflow(
+    *,
+    workflow_name: str,
+    required_artifacts: list[str],
+    runs: list[dict[str, Any]],
+    cutoff_utc: datetime,
+    load_artifacts_for_run: Any,
+) -> tuple[dict[str, Any], dict[str, int]]:
+    runs_in_window: list[tuple[dict[str, Any], datetime | None]] = []
+    runs_outside_window_ignored = 0
+    runs_with_invalid_updated_at = 0
+
+    for run in runs:
+        updated_at = _parse_utc_timestamp(str(run.get("updated_at") or ""))
+        if updated_at is not None and updated_at < cutoff_utc:
+            runs_outside_window_ignored += 1
+            continue
+        if updated_at is None:
+            runs_with_invalid_updated_at += 1
+        runs_in_window.append((run, updated_at))
+
+    runs_sorted = sorted(
+        runs_in_window,
+        key=lambda item: item[1] or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
+    latest_run = runs_sorted[0][0] if runs_sorted else None
+    latest_run_updated_at = runs_sorted[0][1] if runs_sorted else None
+
+    latest_run_id = int(latest_run.get("id") or 0) if latest_run else 0
+    latest_run_status = str(latest_run.get("status") or "") if latest_run else ""
+    latest_run_conclusion = str(latest_run.get("conclusion") or "") if latest_run else ""
+    latest_run_success = bool(
+        latest_run is not None and latest_run_status == "completed" and latest_run_conclusion == "success"
+    )
+
+    artifacts: list[dict[str, Any]] = []
+    available_artifact_names: list[str] = []
+    expired_artifact_names: list[str] = []
+    if latest_run_id > 0:
+        artifacts = load_artifacts_for_run(latest_run_id)
+        available_artifact_names, expired_artifact_names = _extract_artifact_names(artifacts)
+
+    missing_required_artifacts = [item for item in required_artifacts if item not in available_artifact_names]
+    has_recent_run = latest_run is not None
+    is_healthy = bool(has_recent_run and latest_run_success and not missing_required_artifacts)
+
+    reasons: list[str] = []
+    if not has_recent_run:
+        reasons.append("no_recent_completed_run_in_window")
+    elif not latest_run_success:
+        reasons.append("latest_run_not_success")
+    if missing_required_artifacts:
+        reasons.append("required_artifacts_missing")
+
+    evaluation = {
+        "workflow_name": workflow_name,
+        "required_artifacts": required_artifacts,
+        "runs_total_fetched": int(len(runs)),
+        "runs_in_window_total": int(len(runs_in_window)),
+        "runs_outside_window_ignored_total": int(runs_outside_window_ignored),
+        "runs_with_invalid_updated_at_total": int(runs_with_invalid_updated_at),
+        "latest_run": (
+            {
+                "run_id": latest_run_id,
+                "status": latest_run_status,
+                "conclusion": latest_run_conclusion,
+                "updated_at": str(latest_run.get("updated_at") or ""),
+                "updated_at_parsed_utc": _format_utc(latest_run_updated_at),
+            }
+            if latest_run
+            else None
+        ),
+        "artifact_inventory": {
+            "available_artifacts": available_artifact_names,
+            "expired_artifacts": expired_artifact_names,
+            "artifacts_total": int(len(artifacts)),
+        },
+        "missing_required_artifacts": missing_required_artifacts,
+        "has_recent_run": bool(has_recent_run),
+        "latest_run_success": bool(latest_run_success),
+        "is_healthy": bool(is_healthy),
+        "degraded_reasons": reasons,
+    }
+    counters = {
+        "runs_outside_window_ignored_total": int(runs_outside_window_ignored),
+        "runs_with_invalid_updated_at_total": int(runs_with_invalid_updated_at),
+    }
+    return evaluation, counters
+
+
+def run_guard_workflow_health_check(
+    *,
+    label: str,
+    repo: str,
+    branch: str,
+    lookback_hours: int,
+    per_page: int,
+    fixtures_file: Path | None,
+    now_utc: datetime,
+    allow_degraded: bool,
+    output_file: Path,
+) -> dict[str, Any]:
+    _expect(lookback_hours > 0, "lookback_hours must be > 0.")
+    _expect(per_page > 0, "per_page must be > 0.")
+
+    started = time.perf_counter()
+    cutoff_utc = now_utc - timedelta(hours=lookback_hours)
+    fixtures_payload = _load_json_file(fixtures_file) if fixtures_file is not None else None
+
+    def load_runs_for_workflow(workflow_name: str) -> list[dict[str, Any]]:
+        if fixtures_payload is not None:
+            return _load_fixture_runs(fixtures_payload=fixtures_payload, workflow_name=workflow_name)
+        return _fetch_runs_from_github(
+            repo=repo,
+            branch=branch,
+            workflow_name=workflow_name,
+            per_page=per_page,
+        )
+
+    def load_artifacts_for_run(run_id: int) -> list[dict[str, Any]]:
+        if fixtures_payload is not None:
+            return _load_fixture_artifacts(fixtures_payload=fixtures_payload, run_id=run_id)
+        return _fetch_run_artifacts_from_github(repo=repo, run_id=run_id)
+
+    evaluations: list[dict[str, Any]] = []
+    aggregate_runs_outside_window_ignored_total = 0
+    aggregate_runs_with_invalid_updated_at_total = 0
+
+    for spec in DEFAULT_GUARD_WORKFLOW_SPECS:
+        workflow_name = str(spec["workflow_name"])
+        required_artifacts = [str(item) for item in spec.get("required_artifacts") or []]
+        runs = load_runs_for_workflow(workflow_name)
+        evaluation, counters = _evaluate_guard_workflow(
+            workflow_name=workflow_name,
+            required_artifacts=required_artifacts,
+            runs=runs,
+            cutoff_utc=cutoff_utc,
+            load_artifacts_for_run=load_artifacts_for_run,
+        )
+        evaluations.append(evaluation)
+        aggregate_runs_outside_window_ignored_total += int(counters["runs_outside_window_ignored_total"])
+        aggregate_runs_with_invalid_updated_at_total += int(counters["runs_with_invalid_updated_at_total"])
+
+    degraded_workflows = [item for item in evaluations if not bool(item.get("is_healthy"))]
+    workflows_without_recent_run = [item for item in evaluations if not bool(item.get("has_recent_run"))]
+    workflows_with_non_success_latest_run = [
+        item
+        for item in evaluations
+        if bool(item.get("has_recent_run")) and not bool(item.get("latest_run_success"))
+    ]
+    workflows_missing_required_artifacts = [
+        item for item in evaluations if bool(item.get("missing_required_artifacts"))
+    ]
+
+    missing_required_artifacts_total = sum(
+        int(len(item.get("missing_required_artifacts") or [])) for item in evaluations
+    )
+    degraded_workflow_names = [str(item.get("workflow_name") or "") for item in degraded_workflows]
+
+    criteria = [
+        {
+            "name": "guard_workflows_evaluated",
+            "passed": bool(len(evaluations) > 0),
+            "details": f"guard_workflows_total={len(evaluations)}",
+        },
+        {
+            "name": "guard_workflows_healthy",
+            "passed": bool((len(degraded_workflows) == 0) or allow_degraded),
+            "details": (
+                f"degraded_workflows_total={len(degraded_workflows)}, "
+                f"allow_degraded={allow_degraded}"
+            ),
+        },
+    ]
+    failed_criteria = [item for item in criteria if not bool(item.get("passed"))]
+    success = len(failed_criteria) == 0
+
+    report = {
+        "label": label,
+        "success": bool(success),
+        "config": {
+            "repo": repo,
+            "branch": branch,
+            "lookback_hours": int(lookback_hours),
+            "per_page": int(per_page),
+            "allow_degraded": bool(allow_degraded),
+            "now_utc": _format_utc(now_utc),
+            "cutoff_utc": _format_utc(cutoff_utc),
+            "fixtures_file": str(fixtures_file) if fixtures_file is not None else None,
+            "guard_workflow_names": [str(item["workflow_name"]) for item in DEFAULT_GUARD_WORKFLOW_SPECS],
+            "output_file": str(output_file),
+        },
+        "metrics": {
+            "guard_workflows_total": int(len(evaluations)),
+            "guard_workflows_healthy_total": int(len(evaluations) - len(degraded_workflows)),
+            "guard_workflows_degraded_total": int(len(degraded_workflows)),
+            "guard_workflows_without_recent_run_total": int(len(workflows_without_recent_run)),
+            "guard_workflows_non_success_total": int(len(workflows_with_non_success_latest_run)),
+            "guard_workflows_missing_required_artifacts_total": int(len(workflows_missing_required_artifacts)),
+            "missing_required_artifacts_total": int(missing_required_artifacts_total),
+            "runs_outside_window_ignored_total": int(aggregate_runs_outside_window_ignored_total),
+            "runs_with_invalid_updated_at_total": int(aggregate_runs_with_invalid_updated_at_total),
+            "criteria_failed": int(len(failed_criteria)),
+        },
+        "criteria": criteria,
+        "failed_criteria": failed_criteria,
+        "evaluations": evaluations,
+        "degraded_workflows": degraded_workflows,
+        "degraded_workflow_names": degraded_workflow_names,
+        "decision": {
+            "guard_workflow_health_degraded": bool(len(degraded_workflows) > 0),
+            "recommended_action": (
+                "guard_workflow_health_green"
+                if len(degraded_workflows) == 0
+                else "guard_workflow_health_degraded"
+            ),
+        },
+        "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "duration_ms": int((time.perf_counter() - started) * 1000),
+    }
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2), encoding="utf-8")
+
+    if not success:
+        raise RuntimeError(f"Master guard-workflow health check failed: {json.dumps(report, sort_keys=True)}")
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Nightly watchdog for guard workflows on master. Ensures each guard workflow has "
+            "a recent successful run with expected artifacts."
+        )
+    )
+    parser.add_argument("--label", default="master-guard-workflow-health-check")
+    parser.add_argument("--repo", default="donatomaurizio99-collab/GOC")
+    parser.add_argument("--branch", default="master")
+    parser.add_argument("--lookback-hours", type=int, default=30)
+    parser.add_argument("--per-page", type=int, default=50)
+    parser.add_argument("--fixtures-file")
+    parser.add_argument("--now-utc")
+    parser.add_argument("--allow-degraded", action="store_true")
+    parser.add_argument("--output-file", default="artifacts/master-guard-workflow-health-check.json")
+    args = parser.parse_args(argv)
+
+    if int(args.lookback_hours) <= 0:
+        print("[master-guard-workflow-health-check] ERROR: --lookback-hours must be > 0.", file=sys.stderr)
+        return 2
+    if int(args.per_page) <= 0:
+        print("[master-guard-workflow-health-check] ERROR: --per-page must be > 0.", file=sys.stderr)
+        return 2
+
+    fixtures_file = Path(str(args.fixtures_file)).expanduser() if args.fixtures_file else None
+    output_file = Path(str(args.output_file)).expanduser()
+    try:
+        report = run_guard_workflow_health_check(
+            label=str(args.label),
+            repo=str(args.repo),
+            branch=str(args.branch),
+            lookback_hours=int(args.lookback_hours),
+            per_page=int(args.per_page),
+            fixtures_file=fixtures_file,
+            now_utc=_resolve_now_utc(args.now_utc),
+            allow_degraded=bool(args.allow_degraded),
+            output_file=output_file,
+        )
+    except Exception as exc:
+        print(f"[master-guard-workflow-health-check] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-ci-alert-issue-upsert.ps1
+++ b/scripts/run-ci-alert-issue-upsert.ps1
@@ -1,6 +1,6 @@
 ﻿param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("master-branch-protection-drift", "release-gate-runtime-early-warning", "release-gate-runtime-alert-age-slo")]
+    [ValidateSet("master-branch-protection-drift", "master-guard-workflow-health", "release-gate-runtime-early-warning", "release-gate-runtime-alert-age-slo")]
     [string]$SignalId,
     [Parameter(Mandatory = $true)]
     [string]$ReportFile,

--- a/scripts/run-master-guard-workflow-health-check.ps1
+++ b/scripts/run-master-guard-workflow-health-check.ps1
@@ -1,0 +1,38 @@
+param(
+    [string]$PythonExe = "python",
+    [string]$Repo = "donatomaurizio99-collab/GOC",
+    [string]$Branch = "master",
+    [int]$LookbackHours = 30,
+    [int]$PerPage = 50,
+    [string]$FixturesFile = "",
+    [string]$OutputFile = "artifacts\\master-guard-workflow-health-check.json",
+    [switch]$AllowDegraded
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$args = @(
+    ".\\scripts\\master-guard-workflow-health-check.py",
+    "--label", "manual",
+    "--repo", $Repo,
+    "--branch", $Branch,
+    "--lookback-hours", [string]$LookbackHours,
+    "--per-page", [string]$PerPage,
+    "--output-file", $OutputFile
+)
+if ($FixturesFile) {
+    $args += @("--fixtures-file", $FixturesFile)
+}
+if ($AllowDegraded) {
+    $args += "--allow-degraded"
+}
+
+& $PythonExe @args
+if ($LASTEXITCODE -ne 0) {
+    throw "Master guard-workflow health check failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Master guard-workflow health check passed." -ForegroundColor Green

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -11355,6 +11355,9 @@ def test_231_ci_alert_issue_upsert_workflow_wrapper_and_docs_wiring():
     branch_workflow = (
         project_root / ".github" / "workflows" / "master-branch-protection-drift-guard.yml"
     ).read_text(encoding="utf-8")
+    guard_workflow = (
+        project_root / ".github" / "workflows" / "master-guard-workflow-health.yml"
+    ).read_text(encoding="utf-8")
     runtime_workflow = (
         project_root / ".github" / "workflows" / "master-release-gate-runtime-early-warning.yml"
     ).read_text(encoding="utf-8")
@@ -11368,6 +11371,7 @@ def test_231_ci_alert_issue_upsert_workflow_wrapper_and_docs_wiring():
     assert "--alert-age-hours" in wrapper
     assert "--dry-run" in wrapper
     assert "master-branch-protection-drift" in wrapper
+    assert "master-guard-workflow-health" in wrapper
     assert "release-gate-runtime-early-warning" in wrapper
     assert "release-gate-runtime-alert-age-slo" in wrapper
 
@@ -11375,6 +11379,11 @@ def test_231_ci_alert_issue_upsert_workflow_wrapper_and_docs_wiring():
     assert ".\\scripts\\run-ci-alert-issue-upsert.ps1" in branch_workflow
     assert "master-branch-protection-drift-issue-upsert.json" in branch_workflow
     assert "recovery_threshold" in branch_workflow
+
+    assert "issues: write" in guard_workflow
+    assert ".\\scripts\\run-ci-alert-issue-upsert.ps1" in guard_workflow
+    assert "master-guard-workflow-health-issue-upsert.json" in guard_workflow
+    assert "recovery_threshold" in guard_workflow
 
     assert "issues: write" in runtime_workflow
     assert ".\\scripts\\run-ci-alert-issue-upsert.ps1" in runtime_workflow
@@ -11385,6 +11394,8 @@ def test_231_ci_alert_issue_upsert_workflow_wrapper_and_docs_wiring():
 
     assert "run-ci-alert-issue-upsert.ps1" in readme
     assert "labels: `ci-drift` + signal label" in readme
+    assert "[master-guard-workflow-health.yml]" in readme
+    assert "guard-workflow health watchdog" in readme
     assert "auto-close recovered issues after 2 healthy nightly runs" in readme
     assert "at most one open issue per signal" in readme
     assert "stays open beyond the alert-age SLO" in readme
@@ -12186,5 +12197,206 @@ def test_239_ci_alert_issue_upsert_alert_age_slo_parent_coupling_state_machine()
     assert [item["action"] for item in actions4] == ["reopen_issue", "add_comment"]
     assert "<!-- ci-alert-parent-runtime-warning-issue:900 -->" in actions4[0]["body"]
     assert "- Parent runtime warning issue: #900" in actions4[0]["body"]
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_240_master_guard_workflow_health_check_fails_on_degraded_guard_workflows():
+    workspace = _local_test_dir("pytest-master-guard-workflow-health-check-failure").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    fixtures_file = workspace / "fixtures.json"
+    output_file = workspace / "master-guard-workflow-health-check.json"
+
+    fixtures_file.write_text(
+        json.dumps(
+            {
+                "workflow_runs": {
+                    "Master Required Checks 24h": [
+                        {
+                            "id": 9101,
+                            "status": "completed",
+                            "conclusion": "success",
+                            "updated_at": "2026-04-18T02:50:00Z",
+                        }
+                    ],
+                    "Master Branch Protection Drift Guard": [
+                        {
+                            "id": 9102,
+                            "status": "completed",
+                            "conclusion": "success",
+                            "updated_at": "2026-04-18T02:30:00Z",
+                        }
+                    ],
+                    "Master Release Gate Runtime Early Warning": [
+                        {
+                            "id": 9103,
+                            "status": "completed",
+                            "conclusion": "failure",
+                            "updated_at": "2026-04-18T03:20:00Z",
+                        }
+                    ],
+                },
+                "run_artifacts": {
+                    "9101": {
+                        "artifacts": [
+                            {"name": "master-required-checks-24h-report", "expired": False},
+                        ]
+                    },
+                    "9102": {
+                        "artifacts": [
+                            {"name": "master-branch-protection-drift-guard", "expired": False},
+                        ]
+                    },
+                    "9103": {
+                        "artifacts": [
+                            {"name": "release-gate-runtime-early-warning", "expired": False},
+                            {"name": "release-gate-runtime-early-warning-issue-upsert", "expired": False},
+                            {"name": "release-gate-runtime-alert-age-slo-issue-upsert", "expired": False},
+                        ]
+                    },
+                },
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "master-guard-workflow-health-check.py"),
+        "--label",
+        "pytest-master-guard-workflow-health-check",
+        "--fixtures-file",
+        str(fixtures_file.resolve()),
+        "--lookback-hours",
+        "30",
+        "--now-utc",
+        "2026-04-18T04:00:00Z",
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "Master guard-workflow health check failed: "
+    assert marker in completed.stderr
+    payload_text = completed.stderr.split(marker, 1)[1].strip()
+    payload = json.loads(payload_text)
+    assert payload["success"] is False
+    assert payload["metrics"]["guard_workflows_total"] == 3
+    assert payload["metrics"]["guard_workflows_degraded_total"] == 2
+    assert payload["metrics"]["guard_workflows_missing_required_artifacts_total"] == 1
+    assert payload["metrics"]["guard_workflows_non_success_total"] == 1
+    assert "Master Branch Protection Drift Guard" in payload["degraded_workflow_names"]
+    assert "Master Release Gate Runtime Early Warning" in payload["degraded_workflow_names"]
+    assert output_file.exists()
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_241_master_guard_workflow_health_workflow_wrapper_and_docs_wiring():
+    project_root = Path(__file__).resolve().parents[1]
+    workflow = (project_root / ".github" / "workflows" / "master-guard-workflow-health.yml").read_text(
+        encoding="utf-8"
+    )
+    wrapper = (project_root / "scripts" / "run-master-guard-workflow-health-check.ps1").read_text(
+        encoding="utf-8"
+    )
+    readme = (project_root / "README.md").read_text(encoding="utf-8")
+
+    assert "name: Master Guard Workflow Health" in workflow
+    assert 'cron: "35 3 * * *"' in workflow
+    assert ".\\scripts\\run-master-guard-workflow-health-check.ps1" in workflow
+    assert "master-guard-workflow-health-check.json" in workflow
+    assert "master-guard-workflow-health-issue-upsert.json" in workflow
+    assert "master-guard-workflow-health" in workflow
+
+    assert "--lookback-hours" in wrapper
+    assert "--per-page" in wrapper
+    assert "--allow-degraded" in wrapper
+    assert "--fixtures-file" in wrapper
+    assert "master-guard-workflow-health-check.py" in wrapper
+
+    assert "[master-guard-workflow-health.yml]" in readme
+    assert "guard-workflow health watchdog" in readme
+    assert "run-master-guard-workflow-health-check.ps1" in readme
+
+
+def test_242_ci_alert_issue_upsert_creates_issue_for_guard_workflow_health():
+    workspace = _local_test_dir("pytest-ci-alert-issue-upsert-guard-workflow-health-create").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    report_file = workspace / "master-guard-workflow-health-check.json"
+    issues_file = workspace / "issues.json"
+    issue_oplog_file = workspace / "issue-oplog.json"
+    output_file = workspace / "ci-alert-issue-upsert.json"
+
+    report_file.write_text(
+        json.dumps(
+            {
+                "label": "pytest-guard-workflow-health",
+                "config": {"branch": "master"},
+                "metrics": {
+                    "guard_workflows_total": 3,
+                    "guard_workflows_degraded_total": 1,
+                    "missing_required_artifacts_total": 2,
+                },
+                "degraded_workflow_names": ["Master Branch Protection Drift Guard"],
+                "decision": {
+                    "guard_workflow_health_degraded": True,
+                    "recommended_action": "guard_workflow_health_degraded",
+                },
+                "generated_at_utc": "2026-04-18T04:00:00Z",
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    issues_file.write_text("[]", encoding="utf-8")
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "ci-alert-issue-upsert.py"),
+        "--label",
+        "pytest-alert-create-guard-health",
+        "--signal-id",
+        "master-guard-workflow-health",
+        "--repo",
+        "donatomaurizio99-collab/GOC",
+        "--report-file",
+        str(report_file.resolve()),
+        "--issues-file",
+        str(issues_file.resolve()),
+        "--issue-oplog-file",
+        str(issue_oplog_file.resolve()),
+        "--dry-run",
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["decision"]["alert_triggered"] is True
+    assert payload["decision"]["issue_action"] == "created"
+    assert payload["decision"]["issue_deduped"] is False
+    assert "guard-workflow-health" in payload["issue"]["labels"]
+    assert "ci-alert-key:master-guard-workflow-health:donatomaurizio99-collab/GOC:master" in payload["issue"]["marker"]
+    assert output_file.exists()
+
+    issue_oplog = json.loads(issue_oplog_file.read_text(encoding="utf-8"))
+    assert len(issue_oplog["actions"]) == 1
+    assert issue_oplog["actions"][0]["action"] == "create_issue"
+    assert issue_oplog["actions"][0]["labels"] == ["ci-drift", "guard-workflow-health"]
 
     shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
## Summary
- add a new nightly meta-watchdog: `master-guard-workflow-health-check.py`
- verify guard workflows on `master` have a recent successful completed run and publish expected artifacts
- add wrapper + new workflow `master-guard-workflow-health.yml`
- wire guard-health alert issue upsert via `run-ci-alert-issue-upsert.ps1`
- extend `ci-alert-issue-upsert.py` with `master-guard-workflow-health` signal + labels/summary parsing
- document workflow + local command in README
- add tests for watchdog failure path, workflow/wrapper/docs wiring, and alert-upsert creation path

## Local validation
- `python -m py_compile scripts\master-guard-workflow-health-check.py scripts\ci-alert-issue-upsert.py tests\test_goal_ops.py`
- `python -m pytest -q tests\test_goal_ops.py -k "test_223 or test_225 or test_228 or test_229 or test_230 or test_231 or test_232 or test_233 or test_234 or test_235 or test_236 or test_237 or test_238 or test_239 or test_240 or test_241 or test_242"`
- `python .\scripts\p0-runbook-contract-check.py --label local-master-guard-workflow-health --project-root .`
- `./scripts/run-master-guard-workflow-health-check.ps1 -FixturesFile "artifacts/master-guard-workflow-health-fixtures-local.json" -LookbackHours 30 -PerPage 50`
- `./scripts/run-ci-alert-issue-upsert.ps1 -SignalId "master-guard-workflow-health" ... -DryRun`
