### PR TITLE
Improve guard-health issue summaries with per-workflow diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,6 +947,7 @@ Nightly master required-checks monitoring now hard-fails on non-green required C
 Nightly branch-protection drift guard now verifies that `master` keeps exactly the 5 required checks (no missing or unexpected status contexts).
 Nightly guard-workflow health watchdog now verifies that the guard workflows themselves run successfully on `master` and publish their expected artifacts.
 It also enforces a coverage contract so all relevant `master-*` guard/warning/required-checks workflow files are declared in the watchdog with expected artifact contracts.
+Guard-health issue summaries now include per-degraded-workflow diagnostics (reason(s), missing required artifacts, and latest run ID/URL) so on-call can triage directly from the issue.
 Nightly release-gate runtime early warning now flags sustained runtime slowdown (default: 3 consecutive runs >= 540s) before it escalates into flaky failures, and escalates when an active runtime warning issue stays open beyond the alert-age SLO (default: 72h).
 Nightly drift/warning workflows now upsert deduplicated GitHub issues (labels: `ci-drift` + signal label), enforce the invariant of at most one open issue per signal, reset recovery streak on active alerts, and auto-close recovered issues after 2 healthy nightly runs (configurable threshold). The runtime alert-age SLO escalation issue now carries a mandatory parent runtime-warning reference in its issue body and closes immediately when parent-coupled escalation criteria are no longer met.
 

--- a/scripts/ci-alert-issue-upsert.py
+++ b/scripts/ci-alert-issue-upsert.py
@@ -175,6 +175,64 @@ def _coerce_issue_list(payload: Any) -> list[dict[str, Any]]:
     return issues
 
 
+def _coerce_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    coerced: list[str] = []
+    for item in value:
+        text = str(item or "").strip()
+        if text:
+            coerced.append(text)
+    return coerced
+
+
+def _resolve_guard_workflow_run_url(*, repo: str, latest_run: dict[str, Any]) -> str:
+    direct_url = str(latest_run.get("url") or latest_run.get("html_url") or "").strip()
+    if direct_url:
+        return direct_url
+
+    run_id = int(latest_run.get("run_id") or 0)
+    if run_id <= 0:
+        return ""
+    return f"https://github.com/{repo}/actions/runs/{run_id}"
+
+
+def _format_guard_workflow_degraded_detail_lines(
+    *,
+    repo: str,
+    degraded_workflows: list[dict[str, Any]],
+) -> list[str]:
+    detail_lines: list[str] = []
+    for workflow in degraded_workflows:
+        workflow_name = str(workflow.get("workflow_name") or "").strip() or "unknown_workflow"
+        degraded_reasons = _coerce_string_list(workflow.get("degraded_reasons"))
+        missing_required_artifacts = _coerce_string_list(workflow.get("missing_required_artifacts"))
+        latest_run = workflow.get("latest_run") if isinstance(workflow.get("latest_run"), dict) else {}
+        run_id = int(latest_run.get("run_id") or 0)
+        run_url = _resolve_guard_workflow_run_url(repo=repo, latest_run=latest_run)
+
+        reasons_text = ", ".join(degraded_reasons) if degraded_reasons else "none"
+        missing_text = ", ".join(missing_required_artifacts) if missing_required_artifacts else "none"
+        if run_id > 0 and run_url:
+            latest_run_text = f"#{run_id} ({run_url})"
+        elif run_id > 0:
+            latest_run_text = f"#{run_id}"
+        elif run_url:
+            latest_run_text = run_url
+        else:
+            latest_run_text = "none"
+
+        detail_lines.append(
+            (
+                f"- Degraded detail: {workflow_name} | "
+                f"reasons={reasons_text} | "
+                f"missing_required_artifacts={missing_text} | "
+                f"latest_run={latest_run_text}"
+            )
+        )
+    return detail_lines
+
+
 def _load_issues(*, repo: str, state: str, issues_file: Path | None, dry_run: bool) -> list[dict[str, Any]]:
     resolved_state = str(state or "open").strip().lower()
     _expect(resolved_state in {"open", "all"}, f"Unsupported issue state: {state}")
@@ -224,8 +282,15 @@ def _signal_alert_state(
         degraded_workflows = (
             report.get("degraded_workflow_names") if isinstance(report.get("degraded_workflow_names"), list) else []
         )
+        degraded_workflow_details = (
+            report.get("degraded_workflows") if isinstance(report.get("degraded_workflows"), list) else []
+        )
         missing_required_artifacts_total = int(metrics.get("missing_required_artifacts_total") or 0)
         alert_triggered = bool(decision.get("guard_workflow_health_degraded"))
+        degraded_detail_lines = _format_guard_workflow_degraded_detail_lines(
+            repo=repo,
+            degraded_workflows=[item for item in degraded_workflow_details if isinstance(item, dict)],
+        )
         summary = [
             (
                 f"- Degraded guard workflows: {', '.join(str(item) for item in degraded_workflows)}"
@@ -238,6 +303,7 @@ def _signal_alert_state(
                 f"(total={metrics.get('guard_workflows_total', 0)})"
             ),
             f"- Missing required artifacts total: {missing_required_artifacts_total}",
+            *degraded_detail_lines,
             f"- Recommended action: {decision.get('recommended_action') or 'guard_workflow_health_green'}",
         ]
         return alert_triggered, summary, branch, {}

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -12342,6 +12342,7 @@ def test_241_master_guard_workflow_health_workflow_wrapper_and_docs_wiring():
     assert "[master-guard-workflow-health.yml]" in readme
     assert "guard-workflow health watchdog" in readme
     assert "coverage contract" in readme
+    assert "per-degraded-workflow diagnostics" in readme
     assert "run-master-guard-workflow-health-check.ps1" in readme
 
 
@@ -12364,6 +12365,22 @@ def test_242_ci_alert_issue_upsert_creates_issue_for_guard_workflow_health():
                     "missing_required_artifacts_total": 2,
                 },
                 "degraded_workflow_names": ["Master Branch Protection Drift Guard"],
+                "degraded_workflows": [
+                    {
+                        "workflow_name": "Master Branch Protection Drift Guard",
+                        "degraded_reasons": [
+                            "latest_run_not_success",
+                            "required_artifacts_missing",
+                        ],
+                        "missing_required_artifacts": [
+                            "master-branch-protection-drift-issue-upsert",
+                            "master-branch-protection-drift-guard",
+                        ],
+                        "latest_run": {
+                            "run_id": 9302,
+                        },
+                    }
+                ],
                 "decision": {
                     "guard_workflow_health_degraded": True,
                     "recommended_action": "guard_workflow_health_degraded",
@@ -12416,6 +12433,14 @@ def test_242_ci_alert_issue_upsert_creates_issue_for_guard_workflow_health():
     assert len(issue_oplog["actions"]) == 1
     assert issue_oplog["actions"][0]["action"] == "create_issue"
     assert issue_oplog["actions"][0]["labels"] == ["ci-drift", "guard-workflow-health"]
+    created_body = str(issue_oplog["actions"][0]["body"])
+    assert "Degraded detail: Master Branch Protection Drift Guard" in created_body
+    assert "reasons=latest_run_not_success, required_artifacts_missing" in created_body
+    assert (
+        "missing_required_artifacts="
+        "master-branch-protection-drift-issue-upsert, master-branch-protection-drift-guard"
+    ) in created_body
+    assert "latest_run=#9302 (https://github.com/donatomaurizio99-collab/GOC/actions/runs/9302)" in created_body
 
     shutil.rmtree(workspace, ignore_errors=True)
 


### PR DESCRIPTION
﻿## Summary
- deepen `master-guard-workflow-health` alert summaries with per-degraded-workflow diagnostics
- include degraded reason(s), missing required artifacts, and latest run ID/URL directly in the issue body/comment summary
- resolve run URL with direct payload URL when available and fallback to deterministic GitHub run URL from `run_id`
- extend guard-health create/upsert tests to verify diagnostic lines are present
- document the new on-call diagnostics behavior in README

## Validation
- `python -m py_compile scripts/ci-alert-issue-upsert.py scripts/master-guard-workflow-health-check.py tests/test_goal_ops.py`
- `python -m pytest -q tests/test_goal_ops.py -k "test_241 or test_242 or test_240 or test_243"`
- `python .\scripts\p0-runbook-contract-check.py --label local-master-guard-alert-summary-details --project-root .`
