### PR TITLE
Add weekly watchdog rehearsal drill for guard-health alert chain

### DIFF
--- a/.github/workflows/master-watchdog-rehearsal-drill.yml
+++ b/.github/workflows/master-watchdog-rehearsal-drill.yml
@@ -1,0 +1,68 @@
+name: Master Watchdog Rehearsal Drill
+
+on:
+  schedule:
+    - cron: "45 4 * * 1"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch label for the injected watchdog rehearsal"
+        required: false
+        default: "master"
+
+permissions:
+  contents: read
+
+jobs:
+  watchdog-rehearsal-drill:
+    name: Watchdog Rehearsal Drill
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Run watchdog rehearsal drill
+        shell: pwsh
+        env:
+          REPO_FULL: ${{ github.repository }}
+          BRANCH_NAME: ${{ github.event.inputs.branch || 'master' }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          .\scripts\run-master-watchdog-rehearsal-drill.ps1 `
+            -Repo "$env:REPO_FULL" `
+            -Branch "$env:BRANCH_NAME" `
+            -RunUrl "$env:RUN_URL" `
+            -CheckReportFile "artifacts\master-guard-workflow-health-rehearsal-check.json" `
+            -IssueUpsertReportFile "artifacts\master-guard-workflow-health-rehearsal-issue-upsert.json" `
+            -OutputFile "artifacts\master-guard-workflow-health-rehearsal-drill.json"
+
+      - name: Upload watchdog rehearsal check report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: master-guard-workflow-health-rehearsal-check
+          path: artifacts/master-guard-workflow-health-rehearsal-check.json
+          if-no-files-found: error
+
+      - name: Upload watchdog rehearsal issue-upsert report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: master-guard-workflow-health-rehearsal-issue-upsert
+          path: artifacts/master-guard-workflow-health-rehearsal-issue-upsert.json
+          if-no-files-found: error
+
+      - name: Upload watchdog rehearsal drill report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: master-guard-workflow-health-rehearsal-drill
+          path: artifacts/master-guard-workflow-health-rehearsal-drill.json
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -948,6 +948,7 @@ Nightly branch-protection drift guard now verifies that `master` keeps exactly t
 Nightly guard-workflow health watchdog now verifies that the guard workflows themselves run successfully on `master` and publish their expected artifacts.
 It also enforces a coverage contract so all relevant `master-*` guard/warning/required-checks workflow files are declared in the watchdog with expected artifact contracts.
 Guard-health issue summaries now include per-degraded-workflow diagnostics (reason(s), missing required artifacts, and latest run ID/URL) so on-call can triage directly from the issue.
+Weekly [master-watchdog-rehearsal-drill.yml](.github/workflows/master-watchdog-rehearsal-drill.yml) runs an injected-failure drill for the watchdog chain and verifies guard-health alert upsert behavior in dry-run mode.
 Nightly release-gate runtime early warning now flags sustained runtime slowdown (default: 3 consecutive runs >= 540s) before it escalates into flaky failures, and escalates when an active runtime warning issue stays open beyond the alert-age SLO (default: 72h).
 Nightly drift/warning workflows now upsert deduplicated GitHub issues (labels: `ci-drift` + signal label), enforce the invariant of at most one open issue per signal, reset recovery streak on active alerts, and auto-close recovered issues after 2 healthy nightly runs (configurable threshold). The runtime alert-age SLO escalation issue now carries a mandatory parent runtime-warning reference in its issue body and closes immediately when parent-coupled escalation criteria are no longer met.
 

--- a/scripts/master-watchdog-rehearsal-drill.py
+++ b/scripts/master-watchdog-rehearsal-drill.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+
+INJECTED_DEGRADED_WORKFLOW_NAME = "Master Branch Protection Drift Guard"
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _utc_now_text() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _load_json_file(path: Path) -> dict[str, Any]:
+    _expect(path.exists(), f"JSON file not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    _expect(isinstance(payload, dict), f"Expected JSON object in file: {path}")
+    return payload
+
+
+def _run_python_command(*, project_root: Path, command: list[str]) -> None:
+    completed = subprocess.run(
+        [sys.executable, *command],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode == 0:
+        return
+    stderr = completed.stderr.strip()
+    stdout = completed.stdout.strip()
+    raise RuntimeError(
+        "Subprocess failed with exit code "
+        f"{completed.returncode}: {' '.join(command)}; stdout={stdout}; stderr={stderr}"
+    )
+
+
+def _build_guard_health_fixtures() -> dict[str, Any]:
+    return {
+        "workflow_runs": {
+            "Master Required Checks 24h": [
+                {
+                    "id": 9701,
+                    "status": "completed",
+                    "conclusion": "success",
+                    "updated_at": "2026-04-18T02:50:00Z",
+                }
+            ],
+            "Master Branch Protection Drift Guard": [
+                {
+                    "id": 9702,
+                    "status": "completed",
+                    "conclusion": "success",
+                    "updated_at": "2026-04-18T03:10:00Z",
+                }
+            ],
+            "Master Release Gate Runtime Early Warning": [
+                {
+                    "id": 9703,
+                    "status": "completed",
+                    "conclusion": "success",
+                    "updated_at": "2026-04-18T03:20:00Z",
+                }
+            ],
+            "Master Guard Workflow Health": [
+                {
+                    "id": 9704,
+                    "status": "completed",
+                    "conclusion": "success",
+                    "updated_at": "2026-04-18T03:35:00Z",
+                }
+            ],
+        },
+        "run_artifacts": {
+            "9701": {
+                "artifacts": [
+                    {"name": "master-required-checks-24h-report", "expired": False},
+                ]
+            },
+            "9702": {
+                "artifacts": [
+                    {
+                        "name": "master-branch-protection-drift-guard",
+                        "expired": False,
+                    },
+                ]
+            },
+            "9703": {
+                "artifacts": [
+                    {"name": "release-gate-runtime-early-warning", "expired": False},
+                    {
+                        "name": "release-gate-runtime-early-warning-issue-upsert",
+                        "expired": False,
+                    },
+                    {
+                        "name": "release-gate-runtime-alert-age-slo-issue-upsert",
+                        "expired": False,
+                    },
+                ]
+            },
+            "9704": {
+                "artifacts": [
+                    {"name": "master-guard-workflow-health-check", "expired": False},
+                    {
+                        "name": "master-guard-workflow-health-issue-upsert",
+                        "expired": False,
+                    },
+                ]
+            },
+        },
+    }
+
+
+def run_rehearsal_drill(
+    *,
+    label: str,
+    repo: str,
+    branch: str,
+    run_url: str | None,
+    check_report_file: Path,
+    issue_upsert_report_file: Path,
+    output_file: Path,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    project_root = Path(__file__).resolve().parents[1]
+
+    check_report_file.parent.mkdir(parents=True, exist_ok=True)
+    issue_upsert_report_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="master-watchdog-rehearsal-drill-") as temp_root_text:
+        temp_root = Path(temp_root_text)
+        fixtures_file = temp_root / "master-guard-workflow-health-fixtures.json"
+        issues_file = temp_root / "issues.json"
+        issue_oplog_file = temp_root / "issue-oplog.json"
+        fixtures_file.write_text(
+            json.dumps(_build_guard_health_fixtures(), ensure_ascii=True, sort_keys=True),
+            encoding="utf-8",
+        )
+        issues_file.write_text("[]", encoding="utf-8")
+
+        _run_python_command(
+            project_root=project_root,
+            command=[
+                str(project_root / "scripts" / "master-guard-workflow-health-check.py"),
+                "--label",
+                f"{label}-guard-health",
+                "--repo",
+                repo,
+                "--branch",
+                branch,
+                "--fixtures-file",
+                str(fixtures_file.resolve()),
+                "--lookback-hours",
+                "30",
+                "--now-utc",
+                "2026-04-18T04:00:00Z",
+                "--allow-degraded",
+                "--output-file",
+                str(check_report_file.resolve()),
+            ],
+        )
+
+        check_report = _load_json_file(check_report_file)
+        check_decision = check_report.get("decision") if isinstance(check_report.get("decision"), dict) else {}
+        check_metrics = check_report.get("metrics") if isinstance(check_report.get("metrics"), dict) else {}
+        check_degraded_names = (
+            check_report.get("degraded_workflow_names") if isinstance(check_report.get("degraded_workflow_names"), list) else []
+        )
+        check_is_degraded = bool(check_decision.get("guard_workflow_health_degraded"))
+        _expect(check_is_degraded, "Injected failure drill expected guard workflow health degradation signal.")
+        _expect(
+            INJECTED_DEGRADED_WORKFLOW_NAME in [str(item) for item in check_degraded_names],
+            "Injected failure drill did not surface expected degraded workflow name.",
+        )
+        _expect(
+            int(check_metrics.get("guard_workflows_degraded_total") or 0) >= 1,
+            "Injected failure drill expected at least one degraded guard workflow.",
+        )
+
+        issue_upsert_command = [
+            str(project_root / "scripts" / "ci-alert-issue-upsert.py"),
+            "--label",
+            f"{label}-issue-upsert",
+            "--signal-id",
+            "master-guard-workflow-health",
+            "--repo",
+            repo,
+            "--report-file",
+            str(check_report_file.resolve()),
+            "--issues-file",
+            str(issues_file.resolve()),
+            "--issue-oplog-file",
+            str(issue_oplog_file.resolve()),
+            "--dry-run",
+            "--output-file",
+            str(issue_upsert_report_file.resolve()),
+        ]
+        if run_url:
+            issue_upsert_command += ["--run-url", run_url]
+        _run_python_command(project_root=project_root, command=issue_upsert_command)
+
+        issue_upsert_report = _load_json_file(issue_upsert_report_file)
+        issue_upsert_decision = (
+            issue_upsert_report.get("decision") if isinstance(issue_upsert_report.get("decision"), dict) else {}
+        )
+        issue_upsert_alert_triggered = bool(issue_upsert_decision.get("alert_triggered"))
+        issue_upsert_action = str(issue_upsert_decision.get("issue_action") or "")
+        _expect(issue_upsert_alert_triggered, "Injected failure drill expected alert chain to trigger.")
+        _expect(
+            issue_upsert_action == "created",
+            f"Injected failure drill expected issue action 'created', got '{issue_upsert_action or 'none'}'.",
+        )
+
+        issue_oplog = _load_json_file(issue_oplog_file)
+        issue_actions = issue_oplog.get("actions") if isinstance(issue_oplog.get("actions"), list) else []
+        _expect(len(issue_actions) >= 1, "Injected failure drill expected at least one issue-oplog action.")
+        create_issue_action = issue_actions[0] if isinstance(issue_actions[0], dict) else {}
+        _expect(
+            str(create_issue_action.get("action") or "") == "create_issue",
+            "Injected failure drill expected first issue-oplog action to be 'create_issue'.",
+        )
+        create_issue_body = str(create_issue_action.get("body") or "")
+        _expect(
+            "Degraded detail:" in create_issue_body and "latest_run=#" in create_issue_body,
+            "Injected failure drill expected per-workflow degraded diagnostics in issue body.",
+        )
+
+    report = {
+        "label": label,
+        "success": True,
+        "config": {
+            "repo": repo,
+            "branch": branch,
+            "run_url": run_url,
+            "check_report_file": str(check_report_file),
+            "issue_upsert_report_file": str(issue_upsert_report_file),
+            "output_file": str(output_file),
+            "dry_run_issue_upsert": True,
+            "injected_degraded_workflow_name": INJECTED_DEGRADED_WORKFLOW_NAME,
+        },
+        "metrics": {
+            "guard_workflows_degraded_total": int(check_metrics.get("guard_workflows_degraded_total") or 0),
+            "degraded_workflow_names_total": int(len(check_degraded_names)),
+            "issue_actions_total": int(len(issue_actions)),
+        },
+        "decision": {
+            "injected_failure_detected": bool(check_is_degraded),
+            "alert_chain_verified": bool(issue_upsert_alert_triggered and issue_upsert_action == "created"),
+            "recommended_action": "watchdog_rehearsal_chain_verified",
+        },
+        "generated_at_utc": _utc_now_text(),
+        "duration_ms": int((time.perf_counter() - started) * 1000),
+    }
+
+    output_file.write_text(json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2), encoding="utf-8")
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a deterministic watchdog rehearsal drill by injecting a guard-workflow failure and "
+            "verifying the guard-health alert chain end-to-end in dry-run mode."
+        )
+    )
+    parser.add_argument("--label", default="master-watchdog-rehearsal-drill")
+    parser.add_argument("--repo", default="donatomaurizio99-collab/GOC")
+    parser.add_argument("--branch", default="master")
+    parser.add_argument("--run-url")
+    parser.add_argument(
+        "--check-report-file",
+        default="artifacts/master-guard-workflow-health-rehearsal-check.json",
+    )
+    parser.add_argument(
+        "--issue-upsert-report-file",
+        default="artifacts/master-guard-workflow-health-rehearsal-issue-upsert.json",
+    )
+    parser.add_argument(
+        "--output-file",
+        default="artifacts/master-guard-workflow-health-rehearsal-drill.json",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = run_rehearsal_drill(
+            label=str(args.label),
+            repo=str(args.repo),
+            branch=str(args.branch),
+            run_url=str(args.run_url) if args.run_url else None,
+            check_report_file=Path(str(args.check_report_file)).expanduser(),
+            issue_upsert_report_file=Path(str(args.issue_upsert_report_file)).expanduser(),
+            output_file=Path(str(args.output_file)).expanduser(),
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"[master-watchdog-rehearsal-drill] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-master-watchdog-rehearsal-drill.ps1
+++ b/scripts/run-master-watchdog-rehearsal-drill.ps1
@@ -1,0 +1,29 @@
+param(
+    [string]$Label = "master-watchdog-rehearsal-drill",
+    [string]$Repo = "donatomaurizio99-collab/GOC",
+    [string]$Branch = "master",
+    [string]$RunUrl = "",
+    [string]$CheckReportFile = "artifacts\\master-guard-workflow-health-rehearsal-check.json",
+    [string]$IssueUpsertReportFile = "artifacts\\master-guard-workflow-health-rehearsal-issue-upsert.json",
+    [string]$OutputFile = "artifacts\\master-guard-workflow-health-rehearsal-drill.json"
+)
+
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptDir "..")
+$scriptPath = Join-Path $repoRoot "scripts\\master-watchdog-rehearsal-drill.py"
+
+$args = @(
+    $scriptPath,
+    "--label", $Label,
+    "--repo", $Repo,
+    "--branch", $Branch,
+    "--check-report-file", $CheckReportFile,
+    "--issue-upsert-report-file", $IssueUpsertReportFile,
+    "--output-file", $OutputFile
+)
+if ($RunUrl) {
+    $args += @("--run-url", $RunUrl)
+}
+
+& python @args

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -12554,3 +12554,84 @@ def test_243_master_guard_workflow_health_contract_fails_on_uncovered_workflow_f
     assert payload["decision"]["guard_workflow_coverage_contract_ok"] is False
 
     shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_244_master_watchdog_rehearsal_drill_workflow_wrapper_and_docs_wiring():
+    project_root = Path(__file__).resolve().parents[1]
+    workflow = (project_root / ".github" / "workflows" / "master-watchdog-rehearsal-drill.yml").read_text(
+        encoding="utf-8"
+    )
+    wrapper = (project_root / "scripts" / "run-master-watchdog-rehearsal-drill.ps1").read_text(encoding="utf-8")
+    readme = (project_root / "README.md").read_text(encoding="utf-8")
+
+    assert "name: Master Watchdog Rehearsal Drill" in workflow
+    assert 'cron: "45 4 * * 1"' in workflow
+    assert ".\\scripts\\run-master-watchdog-rehearsal-drill.ps1" in workflow
+    assert "master-guard-workflow-health-rehearsal-check.json" in workflow
+    assert "master-guard-workflow-health-rehearsal-issue-upsert.json" in workflow
+    assert "master-guard-workflow-health-rehearsal-drill.json" in workflow
+
+    assert "master-watchdog-rehearsal-drill.py" in wrapper
+    assert "IssueUpsertReportFile" in wrapper
+    assert "CheckReportFile" in wrapper
+    assert "--issue-upsert-report-file" in wrapper
+    assert "--check-report-file" in wrapper
+
+    assert "master-watchdog-rehearsal-drill.yml" in readme
+    assert "injected-failure drill for the watchdog chain" in readme
+
+
+def test_245_master_watchdog_rehearsal_drill_verifies_alert_chain():
+    workspace = _local_test_dir("pytest-master-watchdog-rehearsal-drill").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    check_report_file = workspace / "master-guard-workflow-health-rehearsal-check.json"
+    issue_upsert_report_file = workspace / "master-guard-workflow-health-rehearsal-issue-upsert.json"
+    output_file = workspace / "master-guard-workflow-health-rehearsal-drill.json"
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "master-watchdog-rehearsal-drill.py"),
+        "--label",
+        "pytest-master-watchdog-rehearsal-drill",
+        "--repo",
+        "donatomaurizio99-collab/GOC",
+        "--branch",
+        "master",
+        "--run-url",
+        "https://github.com/donatomaurizio99-collab/GOC/actions/runs/9990001",
+        "--check-report-file",
+        str(check_report_file.resolve()),
+        "--issue-upsert-report-file",
+        str(issue_upsert_report_file.resolve()),
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["decision"]["injected_failure_detected"] is True
+    assert payload["decision"]["alert_chain_verified"] is True
+    assert output_file.exists()
+    assert check_report_file.exists()
+    assert issue_upsert_report_file.exists()
+
+    check_payload = json.loads(check_report_file.read_text(encoding="utf-8"))
+    assert check_payload["decision"]["guard_workflow_health_degraded"] is True
+    assert "Master Branch Protection Drift Guard" in check_payload["degraded_workflow_names"]
+
+    issue_upsert_payload = json.loads(issue_upsert_report_file.read_text(encoding="utf-8"))
+    assert issue_upsert_payload["decision"]["alert_triggered"] is True
+    assert issue_upsert_payload["decision"]["issue_action"] == "created"
+    assert any(
+        "Degraded detail:" in str(action.get("body") or "")
+        for action in issue_upsert_payload["actions"]
+        if isinstance(action, dict)
+    )
+
+    shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
﻿## Summary
- add a dedicated weekly watchdog rehearsal workflow (`master-watchdog-rehearsal-drill.yml`)
- add `scripts/master-watchdog-rehearsal-drill.py` to inject deterministic guard-health failure fixtures and verify alert-chain behavior end-to-end in dry-run mode
- add `scripts/run-master-watchdog-rehearsal-drill.ps1` wrapper for local/CI orchestration
- upload three rehearsal artifacts (guard-health check report, issue-upsert report, drill report)
- document the weekly rehearsal drill in README
- add targeted tests for workflow/wrapper/docs wiring and rehearsal drill chain verification

## Validation
- `python -m py_compile scripts/master-watchdog-rehearsal-drill.py scripts/ci-alert-issue-upsert.py tests/test_goal_ops.py`
- `python -m pytest -q tests/test_goal_ops.py -k "test_240 or test_241 or test_242 or test_243 or test_244 or test_245"`
- `python .\scripts\p0-runbook-contract-check.py --label local-master-watchdog-rehearsal-drill --project-root .`
- `.\scripts\run-master-watchdog-rehearsal-drill.ps1 -Label "local-wrapper-check" -Repo "donatomaurizio99-collab/GOC" -Branch "master" -RunUrl "https://github.com/donatomaurizio99-collab/GOC/actions/runs/9990002" -CheckReportFile "artifacts\local-master-watchdog-rehearsal-check.json" -IssueUpsertReportFile "artifacts\local-master-watchdog-rehearsal-issue-upsert.json" -OutputFile "artifacts\local-master-watchdog-rehearsal-drill.json"`
