### PR TITLE
Guard BOM hardening + chain selftest + weekly reliability digest

### DIFF
--- a/.github/workflows/master-guard-workflow-health.yml
+++ b/.github/workflows/master-guard-workflow-health.yml
@@ -21,6 +21,10 @@ on:
         description: "Healthy nightly runs required before auto-closing an open guard-health issue"
         required: false
         default: "2"
+      active_comment_cooldown:
+        description: "Comment cooldown for unchanged active alerts (comment every N runs)"
+        required: false
+        default: "3"
 
 permissions:
   contents: read
@@ -67,6 +71,7 @@ jobs:
           REPO_FULL: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           RECOVERY_THRESHOLD: ${{ github.event.inputs.recovery_threshold || '2' }}
+          ACTIVE_COMMENT_COOLDOWN: ${{ github.event.inputs.active_comment_cooldown || '3' }}
         run: |
           .\scripts\run-ci-alert-issue-upsert.ps1 `
             -SignalId "master-guard-workflow-health" `
@@ -74,7 +79,18 @@ jobs:
             -ReportFile "artifacts\master-guard-workflow-health-check.json" `
             -RunUrl "$env:RUN_URL" `
             -RecoveryThreshold "$env:RECOVERY_THRESHOLD" `
+            -ActiveCommentCooldown "$env:ACTIVE_COMMENT_COOLDOWN" `
             -OutputFile "artifacts\master-guard-workflow-health-issue-upsert.json"
+
+      - name: Run guard-chain selftest
+        if: always()
+        shell: pwsh
+        run: |
+          .\scripts\run-master-guard-chain-selftest.ps1 `
+            -SignalId "master-guard-workflow-health" `
+            -GuardReportFile "artifacts\master-guard-workflow-health-check.json" `
+            -IssueUpsertReportFile "artifacts\master-guard-workflow-health-issue-upsert.json" `
+            -OutputFile "artifacts\master-guard-workflow-health-selftest.json"
 
       - name: Upload guard-workflow health report
         if: always()
@@ -90,4 +106,12 @@ jobs:
         with:
           name: master-guard-workflow-health-issue-upsert
           path: artifacts/master-guard-workflow-health-issue-upsert.json
+          if-no-files-found: error
+
+      - name: Upload guard-workflow health chain selftest report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: master-guard-workflow-health-selftest
+          path: artifacts/master-guard-workflow-health-selftest.json
           if-no-files-found: error

--- a/.github/workflows/master-reliability-digest.yml
+++ b/.github/workflows/master-reliability-digest.yml
@@ -1,0 +1,101 @@
+name: Master Reliability Digest
+
+on:
+  schedule:
+    - cron: "20 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      ci_per_page:
+        description: "Completed master CI runs fetched for runtime trend"
+        required: false
+        default: "30"
+      guard_per_page:
+        description: "Completed guard-health runs fetched for degradation trend"
+        required: false
+        default: "30"
+      trend_runs:
+        description: "Most recent CI runs included in runtime trend"
+        required: false
+        default: "10"
+      guard_trend_runs:
+        description: "Most recent guard-health runs included in degradation trend"
+        required: false
+        default: "10"
+      release_gate_warning_seconds:
+        description: "Release Gate runtime warning threshold (seconds)"
+        required: false
+        default: "540"
+      warning_sustained_runs:
+        description: "Consecutive over-threshold runs to flag runtime warning"
+        required: false
+        default: "3"
+      fail_on_warning:
+        description: "Fail digest workflow when warning-level findings are present"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  reliability-digest:
+    name: Reliability Digest
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Build master reliability digest
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_FULL: ${{ github.repository }}
+          CI_PER_PAGE: ${{ github.event.inputs.ci_per_page || '30' }}
+          GUARD_PER_PAGE: ${{ github.event.inputs.guard_per_page || '30' }}
+          TREND_RUNS: ${{ github.event.inputs.trend_runs || '10' }}
+          GUARD_TREND_RUNS: ${{ github.event.inputs.guard_trend_runs || '10' }}
+          RELEASE_GATE_WARNING_SECONDS: ${{ github.event.inputs.release_gate_warning_seconds || '540' }}
+          WARNING_SUSTAINED_RUNS: ${{ github.event.inputs.warning_sustained_runs || '3' }}
+          FAIL_ON_WARNING: ${{ github.event.inputs.fail_on_warning || 'false' }}
+        run: |
+          $arguments = @(
+            "-Repo", "$env:REPO_FULL",
+            "-CiPerPage", "$env:CI_PER_PAGE",
+            "-GuardPerPage", "$env:GUARD_PER_PAGE",
+            "-TrendRuns", "$env:TREND_RUNS",
+            "-GuardTrendRuns", "$env:GUARD_TREND_RUNS",
+            "-ReleaseGateWarningSeconds", "$env:RELEASE_GATE_WARNING_SECONDS",
+            "-WarningSustainedRuns", "$env:WARNING_SUSTAINED_RUNS",
+            "-OutputFile", "artifacts\master-reliability-digest.json",
+            "-MarkdownOutputFile", "artifacts\master-reliability-digest.md"
+          )
+          if ($env:FAIL_ON_WARNING -eq "true") {
+            $arguments += "-FailOnWarning"
+          }
+          .\scripts\run-master-reliability-digest.ps1 @arguments
+
+      - name: Publish digest summary
+        if: always()
+        shell: pwsh
+        run: |
+          if (Test-Path "artifacts\master-reliability-digest.md") {
+            Get-Content "artifacts\master-reliability-digest.md" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          }
+
+      - name: Upload reliability digest artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: master-reliability-digest
+          path: |
+            artifacts/master-reliability-digest.json
+            artifacts/master-reliability-digest.md
+          if-no-files-found: error

--- a/.github/workflows/master-watchdog-rehearsal-slo-guard.yml
+++ b/.github/workflows/master-watchdog-rehearsal-slo-guard.yml
@@ -84,6 +84,16 @@ jobs:
             -ActiveCommentCooldown "$env:ACTIVE_COMMENT_COOLDOWN" `
             -OutputFile "artifacts\master-watchdog-rehearsal-slo-guard-issue-upsert.json"
 
+      - name: Run watchdog rehearsal SLO guard chain selftest
+        if: always()
+        shell: pwsh
+        run: |
+          .\scripts\run-master-guard-chain-selftest.ps1 `
+            -SignalId "master-watchdog-rehearsal-drill-slo" `
+            -GuardReportFile "artifacts\master-watchdog-rehearsal-slo-guard.json" `
+            -IssueUpsertReportFile "artifacts\master-watchdog-rehearsal-slo-guard-issue-upsert.json" `
+            -OutputFile "artifacts\master-watchdog-rehearsal-slo-guard-selftest.json"
+
       - name: Upload watchdog rehearsal SLO guard report
         if: always()
         uses: actions/upload-artifact@v4
@@ -98,4 +108,12 @@ jobs:
         with:
           name: master-watchdog-rehearsal-slo-guard-issue-upsert
           path: artifacts/master-watchdog-rehearsal-slo-guard-issue-upsert.json
+          if-no-files-found: error
+
+      - name: Upload watchdog rehearsal SLO guard chain selftest report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: master-watchdog-rehearsal-slo-guard-selftest
+          path: artifacts/master-watchdog-rehearsal-slo-guard-selftest.json
           if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -949,10 +949,12 @@ Nightly guard-workflow health watchdog now verifies that the guard workflows the
 It also enforces a coverage contract so all relevant `master-*` guard/warning/required-checks workflow files are declared in the watchdog with expected artifact contracts.
 Guard-health issue summaries now include per-degraded-workflow diagnostics (reason(s), missing required artifacts, and latest run ID/URL) so on-call can triage directly from the issue.
 Guard-health issue body/comments now include a dedicated `Immediate Actions` section with direct first-response steps and a local repro command.
+Nightly guard workflows now execute `run-master-guard-chain-selftest.ps1` to validate guard-report -> issue-upsert chain consistency and publish dedicated selftest artifacts.
 Weekly [master-watchdog-rehearsal-drill.yml](.github/workflows/master-watchdog-rehearsal-drill.yml) runs an injected-failure drill for the watchdog chain and verifies guard-health alert upsert behavior in dry-run mode.
 Nightly [master-watchdog-rehearsal-slo-guard.yml](.github/workflows/master-watchdog-rehearsal-slo-guard.yml) verifies the rehearsal drill SLO (>=1 successful run in 8 days) and raises a deduped `ci-drift` issue with explicit `stale`/`failed` reason plus latest run reference.
 Nightly release-gate runtime early warning now flags sustained runtime slowdown (default: 3 consecutive runs >= 540s) before it escalates into flaky failures, and escalates when an active runtime warning issue stays open beyond the alert-age SLO (default: 72h).
 Nightly drift/warning workflows now upsert deduplicated GitHub issues (labels: `ci-drift` + signal label), enforce the invariant of at most one open issue per signal, reset recovery streak on active alerts, and auto-close recovered issues after 2 healthy nightly runs (configurable threshold). Active-alert comments are cooldown-throttled for unchanged failure states (default every 3 runs), while issue bodies continue to refresh each run. The runtime alert-age SLO escalation issue now carries a mandatory parent runtime-warning reference in its issue body and closes immediately when parent-coupled escalation criteria are no longer met.
+Weekly [master-reliability-digest.yml](.github/workflows/master-reliability-digest.yml) publishes a trend digest (Release Gate runtime, guard degradations, active-comment suppression totals) as artifact + workflow summary for proactive reliability tracking.
 
 Release Gate workflow artifact includes `p0-release-evidence-bundle` (manifest + copied evidence reports, including safe-mode/A11y/runtime/flake stage outputs, + closure report), Stage-L/M evidence artifacts (`release-gate-evidence-freshness-release-gate.json`, `release-gate-evidence-hash-manifest-release-gate.json`, `release-gate-evidence-manifest-release-gate.json`), Stage-N/O timing-history artifacts (`release-gate-step-timing-schema-release-gate.json`, `release-gate-performance-history-release-gate.json`), Stage-K/P artifacts (`release-gate-step-timings-release-gate.json`, `release-gate-performance-budget-release-gate.json`, `release-gate-stability-final-readiness-release-gate.json`), Stage-Q/R readiness artifacts (`release-gate-staging-soak-readiness-release-gate.json`, `release-gate-rc-canary-rollout-release-gate.json`), Stage-S/T readiness artifacts (`release-gate-evidence-lineage-release-gate.json`, `release-gate-production-readiness-certification-release-gate.json`), Stage-U/AB expanded readiness artifacts (`release-gate-slo-burn-rate-v2-release-gate.json`, `release-gate-deploy-rehearsal-release-gate.json`, `release-gate-chaos-matrix-continuous-release-gate.json`, `release-gate-supply-chain-artifact-trust-release-gate.json`, `release-gate-operations-handoff-readiness-release-gate.json`, `release-gate-evidence-attestation-release-gate.json`, `release-gate-release-train-readiness-release-gate.json`, `release-gate-production-final-attestation-release-gate.json`), Stage-AC/AJ cutover-to-sustainability artifacts (`release-gate-production-cutover-readiness-release-gate.json`, `release-gate-hypercare-activation-release-gate.json`, `release-gate-rollback-trigger-integrity-release-gate.json`, `release-gate-post-cutover-finalization-release-gate.json`, `release-gate-post-release-watch-release-gate.json`, `release-gate-steady-state-certification-release-gate.json`, `release-gate-post-release-continuity-release-gate.json`, `release-gate-production-sustainability-certification-release-gate.json`), and registry attestation artifacts (`release-gate-registry-sync-ci.json`, `release-gate-registry-attestation-gate-ci.json`).
 
@@ -979,6 +981,9 @@ Nightly guard-workflow health watchdog:
 
 Nightly release-gate runtime early warning workflow:
 [master-release-gate-runtime-early-warning.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/master-release-gate-runtime-early-warning.yml)
+
+Weekly master reliability digest workflow:
+[master-reliability-digest.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/master-reliability-digest.yml)
 
 Nightly disaster-recovery rehearsal workflow:
 [disaster-recovery-rehearsal.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/disaster-recovery-rehearsal.yml)
@@ -1010,11 +1015,25 @@ Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-master-guard-workflow-health-check.ps1 -LookbackHours 30 -PerPage 50
 ```
 
+Local guard-chain selftest command:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-master-guard-chain-selftest.ps1 -SignalId master-guard-workflow-health -GuardReportFile artifacts\master-guard-workflow-health-check.json -IssueUpsertReportFile artifacts\master-guard-workflow-health-issue-upsert.json
+```
+
 Local release-gate runtime early warning command:
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-release-gate-runtime-early-warning.ps1 -ThresholdSeconds 540 -SustainedRuns 3
+```
+
+Local master reliability digest command:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-master-reliability-digest.ps1 -ReleaseGateWarningSeconds 540 -WarningSustainedRuns 3
 ```
 
 Local alert-to-action issue upsert command (dry run example):

--- a/scripts/master-guard-chain-selftest.py
+++ b/scripts/master-guard-chain-selftest.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+SIGNAL_ALERT_DECISION_KEY = {
+    "master-guard-workflow-health": "guard_workflow_health_degraded",
+    "master-watchdog-rehearsal-drill-slo": "watchdog_rehearsal_slo_breached",
+}
+
+ACTIVE_ALERT_ACTIONS = {"created", "reopened", "commented", "comment_suppressed_cooldown"}
+RECOVERY_ALERT_ACTIONS = {"closed", "recovery_progress", "none"}
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _load_json_file(path: Path) -> dict[str, Any]:
+    _expect(path.exists(), f"JSON file not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    _expect(isinstance(payload, dict), f"Expected JSON object in file: {path}")
+    return payload
+
+
+def _expected_alert_state(*, signal_id: str, guard_report: dict[str, Any]) -> bool:
+    decision = guard_report.get("decision") if isinstance(guard_report.get("decision"), dict) else {}
+    key = SIGNAL_ALERT_DECISION_KEY.get(signal_id)
+    _expect(bool(key), f"Unsupported signal id for selftest: {signal_id}")
+    return bool(decision.get(str(key)))
+
+
+def run_guard_chain_selftest(
+    *,
+    label: str,
+    signal_id: str,
+    guard_report_file: Path,
+    issue_upsert_report_file: Path,
+    output_file: Path,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    _expect(signal_id in SIGNAL_ALERT_DECISION_KEY, f"Unsupported signal id for selftest: {signal_id}")
+
+    guard_report = _load_json_file(guard_report_file)
+    issue_upsert_report = _load_json_file(issue_upsert_report_file)
+
+    expected_alert_triggered = _expected_alert_state(signal_id=signal_id, guard_report=guard_report)
+    issue_config = (
+        issue_upsert_report.get("config") if isinstance(issue_upsert_report.get("config"), dict) else {}
+    )
+    issue_decision = (
+        issue_upsert_report.get("decision") if isinstance(issue_upsert_report.get("decision"), dict) else {}
+    )
+    issue_metrics = issue_upsert_report.get("metrics") if isinstance(issue_upsert_report.get("metrics"), dict) else {}
+    issue_actions = (
+        issue_upsert_report.get("actions") if isinstance(issue_upsert_report.get("actions"), list) else []
+    )
+
+    issue_signal_id = str(issue_config.get("signal_id") or "")
+    issue_alert_triggered = bool(issue_decision.get("alert_triggered"))
+    issue_action = str(issue_decision.get("issue_action") or "none")
+    immediate_action_lines_total = int(issue_metrics.get("immediate_action_lines_total") or 0)
+
+    expected_report_basename = guard_report_file.name
+    issue_report_file_text = str(issue_config.get("report_file") or "")
+    issue_report_basename = Path(issue_report_file_text).name if issue_report_file_text else ""
+    report_file_matches = bool(
+        issue_report_basename and issue_report_basename.lower() == expected_report_basename.lower()
+    )
+
+    issue_action_allowed = (
+        issue_action in ACTIVE_ALERT_ACTIONS if expected_alert_triggered else issue_action in RECOVERY_ALERT_ACTIONS
+    )
+
+    criteria = [
+        {
+            "name": "signal_id_matches",
+            "passed": bool(issue_signal_id == signal_id),
+            "details": f"expected={signal_id}, actual={issue_signal_id or 'none'}",
+        },
+        {
+            "name": "issue_upsert_report_file_matches_guard_report",
+            "passed": bool(report_file_matches),
+            "details": (
+                f"expected_report={expected_report_basename}, "
+                f"issue_upsert_report={issue_report_basename or 'none'}"
+            ),
+        },
+        {
+            "name": "alert_state_propagated",
+            "passed": bool(issue_alert_triggered == expected_alert_triggered),
+            "details": (
+                f"expected_alert_triggered={expected_alert_triggered}, "
+                f"issue_alert_triggered={issue_alert_triggered}"
+            ),
+        },
+        {
+            "name": "issue_action_consistent_with_alert_state",
+            "passed": bool(issue_action_allowed),
+            "details": (
+                f"expected_alert_triggered={expected_alert_triggered}, "
+                f"issue_action={issue_action or 'none'}"
+            ),
+        },
+        {
+            "name": "issue_actions_recorded",
+            "passed": bool(isinstance(issue_upsert_report.get("actions"), list)),
+            "details": f"issue_actions_total={len(issue_actions)}",
+        },
+        {
+            "name": "guard_health_immediate_actions_present_when_alerted",
+            "passed": bool(
+                signal_id != "master-guard-workflow-health"
+                or (not expected_alert_triggered)
+                or immediate_action_lines_total > 0
+            ),
+            "details": (
+                f"signal_id={signal_id}, expected_alert_triggered={expected_alert_triggered}, "
+                f"immediate_action_lines_total={immediate_action_lines_total}"
+            ),
+        },
+    ]
+    failed_criteria = [item for item in criteria if not bool(item.get("passed"))]
+    success = len(failed_criteria) == 0
+
+    report = {
+        "label": label,
+        "success": bool(success),
+        "config": {
+            "signal_id": signal_id,
+            "guard_report_file": str(guard_report_file),
+            "issue_upsert_report_file": str(issue_upsert_report_file),
+            "output_file": str(output_file),
+        },
+        "metrics": {
+            "criteria_failed": int(len(failed_criteria)),
+            "guard_decision_keys_total": int(
+                len(guard_report.get("decision")) if isinstance(guard_report.get("decision"), dict) else 0
+            ),
+            "issue_actions_total": int(len(issue_actions)),
+            "immediate_action_lines_total": int(immediate_action_lines_total),
+        },
+        "criteria": criteria,
+        "failed_criteria": failed_criteria,
+        "decision": {
+            "expected_alert_triggered": bool(expected_alert_triggered),
+            "issue_alert_triggered": bool(issue_alert_triggered),
+            "issue_action": issue_action,
+            "signal_chain_consistent": bool(success),
+            "recommended_action": (
+                "guard_chain_healthy"
+                if success
+                else "investigate_guard_chain_signal_mismatch"
+            ),
+        },
+        "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "duration_ms": int((time.perf_counter() - started) * 1000),
+    }
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2), encoding="utf-8")
+
+    if not success:
+        raise RuntimeError(f"Master guard-chain selftest failed: {json.dumps(report, sort_keys=True)}")
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify guard report -> issue upsert chain consistency for master guard workflows "
+            "using generated report artifacts."
+        )
+    )
+    parser.add_argument("--label", default="master-guard-chain-selftest")
+    parser.add_argument(
+        "--signal-id",
+        choices=sorted(SIGNAL_ALERT_DECISION_KEY.keys()),
+        required=True,
+    )
+    parser.add_argument("--guard-report-file", required=True)
+    parser.add_argument("--issue-upsert-report-file", required=True)
+    parser.add_argument("--output-file", default="artifacts/master-guard-chain-selftest.json")
+    args = parser.parse_args(argv)
+
+    try:
+        report = run_guard_chain_selftest(
+            label=str(args.label),
+            signal_id=str(args.signal_id),
+            guard_report_file=Path(str(args.guard_report_file)).expanduser(),
+            issue_upsert_report_file=Path(str(args.issue_upsert_report_file)).expanduser(),
+            output_file=Path(str(args.output_file)).expanduser(),
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"[master-guard-chain-selftest] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/master-guard-workflow-health-check.py
+++ b/scripts/master-guard-workflow-health-check.py
@@ -78,7 +78,7 @@ def _run_gh_api(path: str) -> dict[str, Any]:
 
 def _load_json_file(path: Path) -> dict[str, Any]:
     _expect(path.exists(), f"JSON file not found: {path}")
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
     _expect(isinstance(payload, dict), f"Expected JSON object in file: {path}")
     return payload
 
@@ -111,7 +111,7 @@ def _discover_relevant_master_guard_workflow_files(*, project_root: Path) -> lis
 def _parse_workflow_name_from_file(path: Path) -> str:
     if not path.exists():
         return ""
-    for line in path.read_text(encoding="utf-8").splitlines():
+    for line in path.read_text(encoding="utf-8-sig").splitlines():
         stripped = line.strip()
         if not stripped.startswith("name:"):
             continue

--- a/scripts/master-reliability-digest.py
+++ b/scripts/master-reliability-digest.py
@@ -1,0 +1,672 @@
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import subprocess
+import sys
+import time
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _run_gh_api(path: str) -> dict[str, Any]:
+    command = ["gh", "api", path]
+    completed = subprocess.run(command, capture_output=True, text=True)
+    _expect(
+        completed.returncode == 0,
+        f"gh api failed ({completed.returncode}) for '{path}': {completed.stderr.strip()}",
+    )
+    payload = json.loads(completed.stdout)
+    _expect(isinstance(payload, dict), f"Expected JSON object from gh api path '{path}'.")
+    return payload
+
+
+def _run_gh_api_bytes(path: str) -> bytes:
+    command = ["gh", "api", path]
+    completed = subprocess.run(command, capture_output=True)
+    _expect(
+        completed.returncode == 0,
+        (
+            f"gh api (bytes) failed ({completed.returncode}) for '{path}': "
+            f"{completed.stderr.decode('utf-8', errors='replace').strip()}"
+        ),
+    )
+    return completed.stdout
+
+
+def _load_json_file(path: Path) -> dict[str, Any]:
+    _expect(path.exists(), f"JSON file not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    _expect(isinstance(payload, dict), f"Expected JSON object in file: {path}")
+    return payload
+
+
+def _load_json_from_zip_bytes(data: bytes) -> dict[str, Any]:
+    with zipfile.ZipFile(io.BytesIO(data)) as archive:
+        candidate_names = sorted(name for name in archive.namelist() if name.lower().endswith(".json"))
+        _expect(candidate_names, "Artifact zip did not contain a JSON file.")
+        with archive.open(candidate_names[0]) as handle:
+            payload = json.loads(handle.read().decode("utf-8-sig"))
+    _expect(isinstance(payload, dict), "Expected JSON object payload in artifact zip.")
+    return payload
+
+
+def _parse_utc_timestamp(value: str) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _format_utc(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _seconds_between(started_at: datetime | None, completed_at: datetime | None) -> float | None:
+    if started_at is None or completed_at is None:
+        return None
+    delta = (completed_at - started_at).total_seconds()
+    return max(0.0, float(delta))
+
+
+def _resolve_run_url(*, repo: str, run: dict[str, Any]) -> str:
+    direct = str(run.get("html_url") or "").strip()
+    if direct:
+        return direct
+    run_id = int(run.get("id") or 0)
+    if run_id <= 0:
+        return ""
+    return f"https://github.com/{repo}/actions/runs/{run_id}"
+
+
+def _fetch_workflow_id(*, repo: str, workflow_name: str) -> int:
+    payload = _run_gh_api(f"repos/{repo}/actions/workflows?per_page=100")
+    workflows = payload.get("workflows") or []
+    _expect(isinstance(workflows, list), "Invalid workflows payload format.")
+    for workflow in workflows:
+        if not isinstance(workflow, dict):
+            continue
+        if str(workflow.get("name") or "").strip() == workflow_name:
+            workflow_id = int(workflow.get("id") or 0)
+            _expect(workflow_id > 0, f"Workflow '{workflow_name}' has invalid id.")
+            return workflow_id
+    raise RuntimeError(f"Workflow '{workflow_name}' not found in repo '{repo}'.")
+
+
+def _fetch_runs_from_github(
+    *,
+    repo: str,
+    branch: str,
+    workflow_name: str,
+    per_page: int,
+) -> list[dict[str, Any]]:
+    workflow_id = _fetch_workflow_id(repo=repo, workflow_name=workflow_name)
+    payload = _run_gh_api(
+        f"repos/{repo}/actions/workflows/{workflow_id}/runs?branch={branch}&status=completed&per_page={per_page}"
+    )
+    runs = payload.get("workflow_runs") or []
+    _expect(isinstance(runs, list), f"Invalid workflow runs payload for workflow '{workflow_name}'.")
+    return [item for item in runs if isinstance(item, dict)]
+
+
+def _fetch_run_jobs_from_github(*, repo: str, run_id: int) -> list[dict[str, Any]]:
+    payload = _run_gh_api(f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100")
+    jobs = payload.get("jobs") or []
+    _expect(isinstance(jobs, list), f"Invalid jobs payload format for run {run_id}.")
+    return [item for item in jobs if isinstance(item, dict)]
+
+
+def _fetch_run_artifacts_from_github(*, repo: str, run_id: int) -> list[dict[str, Any]]:
+    payload = _run_gh_api(f"repos/{repo}/actions/runs/{run_id}/artifacts?per_page=100")
+    artifacts = payload.get("artifacts") or []
+    _expect(isinstance(artifacts, list), f"Invalid artifacts payload format for run {run_id}.")
+    return [item for item in artifacts if isinstance(item, dict)]
+
+
+def _load_runs_fixture(path: Path, *, workflow_name: str) -> list[dict[str, Any]]:
+    payload = _load_json_file(path)
+    if isinstance(payload.get("workflow_runs"), list):
+        runs = payload.get("workflow_runs") or []
+    elif isinstance(payload.get("workflow_runs"), dict):
+        runs = (payload.get("workflow_runs") or {}).get(workflow_name) or []
+    else:
+        runs = payload.get("runs") or []
+    _expect(isinstance(runs, list), f"Invalid runs fixture payload in {path}")
+    return [item for item in runs if isinstance(item, dict)]
+
+
+def _load_jobs_fixture(*, jobs_dir: Path, run_id: int) -> list[dict[str, Any]]:
+    candidate_paths = [
+        jobs_dir / f"{run_id}.json",
+        jobs_dir / f"run-{run_id}.json",
+        jobs_dir / f"run-{run_id}-jobs.json",
+    ]
+    file_path = next((path for path in candidate_paths if path.exists()), None)
+    _expect(file_path is not None, f"No jobs fixture file found for run id {run_id} in {jobs_dir}")
+    payload = _load_json_file(file_path)
+    jobs = payload.get("jobs") or []
+    _expect(isinstance(jobs, list), f"Invalid jobs fixture payload format for run {run_id}: {file_path}")
+    return [item for item in jobs if isinstance(item, dict)]
+
+
+def _load_guard_issue_upsert_report_fixture(*, reports_dir: Path, run_id: int) -> dict[str, Any] | None:
+    candidate_paths = [
+        reports_dir / f"{run_id}.json",
+        reports_dir / f"run-{run_id}.json",
+        reports_dir / f"run-{run_id}-issue-upsert.json",
+        reports_dir / f"master-guard-workflow-health-issue-upsert-{run_id}.json",
+    ]
+    file_path = next((path for path in candidate_paths if path.exists()), None)
+    if file_path is None:
+        return None
+    return _load_json_file(file_path)
+
+
+def _load_guard_issue_upsert_report_from_github(
+    *,
+    repo: str,
+    run_id: int,
+    artifact_name: str,
+) -> dict[str, Any] | None:
+    artifacts = _fetch_run_artifacts_from_github(repo=repo, run_id=run_id)
+    for artifact in artifacts:
+        if str(artifact.get("name") or "") != artifact_name:
+            continue
+        if bool(artifact.get("expired")):
+            return None
+        download_url = str(artifact.get("archive_download_url") or "").strip()
+        if not download_url:
+            return None
+        archive_bytes = _run_gh_api_bytes(download_url)
+        return _load_json_from_zip_bytes(archive_bytes)
+    return None
+
+
+def _build_release_gate_samples(
+    *,
+    repo: str,
+    runs: list[dict[str, Any]],
+    release_gate_job_name: str,
+    trend_runs: int,
+    jobs_dir: Path | None,
+) -> list[dict[str, Any]]:
+    samples: list[dict[str, Any]] = []
+    for run in runs[:trend_runs]:
+        run_id = int(run.get("id") or 0)
+        if run_id <= 0:
+            continue
+        jobs = (
+            _load_jobs_fixture(jobs_dir=jobs_dir, run_id=run_id)
+            if jobs_dir is not None
+            else _fetch_run_jobs_from_github(repo=repo, run_id=run_id)
+        )
+        matching_jobs = [job for job in jobs if str(job.get("name") or "").strip() == release_gate_job_name]
+        durations: list[float] = []
+        for job in matching_jobs:
+            started_at = _parse_utc_timestamp(str(job.get("started_at") or ""))
+            completed_at = _parse_utc_timestamp(str(job.get("completed_at") or ""))
+            duration = _seconds_between(started_at, completed_at)
+            if duration is not None:
+                durations.append(float(duration))
+        selected_duration = max(durations) if durations else None
+        samples.append(
+            {
+                "run_id": run_id,
+                "run_url": _resolve_run_url(repo=repo, run=run),
+                "updated_at": str(run.get("updated_at") or ""),
+                "release_gate_duration_seconds": (
+                    round(float(selected_duration), 3) if selected_duration is not None else None
+                ),
+                "release_gate_job_matches_total": int(len(matching_jobs)),
+            }
+        )
+    return samples
+
+
+def _build_guard_samples(*, repo: str, runs: list[dict[str, Any]], trend_runs: int) -> list[dict[str, Any]]:
+    return [
+        {
+            "run_id": int(run.get("id") or 0),
+            "run_url": _resolve_run_url(repo=repo, run=run),
+            "status": str(run.get("status") or ""),
+            "conclusion": str(run.get("conclusion") or ""),
+            "updated_at": str(run.get("updated_at") or ""),
+        }
+        for run in runs[:trend_runs]
+        if int(run.get("id") or 0) > 0
+    ]
+
+
+def _build_reliability_markdown(
+    *,
+    generated_at_utc: str,
+    release_gate_warning_seconds: int,
+    warning_sustained_runs: int,
+    release_gate_warning_triggered: bool,
+    release_gate_consecutive_over_threshold: int,
+    release_gate_samples: list[dict[str, Any]],
+    guard_samples: list[dict[str, Any]],
+    guard_non_success_runs: list[dict[str, Any]],
+    issue_upsert_samples: list[dict[str, Any]],
+    upsert_artifacts_missing_total: int,
+    active_comment_suppressed_total_sum: int,
+) -> str:
+    latest_release_sample = release_gate_samples[0] if release_gate_samples else {}
+    latest_guard_degraded = guard_non_success_runs[0] if guard_non_success_runs else {}
+    latest_upsert_sample = issue_upsert_samples[0] if issue_upsert_samples else {}
+
+    release_duration_text = (
+        f"{latest_release_sample.get('release_gate_duration_seconds')}s"
+        if latest_release_sample and latest_release_sample.get("release_gate_duration_seconds") is not None
+        else "unknown"
+    )
+    release_run_url = str(latest_release_sample.get("run_url") or "")
+    release_run_id = int(latest_release_sample.get("run_id") or 0)
+
+    degraded_run_url = str(latest_guard_degraded.get("run_url") or "")
+    degraded_run_id = int(latest_guard_degraded.get("run_id") or 0)
+    degraded_conclusion = str(latest_guard_degraded.get("conclusion") or "")
+
+    latest_upsert_run_id = int(latest_upsert_sample.get("run_id") or 0)
+    latest_upsert_issue_action = str(latest_upsert_sample.get("issue_action") or "none")
+    latest_upsert_suppressed = int(latest_upsert_sample.get("active_comment_suppressed_total") or 0)
+
+    lines = [
+        "# Master Reliability Digest",
+        "",
+        f"- Generated at (UTC): `{generated_at_utc}`",
+        "",
+        "## Release Gate Runtime Trend",
+        f"- Samples: {len(release_gate_samples)}",
+        (
+            f"- Latest Release Gate runtime: `{release_duration_text}` on run "
+            f"`#{release_run_id}` ({release_run_url})"
+            if release_run_id > 0 and release_run_url
+            else "- Latest Release Gate runtime: unknown"
+        ),
+        (
+            f"- Early-warning threshold: `{release_gate_warning_seconds}s` sustained for "
+            f"`{warning_sustained_runs}` runs (current streak={release_gate_consecutive_over_threshold})"
+        ),
+        f"- Runtime warning triggered: {'yes' if release_gate_warning_triggered else 'no'}",
+        "",
+        "## Guard Workflow Degradations",
+        f"- Guard samples: {len(guard_samples)}",
+        f"- Non-success guard runs: {len(guard_non_success_runs)}",
+        (
+            f"- Latest degraded guard run: `#{degraded_run_id}` ({degraded_run_url}) "
+            f"conclusion=`{degraded_conclusion or 'unknown'}`"
+            if degraded_run_id > 0 and degraded_run_url
+            else "- Latest degraded guard run: none"
+        ),
+        "",
+        "## Active Alert Cooldown Signal",
+        f"- Parsed issue-upsert reports: {len(issue_upsert_samples)}",
+        f"- Missing issue-upsert artifacts/reports: {upsert_artifacts_missing_total}",
+        f"- `active_comment_suppressed_total` sum: {active_comment_suppressed_total_sum}",
+        (
+            f"- Latest upsert sample: run `#{latest_upsert_run_id}`, issue_action=`{latest_upsert_issue_action}`, "
+            f"active_comment_suppressed_total={latest_upsert_suppressed}"
+            if latest_upsert_run_id > 0
+            else "- Latest upsert sample: none"
+        ),
+    ]
+    return "\n".join(lines).strip() + "\n"
+
+
+def run_master_reliability_digest(
+    *,
+    label: str,
+    repo: str,
+    branch: str,
+    ci_workflow_name: str,
+    guard_workflow_name: str,
+    release_gate_job_name: str,
+    issue_upsert_artifact_name: str,
+    ci_per_page: int,
+    guard_per_page: int,
+    trend_runs: int,
+    guard_trend_runs: int,
+    release_gate_warning_seconds: int,
+    warning_sustained_runs: int,
+    fail_on_warning: bool,
+    ci_runs_file: Path | None,
+    ci_jobs_dir: Path | None,
+    guard_runs_file: Path | None,
+    guard_upsert_reports_dir: Path | None,
+    output_file: Path,
+    markdown_output_file: Path,
+) -> dict[str, Any]:
+    _expect(ci_per_page > 0, "ci_per_page must be > 0.")
+    _expect(guard_per_page > 0, "guard_per_page must be > 0.")
+    _expect(trend_runs > 0, "trend_runs must be > 0.")
+    _expect(guard_trend_runs > 0, "guard_trend_runs must be > 0.")
+    _expect(release_gate_warning_seconds > 0, "release_gate_warning_seconds must be > 0.")
+    _expect(warning_sustained_runs > 0, "warning_sustained_runs must be > 0.")
+
+    started = time.perf_counter()
+    ci_runs = (
+        _load_runs_fixture(ci_runs_file, workflow_name=ci_workflow_name)
+        if ci_runs_file is not None
+        else _fetch_runs_from_github(
+            repo=repo,
+            branch=branch,
+            workflow_name=ci_workflow_name,
+            per_page=ci_per_page,
+        )
+    )
+    guard_runs = (
+        _load_runs_fixture(guard_runs_file, workflow_name=guard_workflow_name)
+        if guard_runs_file is not None
+        else _fetch_runs_from_github(
+            repo=repo,
+            branch=branch,
+            workflow_name=guard_workflow_name,
+            per_page=guard_per_page,
+        )
+    )
+
+    release_gate_samples = _build_release_gate_samples(
+        repo=repo,
+        runs=ci_runs,
+        release_gate_job_name=release_gate_job_name,
+        trend_runs=trend_runs,
+        jobs_dir=ci_jobs_dir,
+    )
+    release_gate_duration_samples = [
+        item for item in release_gate_samples if item.get("release_gate_duration_seconds") is not None
+    ]
+
+    guard_samples = _build_guard_samples(repo=repo, runs=guard_runs, trend_runs=guard_trend_runs)
+    guard_non_success_runs = [
+        item
+        for item in guard_samples
+        if str(item.get("status") or "") == "completed"
+        and str(item.get("conclusion") or "").strip().lower() != "success"
+    ]
+
+    release_gate_consecutive_over_threshold = 0
+    for sample in release_gate_duration_samples:
+        duration_seconds = float(sample.get("release_gate_duration_seconds") or 0.0)
+        if duration_seconds >= float(release_gate_warning_seconds):
+            release_gate_consecutive_over_threshold += 1
+        else:
+            break
+
+    release_gate_warning_triggered = bool(
+        release_gate_consecutive_over_threshold >= warning_sustained_runs
+        and len(release_gate_duration_samples) >= warning_sustained_runs
+    )
+    if release_gate_warning_triggered:
+        print(
+            "::warning::Master reliability digest detected sustained Release Gate slowdown: "
+            f"{release_gate_consecutive_over_threshold} consecutive runs >= {release_gate_warning_seconds}s."
+        )
+
+    issue_upsert_samples: list[dict[str, Any]] = []
+    upsert_artifacts_missing_total = 0
+    active_comment_suppressed_total_sum = 0
+    for guard_run in guard_samples:
+        run_id = int(guard_run.get("run_id") or 0)
+        if run_id <= 0:
+            continue
+        issue_upsert_payload = (
+            _load_guard_issue_upsert_report_fixture(reports_dir=guard_upsert_reports_dir, run_id=run_id)
+            if guard_upsert_reports_dir is not None
+            else _load_guard_issue_upsert_report_from_github(
+                repo=repo,
+                run_id=run_id,
+                artifact_name=issue_upsert_artifact_name,
+            )
+        )
+        if issue_upsert_payload is None:
+            upsert_artifacts_missing_total += 1
+            continue
+        issue_metrics = (
+            issue_upsert_payload.get("metrics") if isinstance(issue_upsert_payload.get("metrics"), dict) else {}
+        )
+        issue_decision = (
+            issue_upsert_payload.get("decision") if isinstance(issue_upsert_payload.get("decision"), dict) else {}
+        )
+        active_comment_suppressed_total = int(issue_metrics.get("active_comment_suppressed_total") or 0)
+        active_comment_suppressed_total_sum += active_comment_suppressed_total
+        issue_upsert_samples.append(
+            {
+                "run_id": run_id,
+                "active_comment_suppressed_total": active_comment_suppressed_total,
+                "issue_action": str(issue_decision.get("issue_action") or "none"),
+                "alert_triggered": bool(issue_decision.get("alert_triggered")),
+            }
+        )
+
+    avg_release_gate_seconds = (
+        round(
+            sum(float(item.get("release_gate_duration_seconds") or 0.0) for item in release_gate_duration_samples)
+            / len(release_gate_duration_samples),
+            3,
+        )
+        if release_gate_duration_samples
+        else None
+    )
+    max_release_gate_seconds = (
+        max(float(item.get("release_gate_duration_seconds") or 0.0) for item in release_gate_duration_samples)
+        if release_gate_duration_samples
+        else None
+    )
+
+    criteria = [
+        {
+            "name": "release_gate_samples_present",
+            "passed": bool(len(release_gate_duration_samples) > 0),
+            "details": f"release_gate_duration_samples_total={len(release_gate_duration_samples)}",
+        },
+        {
+            "name": "guard_samples_present",
+            "passed": bool(len(guard_samples) > 0),
+            "details": f"guard_samples_total={len(guard_samples)}",
+        },
+        {
+            "name": "warning_policy",
+            "passed": bool(
+                (not fail_on_warning)
+                or (not release_gate_warning_triggered and len(guard_non_success_runs) == 0)
+            ),
+            "details": (
+                f"fail_on_warning={fail_on_warning}, "
+                f"release_gate_warning_triggered={release_gate_warning_triggered}, "
+                f"guard_non_success_total={len(guard_non_success_runs)}"
+            ),
+        },
+    ]
+    failed_criteria = [item for item in criteria if not bool(item.get("passed"))]
+    success = len(failed_criteria) == 0
+
+    generated_at_utc = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    markdown = _build_reliability_markdown(
+        generated_at_utc=generated_at_utc,
+        release_gate_warning_seconds=release_gate_warning_seconds,
+        warning_sustained_runs=warning_sustained_runs,
+        release_gate_warning_triggered=release_gate_warning_triggered,
+        release_gate_consecutive_over_threshold=release_gate_consecutive_over_threshold,
+        release_gate_samples=release_gate_duration_samples,
+        guard_samples=guard_samples,
+        guard_non_success_runs=guard_non_success_runs,
+        issue_upsert_samples=issue_upsert_samples,
+        upsert_artifacts_missing_total=upsert_artifacts_missing_total,
+        active_comment_suppressed_total_sum=active_comment_suppressed_total_sum,
+    )
+
+    report = {
+        "label": label,
+        "success": bool(success),
+        "config": {
+            "repo": repo,
+            "branch": branch,
+            "ci_workflow_name": ci_workflow_name,
+            "guard_workflow_name": guard_workflow_name,
+            "release_gate_job_name": release_gate_job_name,
+            "issue_upsert_artifact_name": issue_upsert_artifact_name,
+            "ci_per_page": int(ci_per_page),
+            "guard_per_page": int(guard_per_page),
+            "trend_runs": int(trend_runs),
+            "guard_trend_runs": int(guard_trend_runs),
+            "release_gate_warning_seconds": int(release_gate_warning_seconds),
+            "warning_sustained_runs": int(warning_sustained_runs),
+            "fail_on_warning": bool(fail_on_warning),
+            "ci_runs_file": str(ci_runs_file) if ci_runs_file is not None else None,
+            "ci_jobs_dir": str(ci_jobs_dir) if ci_jobs_dir is not None else None,
+            "guard_runs_file": str(guard_runs_file) if guard_runs_file is not None else None,
+            "guard_upsert_reports_dir": str(guard_upsert_reports_dir) if guard_upsert_reports_dir is not None else None,
+            "output_file": str(output_file),
+            "markdown_output_file": str(markdown_output_file),
+        },
+        "metrics": {
+            "release_gate_duration_samples_total": int(len(release_gate_duration_samples)),
+            "release_gate_consecutive_over_threshold": int(release_gate_consecutive_over_threshold),
+            "release_gate_warning_triggered": 1 if release_gate_warning_triggered else 0,
+            "release_gate_duration_avg_seconds": avg_release_gate_seconds,
+            "release_gate_duration_max_seconds": (
+                round(float(max_release_gate_seconds), 3) if max_release_gate_seconds is not None else None
+            ),
+            "guard_samples_total": int(len(guard_samples)),
+            "guard_non_success_total": int(len(guard_non_success_runs)),
+            "issue_upsert_samples_total": int(len(issue_upsert_samples)),
+            "upsert_artifacts_missing_total": int(upsert_artifacts_missing_total),
+            "active_comment_suppressed_total_sum": int(active_comment_suppressed_total_sum),
+            "criteria_failed": int(len(failed_criteria)),
+        },
+        "criteria": criteria,
+        "failed_criteria": failed_criteria,
+        "decision": {
+            "release_gate_warning_triggered": bool(release_gate_warning_triggered),
+            "guard_health_degraded": bool(len(guard_non_success_runs) > 0),
+            "warning_level": (
+                "warning"
+                if release_gate_warning_triggered or len(guard_non_success_runs) > 0
+                else "healthy"
+            ),
+            "recommended_action": (
+                "investigate_master_reliability_regression"
+                if release_gate_warning_triggered or len(guard_non_success_runs) > 0
+                else "master_reliability_stable"
+            ),
+        },
+        "release_gate_samples": release_gate_duration_samples,
+        "guard_runs": guard_samples,
+        "guard_non_success_runs": guard_non_success_runs,
+        "issue_upsert_samples": issue_upsert_samples,
+        "markdown_summary": markdown,
+        "generated_at_utc": generated_at_utc,
+        "duration_ms": int((time.perf_counter() - started) * 1000),
+    }
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    markdown_output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2), encoding="utf-8")
+    markdown_output_file.write_text(markdown, encoding="utf-8")
+
+    if not success:
+        raise RuntimeError(f"Master reliability digest failed: {json.dumps(report, sort_keys=True)}")
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build a weekly master reliability digest with release-gate runtime trend, "
+            "guard degradation summary, and active-alert cooldown suppression metrics."
+        )
+    )
+    parser.add_argument("--label", default="master-reliability-digest")
+    parser.add_argument("--repo", default="donatomaurizio99-collab/GOC")
+    parser.add_argument("--branch", default="master")
+    parser.add_argument("--ci-workflow-name", default="CI")
+    parser.add_argument("--guard-workflow-name", default="Master Guard Workflow Health")
+    parser.add_argument("--release-gate-job-name", default="Release Gate (Windows)")
+    parser.add_argument("--issue-upsert-artifact-name", default="master-guard-workflow-health-issue-upsert")
+    parser.add_argument("--ci-per-page", type=int, default=30)
+    parser.add_argument("--guard-per-page", type=int, default=30)
+    parser.add_argument("--trend-runs", type=int, default=10)
+    parser.add_argument("--guard-trend-runs", type=int, default=10)
+    parser.add_argument("--release-gate-warning-seconds", type=int, default=540)
+    parser.add_argument("--warning-sustained-runs", type=int, default=3)
+    parser.add_argument("--ci-runs-file")
+    parser.add_argument("--ci-jobs-dir")
+    parser.add_argument("--guard-runs-file")
+    parser.add_argument("--guard-upsert-reports-dir")
+    parser.add_argument("--fail-on-warning", action="store_true")
+    parser.add_argument("--output-file", default="artifacts/master-reliability-digest.json")
+    parser.add_argument("--markdown-output-file", default="artifacts/master-reliability-digest.md")
+    args = parser.parse_args(argv)
+
+    if int(args.ci_per_page) <= 0:
+        print("[master-reliability-digest] ERROR: --ci-per-page must be > 0.", file=sys.stderr)
+        return 2
+    if int(args.guard_per_page) <= 0:
+        print("[master-reliability-digest] ERROR: --guard-per-page must be > 0.", file=sys.stderr)
+        return 2
+    if int(args.trend_runs) <= 0:
+        print("[master-reliability-digest] ERROR: --trend-runs must be > 0.", file=sys.stderr)
+        return 2
+    if int(args.guard_trend_runs) <= 0:
+        print("[master-reliability-digest] ERROR: --guard-trend-runs must be > 0.", file=sys.stderr)
+        return 2
+    if int(args.release_gate_warning_seconds) <= 0:
+        print("[master-reliability-digest] ERROR: --release-gate-warning-seconds must be > 0.", file=sys.stderr)
+        return 2
+    if int(args.warning_sustained_runs) <= 0:
+        print("[master-reliability-digest] ERROR: --warning-sustained-runs must be > 0.", file=sys.stderr)
+        return 2
+
+    try:
+        report = run_master_reliability_digest(
+            label=str(args.label),
+            repo=str(args.repo),
+            branch=str(args.branch),
+            ci_workflow_name=str(args.ci_workflow_name),
+            guard_workflow_name=str(args.guard_workflow_name),
+            release_gate_job_name=str(args.release_gate_job_name),
+            issue_upsert_artifact_name=str(args.issue_upsert_artifact_name),
+            ci_per_page=int(args.ci_per_page),
+            guard_per_page=int(args.guard_per_page),
+            trend_runs=int(args.trend_runs),
+            guard_trend_runs=int(args.guard_trend_runs),
+            release_gate_warning_seconds=int(args.release_gate_warning_seconds),
+            warning_sustained_runs=int(args.warning_sustained_runs),
+            fail_on_warning=bool(args.fail_on_warning),
+            ci_runs_file=Path(str(args.ci_runs_file)).expanduser() if args.ci_runs_file else None,
+            ci_jobs_dir=Path(str(args.ci_jobs_dir)).expanduser() if args.ci_jobs_dir else None,
+            guard_runs_file=Path(str(args.guard_runs_file)).expanduser() if args.guard_runs_file else None,
+            guard_upsert_reports_dir=(
+                Path(str(args.guard_upsert_reports_dir)).expanduser() if args.guard_upsert_reports_dir else None
+            ),
+            output_file=Path(str(args.output_file)).expanduser(),
+            markdown_output_file=Path(str(args.markdown_output_file)).expanduser(),
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"[master-reliability-digest] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/master-watchdog-rehearsal-drill.py
+++ b/scripts/master-watchdog-rehearsal-drill.py
@@ -24,7 +24,7 @@ def _utc_now_text() -> str:
 
 def _load_json_file(path: Path) -> dict[str, Any]:
     _expect(path.exists(), f"JSON file not found: {path}")
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
     _expect(isinstance(payload, dict), f"Expected JSON object in file: {path}")
     return payload
 

--- a/scripts/master-watchdog-rehearsal-slo-guard.py
+++ b/scripts/master-watchdog-rehearsal-slo-guard.py
@@ -29,7 +29,7 @@ def _run_gh_api(path: str) -> dict[str, Any]:
 
 def _load_json_file(path: Path) -> dict[str, Any]:
     _expect(path.exists(), f"JSON file not found: {path}")
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
     _expect(isinstance(payload, dict), f"Expected JSON object in file: {path}")
     return payload
 

--- a/scripts/run-master-guard-chain-selftest.ps1
+++ b/scripts/run-master-guard-chain-selftest.ps1
@@ -1,0 +1,24 @@
+param(
+    [string]$Label = "master-guard-chain-selftest",
+    [ValidateSet("master-guard-workflow-health", "master-watchdog-rehearsal-drill-slo")]
+    [string]$SignalId = "master-guard-workflow-health",
+    [string]$GuardReportFile = "artifacts\\master-guard-workflow-health-check.json",
+    [string]$IssueUpsertReportFile = "artifacts\\master-guard-workflow-health-issue-upsert.json",
+    [string]$OutputFile = "artifacts\\master-guard-chain-selftest.json"
+)
+
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptDir "..")
+$scriptPath = Join-Path $repoRoot "scripts\\master-guard-chain-selftest.py"
+
+$args = @(
+    $scriptPath,
+    "--label", $Label,
+    "--signal-id", $SignalId,
+    "--guard-report-file", $GuardReportFile,
+    "--issue-upsert-report-file", $IssueUpsertReportFile,
+    "--output-file", $OutputFile
+)
+
+& python @args

--- a/scripts/run-master-reliability-digest.ps1
+++ b/scripts/run-master-reliability-digest.ps1
@@ -1,0 +1,55 @@
+param(
+    [string]$Label = "master-reliability-digest",
+    [string]$Repo = "donatomaurizio99-collab/GOC",
+    [string]$Branch = "master",
+    [int]$CiPerPage = 30,
+    [int]$GuardPerPage = 30,
+    [int]$TrendRuns = 10,
+    [int]$GuardTrendRuns = 10,
+    [int]$ReleaseGateWarningSeconds = 540,
+    [int]$WarningSustainedRuns = 3,
+    [string]$CiRunsFile = "",
+    [string]$CiJobsDir = "",
+    [string]$GuardRunsFile = "",
+    [string]$GuardUpsertReportsDir = "",
+    [string]$OutputFile = "artifacts\\master-reliability-digest.json",
+    [string]$MarkdownOutputFile = "artifacts\\master-reliability-digest.md",
+    [switch]$FailOnWarning
+)
+
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptDir "..")
+$scriptPath = Join-Path $repoRoot "scripts\\master-reliability-digest.py"
+
+$args = @(
+    $scriptPath,
+    "--label", $Label,
+    "--repo", $Repo,
+    "--branch", $Branch,
+    "--ci-per-page", [string]$CiPerPage,
+    "--guard-per-page", [string]$GuardPerPage,
+    "--trend-runs", [string]$TrendRuns,
+    "--guard-trend-runs", [string]$GuardTrendRuns,
+    "--release-gate-warning-seconds", [string]$ReleaseGateWarningSeconds,
+    "--warning-sustained-runs", [string]$WarningSustainedRuns,
+    "--output-file", $OutputFile,
+    "--markdown-output-file", $MarkdownOutputFile
+)
+if ($CiRunsFile) {
+    $args += @("--ci-runs-file", $CiRunsFile)
+}
+if ($CiJobsDir) {
+    $args += @("--ci-jobs-dir", $CiJobsDir)
+}
+if ($GuardRunsFile) {
+    $args += @("--guard-runs-file", $GuardRunsFile)
+}
+if ($GuardUpsertReportsDir) {
+    $args += @("--guard-upsert-reports-dir", $GuardUpsertReportsDir)
+}
+if ($FailOnWarning) {
+    $args += "--fail-on-warning"
+}
+
+& python @args

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -12460,6 +12460,7 @@ def test_241_master_guard_workflow_health_workflow_wrapper_and_docs_wiring():
     wrapper = (project_root / "scripts" / "run-master-guard-workflow-health-check.ps1").read_text(
         encoding="utf-8"
     )
+    selftest_wrapper = (project_root / "scripts" / "run-master-guard-chain-selftest.ps1").read_text(encoding="utf-8")
     readme = (project_root / "README.md").read_text(encoding="utf-8")
 
     assert "name: Master Guard Workflow Health" in workflow
@@ -12467,7 +12468,10 @@ def test_241_master_guard_workflow_health_workflow_wrapper_and_docs_wiring():
     assert ".\\scripts\\run-master-guard-workflow-health-check.ps1" in workflow
     assert "master-guard-workflow-health-check.json" in workflow
     assert "master-guard-workflow-health-issue-upsert.json" in workflow
+    assert "master-guard-workflow-health-selftest.json" in workflow
     assert "master-guard-workflow-health" in workflow
+    assert "active_comment_cooldown" in workflow
+    assert ".\\scripts\\run-master-guard-chain-selftest.ps1" in workflow
 
     assert "--lookback-hours" in wrapper
     assert "--per-page" in wrapper
@@ -12475,12 +12479,17 @@ def test_241_master_guard_workflow_health_workflow_wrapper_and_docs_wiring():
     assert "--fixtures-file" in wrapper
     assert "--contract-workflow-files" in wrapper
     assert "master-guard-workflow-health-check.py" in wrapper
+    assert "master-guard-chain-selftest.py" in selftest_wrapper
+    assert "--signal-id" in selftest_wrapper
+    assert "--guard-report-file" in selftest_wrapper
+    assert "--issue-upsert-report-file" in selftest_wrapper
 
     assert "[master-guard-workflow-health.yml]" in readme
     assert "guard-workflow health watchdog" in readme
     assert "coverage contract" in readme
     assert "per-degraded-workflow diagnostics" in readme
     assert "master-watchdog-rehearsal-slo-guard.yml" in readme
+    assert "run-master-guard-chain-selftest.ps1" in readme
     assert "run-master-guard-workflow-health-check.ps1" in readme
 
 
@@ -12888,6 +12897,8 @@ def test_246_master_watchdog_rehearsal_slo_guard_workflow_wrapper_and_docs_wirin
     assert ".\\scripts\\run-master-watchdog-rehearsal-slo-guard.ps1" in workflow
     assert "master-watchdog-rehearsal-slo-guard.json" in workflow
     assert "master-watchdog-rehearsal-slo-guard-issue-upsert.json" in workflow
+    assert "master-watchdog-rehearsal-slo-guard-selftest.json" in workflow
+    assert ".\\scripts\\run-master-guard-chain-selftest.ps1" in workflow
     assert "master-watchdog-rehearsal-drill-slo" in workflow
 
     assert "master-watchdog-rehearsal-slo-guard.py" in wrapper
@@ -12898,6 +12909,7 @@ def test_246_master_watchdog_rehearsal_slo_guard_workflow_wrapper_and_docs_wirin
     assert "AllowBreach" in wrapper
 
     assert "master-watchdog-rehearsal-slo-guard.yml" in readme
+    assert "master-reliability-digest.yml" in readme
     assert "stale`/`failed` reason" in readme
 
 
@@ -13017,5 +13029,387 @@ def test_248_master_watchdog_rehearsal_slo_guard_detects_failed_breach():
     assert payload["decision"]["watchdog_rehearsal_slo_breached"] is True
     assert payload["decision"]["breach_reason"] == "failed"
     assert payload["latest_run"]["run_id"] == 771002
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_248b_master_watchdog_rehearsal_slo_guard_accepts_bom_runs_fixture():
+    workspace = _local_test_dir("pytest-master-watchdog-rehearsal-slo-guard-bom").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    runs_file = workspace / "runs-bom.json"
+
+    payload_text = json.dumps(
+        {
+            "workflow_runs": [
+                {
+                    "id": 771003,
+                    "status": "completed",
+                    "conclusion": "success",
+                    "updated_at": "2026-04-18T11:00:00Z",
+                    "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/771003",
+                }
+            ]
+        },
+        ensure_ascii=True,
+        sort_keys=True,
+    )
+    runs_file.write_bytes(("\ufeff" + payload_text).encode("utf-8"))
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "master-watchdog-rehearsal-slo-guard.py"),
+        "--label",
+        "pytest-master-watchdog-rehearsal-slo-guard-bom",
+        "--repo",
+        "donatomaurizio99-collab/GOC",
+        "--branch",
+        "master",
+        "--workflow-name",
+        "Master Watchdog Rehearsal Drill",
+        "--max-age-hours",
+        "192",
+        "--runs-file",
+        str(runs_file.resolve()),
+        "--now-utc",
+        "2026-04-18T12:00:00Z",
+        "--output-file",
+        str((workspace / "master-watchdog-rehearsal-slo-guard.json").resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    parsed = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert parsed["success"] is True
+    assert parsed["decision"]["watchdog_rehearsal_slo_breached"] is False
+    assert parsed["latest_run"]["run_id"] == 771003
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_249_master_guard_chain_selftest_verifies_signal_chain():
+    workspace = _local_test_dir("pytest-master-guard-chain-selftest").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    guard_report_file = workspace / "master-guard-workflow-health-check.json"
+    issue_upsert_report_file = workspace / "master-guard-workflow-health-issue-upsert.json"
+    output_file = workspace / "master-guard-workflow-health-selftest.json"
+
+    guard_report_file.write_text(
+        json.dumps(
+            {
+                "label": "pytest-guard-health",
+                "decision": {
+                    "guard_workflow_health_degraded": True,
+                    "recommended_action": "guard_workflow_health_degraded",
+                },
+                "generated_at_utc": "2026-04-18T04:00:00Z",
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    issue_upsert_report_file.write_text(
+        json.dumps(
+            {
+                "label": "pytest-guard-health-upsert",
+                "success": True,
+                "config": {
+                    "signal_id": "master-guard-workflow-health",
+                    "report_file": str(guard_report_file.resolve()),
+                },
+                "metrics": {
+                    "immediate_action_lines_total": 3,
+                    "active_comment_suppressed_total": 1,
+                },
+                "decision": {
+                    "alert_triggered": True,
+                    "issue_action": "commented",
+                },
+                "actions": [
+                    {
+                        "action": "comment_issue",
+                        "issue_number": 123,
+                    }
+                ],
+                "generated_at_utc": "2026-04-18T04:05:00Z",
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "master-guard-chain-selftest.py"),
+        "--label",
+        "pytest-master-guard-chain-selftest",
+        "--signal-id",
+        "master-guard-workflow-health",
+        "--guard-report-file",
+        str(guard_report_file.resolve()),
+        "--issue-upsert-report-file",
+        str(issue_upsert_report_file.resolve()),
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["decision"]["signal_chain_consistent"] is True
+    assert payload["decision"]["expected_alert_triggered"] is True
+    assert payload["decision"]["issue_alert_triggered"] is True
+    assert payload["decision"]["issue_action"] == "commented"
+    assert output_file.exists()
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_250_master_reliability_digest_workflow_wrapper_and_docs_wiring():
+    project_root = Path(__file__).resolve().parents[1]
+    workflow = (project_root / ".github" / "workflows" / "master-reliability-digest.yml").read_text(encoding="utf-8")
+    wrapper = (project_root / "scripts" / "run-master-reliability-digest.ps1").read_text(encoding="utf-8")
+    readme = (project_root / "README.md").read_text(encoding="utf-8")
+
+    assert "name: Master Reliability Digest" in workflow
+    assert 'cron: "20 6 * * 1"' in workflow
+    assert ".\\scripts\\run-master-reliability-digest.ps1" in workflow
+    assert "master-reliability-digest.json" in workflow
+    assert "master-reliability-digest.md" in workflow
+    assert "master-reliability-digest" in workflow
+
+    assert "master-reliability-digest.py" in wrapper
+    assert "--release-gate-warning-seconds" in wrapper
+    assert "--warning-sustained-runs" in wrapper
+    assert "--guard-upsert-reports-dir" in wrapper
+    assert "MarkdownOutputFile" in wrapper
+
+    assert "master-reliability-digest.yml" in readme
+    assert "run-master-reliability-digest.ps1" in readme
+    assert "trend digest" in readme
+
+
+def test_251_master_reliability_digest_computes_trends_from_fixtures():
+    workspace = _local_test_dir("pytest-master-reliability-digest").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    ci_runs_file = workspace / "ci-runs.json"
+    ci_jobs_dir = workspace / "ci-jobs"
+    guard_runs_file = workspace / "guard-runs.json"
+    guard_upsert_dir = workspace / "guard-upsert"
+    output_file = workspace / "master-reliability-digest.json"
+    markdown_output_file = workspace / "master-reliability-digest.md"
+
+    ci_jobs_dir.mkdir(parents=True, exist_ok=True)
+    guard_upsert_dir.mkdir(parents=True, exist_ok=True)
+
+    ci_runs_file.write_text(
+        json.dumps(
+            {
+                "workflow_runs": [
+                    {
+                        "id": 8801,
+                        "updated_at": "2026-04-18T04:00:00Z",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/8801",
+                    },
+                    {
+                        "id": 8802,
+                        "updated_at": "2026-04-18T03:00:00Z",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/8802",
+                    },
+                    {
+                        "id": 8803,
+                        "updated_at": "2026-04-18T02:00:00Z",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/8803",
+                    },
+                ]
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (ci_jobs_dir / "8801.json").write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "name": "Release Gate (Windows)",
+                        "started_at": "2026-04-18T04:00:00Z",
+                        "completed_at": "2026-04-18T04:10:20Z",
+                    }
+                ]
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (ci_jobs_dir / "8802.json").write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "name": "Release Gate (Windows)",
+                        "started_at": "2026-04-18T03:00:00Z",
+                        "completed_at": "2026-04-18T03:10:05Z",
+                    }
+                ]
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (ci_jobs_dir / "8803.json").write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "name": "Release Gate (Windows)",
+                        "started_at": "2026-04-18T02:00:00Z",
+                        "completed_at": "2026-04-18T02:08:20Z",
+                    }
+                ]
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    guard_runs_file.write_text(
+        json.dumps(
+            {
+                "workflow_runs": [
+                    {
+                        "id": 9901,
+                        "updated_at": "2026-04-18T03:40:00Z",
+                        "status": "completed",
+                        "conclusion": "failure",
+                        "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/9901",
+                    },
+                    {
+                        "id": 9902,
+                        "updated_at": "2026-04-18T02:40:00Z",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/9902",
+                    },
+                    {
+                        "id": 9903,
+                        "updated_at": "2026-04-18T01:40:00Z",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/9903",
+                    },
+                ]
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (guard_upsert_dir / "9901.json").write_text(
+        json.dumps(
+            {
+                "metrics": {"active_comment_suppressed_total": 2},
+                "decision": {"issue_action": "comment_suppressed_cooldown", "alert_triggered": True},
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (guard_upsert_dir / "9902.json").write_text(
+        json.dumps(
+            {
+                "metrics": {"active_comment_suppressed_total": 1},
+                "decision": {"issue_action": "commented", "alert_triggered": True},
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (guard_upsert_dir / "9903.json").write_text(
+        json.dumps(
+            {
+                "metrics": {"active_comment_suppressed_total": 0},
+                "decision": {"issue_action": "none", "alert_triggered": False},
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "master-reliability-digest.py"),
+        "--label",
+        "pytest-master-reliability-digest",
+        "--repo",
+        "donatomaurizio99-collab/GOC",
+        "--branch",
+        "master",
+        "--ci-runs-file",
+        str(ci_runs_file.resolve()),
+        "--ci-jobs-dir",
+        str(ci_jobs_dir.resolve()),
+        "--guard-runs-file",
+        str(guard_runs_file.resolve()),
+        "--guard-upsert-reports-dir",
+        str(guard_upsert_dir.resolve()),
+        "--trend-runs",
+        "3",
+        "--guard-trend-runs",
+        "3",
+        "--release-gate-warning-seconds",
+        "540",
+        "--warning-sustained-runs",
+        "2",
+        "--output-file",
+        str(output_file.resolve()),
+        "--markdown-output-file",
+        str(markdown_output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["decision"]["release_gate_warning_triggered"] is True
+    assert payload["metrics"]["release_gate_consecutive_over_threshold"] == 2
+    assert payload["metrics"]["guard_non_success_total"] == 1
+    assert payload["metrics"]["active_comment_suppressed_total_sum"] == 3
+    assert payload["metrics"]["upsert_artifacts_missing_total"] == 0
+    assert output_file.exists()
+    assert markdown_output_file.exists()
+
+    markdown = markdown_output_file.read_text(encoding="utf-8")
+    assert "# Master Reliability Digest" in markdown
+    assert "Release Gate Runtime Trend" in markdown
+    assert "Guard Workflow Degradations" in markdown
+    assert "active_comment_suppressed_total" in markdown
 
     shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
## Summary
- harden guard JSON loading for BOM-encoded fixtures by switching relevant guard loaders to `utf-8-sig`
- add guard-chain selftest (`master-guard-chain-selftest.py` + wrapper) and wire it into nightly guard workflows so each run verifies report -> issue-upsert consistency end-to-end
- add weekly `master-reliability-digest.yml` with script/wrapper to publish trend digest (Release Gate runtime, guard degradations, active-comment suppression totals) as JSON + Markdown summary artifact
- update README and targeted tests for all new wiring/behavior

## Validation
- `python -m py_compile scripts\\master-watchdog-rehearsal-slo-guard.py scripts\\master-watchdog-rehearsal-drill.py scripts\\master-guard-workflow-health-check.py scripts\\master-guard-chain-selftest.py scripts\\master-reliability-digest.py tests\\test_goal_ops.py`
- `python -m pytest -q tests\\test_goal_ops.py -k "test_231 or test_240 or test_241 or test_242 or test_242b or test_243 or test_244 or test_245 or test_246 or test_247 or test_248 or test_248b or test_249 or test_250 or test_251"`
- `python .\\scripts\\p0-runbook-contract-check.py --label local-guard-bom-selftest-reliability-digest --project-root .`
- `./scripts/run-master-guard-chain-selftest.ps1` (manual fixture sanity check)
- `./scripts/run-master-reliability-digest.ps1` (manual fixture sanity check)
