### PR TITLE
Stage: guard burn-in check + production readiness gate + Node24 hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   release-gate-windows:
     name: Release Gate (Windows)

--- a/.github/workflows/master-branch-protection-drift-guard.yml
+++ b/.github/workflows/master-branch-protection-drift-guard.yml
@@ -14,6 +14,9 @@ on:
         required: false
         default: "2"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   issues: write

--- a/.github/workflows/master-guard-burnin-check.yml
+++ b/.github/workflows/master-guard-burnin-check.yml
@@ -1,0 +1,81 @@
+name: Master Guard Burn-in Check
+
+on:
+  schedule:
+    - cron: "40 5 * * *"
+  workflow_dispatch:
+    inputs:
+      per_page:
+        description: "Maximum completed runs fetched per guarded workflow"
+        required: false
+        default: "20"
+      required_successful_runs:
+        description: "Required successful completed runs for nightly guard workflows"
+        required: false
+        default: "3"
+      digest_required_successful_runs:
+        description: "Required successful completed runs for weekly reliability digest workflow"
+        required: false
+        default: "1"
+      drill_required_successful_runs:
+        description: "Required successful completed runs for weekly watchdog rehearsal drill workflow"
+        required: false
+        default: "1"
+      allow_degraded:
+        description: "Do not fail workflow when guard burn-in requirements are not met"
+        required: false
+        default: "false"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  guard-burnin-check:
+    name: Guard Burn-in Check
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Run guard burn-in check
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_FULL: ${{ github.repository }}
+          PER_PAGE: ${{ github.event.inputs.per_page || '20' }}
+          REQUIRED_SUCCESSFUL_RUNS: ${{ github.event.inputs.required_successful_runs || '3' }}
+          DIGEST_REQUIRED_SUCCESSFUL_RUNS: ${{ github.event.inputs.digest_required_successful_runs || '1' }}
+          DRILL_REQUIRED_SUCCESSFUL_RUNS: ${{ github.event.inputs.drill_required_successful_runs || '1' }}
+          ALLOW_DEGRADED: ${{ github.event.inputs.allow_degraded || 'false' }}
+        run: |
+          $arguments = @(
+            "-Repo", "$env:REPO_FULL",
+            "-PerPage", "$env:PER_PAGE",
+            "-RequiredSuccessfulRuns", "$env:REQUIRED_SUCCESSFUL_RUNS",
+            "-DigestRequiredSuccessfulRuns", "$env:DIGEST_REQUIRED_SUCCESSFUL_RUNS",
+            "-DrillRequiredSuccessfulRuns", "$env:DRILL_REQUIRED_SUCCESSFUL_RUNS",
+            "-OutputFile", "artifacts\master-guard-burnin-check.json"
+          )
+          if ($env:ALLOW_DEGRADED -eq "true") {
+            $arguments += "-AllowDegraded"
+          }
+          .\scripts\run-master-guard-burnin-check.ps1 @arguments
+
+      - name: Upload guard burn-in report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: master-guard-burnin-check
+          path: artifacts/master-guard-burnin-check.json
+          if-no-files-found: error

--- a/.github/workflows/master-guard-workflow-health.yml
+++ b/.github/workflows/master-guard-workflow-health.yml
@@ -26,6 +26,9 @@ on:
         required: false
         default: "3"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   issues: write

--- a/.github/workflows/master-production-readiness-gate.yml
+++ b/.github/workflows/master-production-readiness-gate.yml
@@ -1,0 +1,159 @@
+name: Master Production Readiness Gate
+
+on:
+  schedule:
+    - cron: "55 5 * * *"
+  workflow_dispatch:
+    inputs:
+      required_checks_lookback_hours:
+        description: "Lookback window (hours) for required-check integrity report"
+        required: false
+        default: "24"
+      required_checks_per_page:
+        description: "Maximum completed CI runs fetched for required-check integrity report"
+        required: false
+        default: "100"
+      guard_health_lookback_hours:
+        description: "Lookback window (hours) for guard-workflow health report"
+        required: false
+        default: "30"
+      guard_health_per_page:
+        description: "Maximum completed runs fetched per guard workflow"
+        required: false
+        default: "50"
+      burnin_per_page:
+        description: "Maximum completed runs fetched per burn-in workflow"
+        required: false
+        default: "20"
+      burnin_required_successful_runs:
+        description: "Required successful completed runs for nightly guard workflows"
+        required: false
+        default: "3"
+      burnin_digest_required_successful_runs:
+        description: "Required successful completed runs for weekly reliability digest workflow"
+        required: false
+        default: "1"
+      burnin_drill_required_successful_runs:
+        description: "Required successful completed runs for weekly watchdog rehearsal drill workflow"
+        required: false
+        default: "1"
+      allow_not_ready:
+        description: "Do not fail workflow when production-readiness criteria are not met"
+        required: false
+        default: "false"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  production-readiness-gate:
+    name: Production Readiness Gate
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Build required-check integrity report
+        continue-on-error: true
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUIRED_CHECKS_LOOKBACK_HOURS: ${{ github.event.inputs.required_checks_lookback_hours || '24' }}
+          REQUIRED_CHECKS_PER_PAGE: ${{ github.event.inputs.required_checks_per_page || '100' }}
+        run: |
+          .\scripts\run-master-required-checks-24h-report.ps1 `
+            -LookbackHours "$env:REQUIRED_CHECKS_LOOKBACK_HOURS" `
+            -PerPage "$env:REQUIRED_CHECKS_PER_PAGE" `
+            -AllowNonGreen `
+            -OutputFile "artifacts\master-required-checks-24h-report-readiness.json"
+
+      - name: Build branch-protection integrity report
+        continue-on-error: true
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          .\scripts\run-master-branch-protection-drift-guard.ps1 `
+            -AllowDrift `
+            -OutputFile "artifacts\master-branch-protection-drift-guard-readiness.json"
+
+      - name: Build guard-workflow health report
+        continue-on-error: true
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GUARD_HEALTH_LOOKBACK_HOURS: ${{ github.event.inputs.guard_health_lookback_hours || '30' }}
+          GUARD_HEALTH_PER_PAGE: ${{ github.event.inputs.guard_health_per_page || '50' }}
+        run: |
+          .\scripts\run-master-guard-workflow-health-check.ps1 `
+            -LookbackHours "$env:GUARD_HEALTH_LOOKBACK_HOURS" `
+            -PerPage "$env:GUARD_HEALTH_PER_PAGE" `
+            -AllowDegraded `
+            -OutputFile "artifacts\master-guard-workflow-health-check-readiness.json"
+
+      - name: Build guard burn-in report
+        continue-on-error: true
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BURNIN_PER_PAGE: ${{ github.event.inputs.burnin_per_page || '20' }}
+          BURNIN_REQUIRED_SUCCESSFUL_RUNS: ${{ github.event.inputs.burnin_required_successful_runs || '3' }}
+          BURNIN_DIGEST_REQUIRED_SUCCESSFUL_RUNS: ${{ github.event.inputs.burnin_digest_required_successful_runs || '1' }}
+          BURNIN_DRILL_REQUIRED_SUCCESSFUL_RUNS: ${{ github.event.inputs.burnin_drill_required_successful_runs || '1' }}
+        run: |
+          .\scripts\run-master-guard-burnin-check.ps1 `
+            -PerPage "$env:BURNIN_PER_PAGE" `
+            -RequiredSuccessfulRuns "$env:BURNIN_REQUIRED_SUCCESSFUL_RUNS" `
+            -DigestRequiredSuccessfulRuns "$env:BURNIN_DIGEST_REQUIRED_SUCCESSFUL_RUNS" `
+            -DrillRequiredSuccessfulRuns "$env:BURNIN_DRILL_REQUIRED_SUCCESSFUL_RUNS" `
+            -AllowDegraded `
+            -OutputFile "artifacts\master-guard-burnin-check-readiness.json"
+
+      - name: Evaluate production readiness gate
+        if: always()
+        shell: pwsh
+        env:
+          ALLOW_NOT_READY: ${{ github.event.inputs.allow_not_ready || 'false' }}
+        run: |
+          $arguments = @(
+            "-RequiredChecksReportFile", "artifacts\master-required-checks-24h-report-readiness.json",
+            "-BranchProtectionReportFile", "artifacts\master-branch-protection-drift-guard-readiness.json",
+            "-GuardHealthReportFile", "artifacts\master-guard-workflow-health-check-readiness.json",
+            "-GuardBurninReportFile", "artifacts\master-guard-burnin-check-readiness.json",
+            "-OutputFile", "artifacts\master-production-readiness-gate.json"
+          )
+          if ($env:ALLOW_NOT_READY -eq "true") {
+            $arguments += "-AllowNotReady"
+          }
+          .\scripts\run-master-production-readiness-gate.ps1 @arguments
+
+      - name: Publish production readiness summary
+        if: always()
+        shell: pwsh
+        run: |
+          if (Test-Path "artifacts\master-production-readiness-gate.json") {
+            $payload = Get-Content "artifacts\master-production-readiness-gate.json" -Raw | ConvertFrom-Json
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "## Master Production Readiness Gate"
+            foreach ($line in $payload.summary_lines) {
+              Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- $line"
+            }
+          }
+
+      - name: Upload production readiness gate report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: master-production-readiness-gate
+          path: artifacts/master-production-readiness-gate.json
+          if-no-files-found: error

--- a/.github/workflows/master-release-gate-runtime-early-warning.yml
+++ b/.github/workflows/master-release-gate-runtime-early-warning.yml
@@ -34,6 +34,9 @@ on:
         required: false
         default: "72"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   issues: write

--- a/.github/workflows/master-reliability-digest-guard.yml
+++ b/.github/workflows/master-reliability-digest-guard.yml
@@ -26,6 +26,9 @@ on:
         required: false
         default: "3"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   issues: write

--- a/.github/workflows/master-reliability-digest.yml
+++ b/.github/workflows/master-reliability-digest.yml
@@ -42,6 +42,9 @@ on:
         required: false
         default: "3"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   actions: read

--- a/.github/workflows/master-required-checks-24h.yml
+++ b/.github/workflows/master-required-checks-24h.yml
@@ -22,6 +22,9 @@ on:
         required: false
         default: "false"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
 

--- a/.github/workflows/master-watchdog-rehearsal-drill.yml
+++ b/.github/workflows/master-watchdog-rehearsal-drill.yml
@@ -10,6 +10,9 @@ on:
         required: false
         default: "master"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
 

--- a/.github/workflows/master-watchdog-rehearsal-slo-guard.yml
+++ b/.github/workflows/master-watchdog-rehearsal-slo-guard.yml
@@ -26,6 +26,9 @@ on:
         required: false
         default: "3"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   issues: write

--- a/README.md
+++ b/README.md
@@ -955,6 +955,9 @@ Nightly [master-watchdog-rehearsal-slo-guard.yml](.github/workflows/master-watch
 Nightly release-gate runtime early warning now flags sustained runtime slowdown (default: 3 consecutive runs >= 540s) before it escalates into flaky failures, and escalates when an active runtime warning issue stays open beyond the alert-age SLO (default: 72h).
 Nightly drift/warning workflows now upsert deduplicated GitHub issues (labels: `ci-drift` + signal label), enforce the invariant of at most one open issue per signal, reset recovery streak on active alerts, and auto-close recovered issues after 2 healthy nightly runs (configurable threshold). Active-alert comments are cooldown-throttled for unchanged failure states (default every 3 runs), while issue bodies continue to refresh each run. The runtime alert-age SLO escalation issue now carries a mandatory parent runtime-warning reference in its issue body and closes immediately when parent-coupled escalation criteria are no longer met.
 Weekly [master-reliability-digest.yml](.github/workflows/master-reliability-digest.yml) publishes a trend digest (Release Gate runtime, guard degradations, active-comment suppression totals) as artifact + workflow summary for proactive reliability tracking and feeds the deduped warning signal `master-reliability-digest-warning`.
+Nightly [master-guard-burnin-check.yml](.github/workflows/master-guard-burnin-check.yml) enforces burn-in health for master guard/digest workflows by requiring recent successful runs with required artifacts (including weekly digest/rehearsal bootstrap windows).
+Daily [master-production-readiness-gate.yml](.github/workflows/master-production-readiness-gate.yml) aggregates required-check integrity, branch-protection drift, guard-workflow health, and guard burn-in into one hard go/no-go production readiness gate.
+Core CI and master guard/reliability workflows now set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to proactively avoid Node-20 action-runtime deprecation drift.
 
 Release Gate workflow artifact includes `p0-release-evidence-bundle` (manifest + copied evidence reports, including safe-mode/A11y/runtime/flake stage outputs, + closure report), Stage-L/M evidence artifacts (`release-gate-evidence-freshness-release-gate.json`, `release-gate-evidence-hash-manifest-release-gate.json`, `release-gate-evidence-manifest-release-gate.json`), Stage-N/O timing-history artifacts (`release-gate-step-timing-schema-release-gate.json`, `release-gate-performance-history-release-gate.json`), Stage-K/P artifacts (`release-gate-step-timings-release-gate.json`, `release-gate-performance-budget-release-gate.json`, `release-gate-stability-final-readiness-release-gate.json`), Stage-Q/R readiness artifacts (`release-gate-staging-soak-readiness-release-gate.json`, `release-gate-rc-canary-rollout-release-gate.json`), Stage-S/T readiness artifacts (`release-gate-evidence-lineage-release-gate.json`, `release-gate-production-readiness-certification-release-gate.json`), Stage-U/AB expanded readiness artifacts (`release-gate-slo-burn-rate-v2-release-gate.json`, `release-gate-deploy-rehearsal-release-gate.json`, `release-gate-chaos-matrix-continuous-release-gate.json`, `release-gate-supply-chain-artifact-trust-release-gate.json`, `release-gate-operations-handoff-readiness-release-gate.json`, `release-gate-evidence-attestation-release-gate.json`, `release-gate-release-train-readiness-release-gate.json`, `release-gate-production-final-attestation-release-gate.json`), Stage-AC/AJ cutover-to-sustainability artifacts (`release-gate-production-cutover-readiness-release-gate.json`, `release-gate-hypercare-activation-release-gate.json`, `release-gate-rollback-trigger-integrity-release-gate.json`, `release-gate-post-cutover-finalization-release-gate.json`, `release-gate-post-release-watch-release-gate.json`, `release-gate-steady-state-certification-release-gate.json`, `release-gate-post-release-continuity-release-gate.json`, `release-gate-production-sustainability-certification-release-gate.json`), and registry attestation artifacts (`release-gate-registry-sync-ci.json`, `release-gate-registry-attestation-gate-ci.json`).
 
@@ -988,6 +991,12 @@ Weekly master reliability digest workflow:
 Nightly master reliability digest guard workflow:
 [master-reliability-digest-guard.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/master-reliability-digest-guard.yml)
 
+Nightly master guard burn-in workflow:
+[master-guard-burnin-check.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/master-guard-burnin-check.yml)
+
+Daily master production readiness gate workflow:
+[master-production-readiness-gate.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/master-production-readiness-gate.yml)
+
 Nightly disaster-recovery rehearsal workflow:
 [disaster-recovery-rehearsal.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/disaster-recovery-rehearsal.yml)
 
@@ -1016,6 +1025,20 @@ Local guard-workflow health watchdog command:
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-master-guard-workflow-health-check.ps1 -LookbackHours 30 -PerPage 50
+```
+
+Local guard burn-in check command:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-master-guard-burnin-check.ps1 -PerPage 20 -RequiredSuccessfulRuns 3 -DigestRequiredSuccessfulRuns 1 -DrillRequiredSuccessfulRuns 1
+```
+
+Local production readiness gate command:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-master-production-readiness-gate.ps1 -RequiredChecksReportFile artifacts\master-required-checks-24h-report-readiness.json -BranchProtectionReportFile artifacts\master-branch-protection-drift-guard-readiness.json -GuardHealthReportFile artifacts\master-guard-workflow-health-check-readiness.json -GuardBurninReportFile artifacts\master-guard-burnin-check-readiness.json
 ```
 
 Local guard-chain selftest command:

--- a/scripts/master-guard-burnin-check.py
+++ b/scripts/master-guard-burnin-check.py
@@ -1,0 +1,576 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_GUARD_BURNIN_WORKFLOW_SPECS = [
+    {
+        "workflow_file": "master-required-checks-24h.yml",
+        "workflow_name": "Master Required Checks 24h",
+        "required_artifacts": ["master-required-checks-24h-report"],
+    },
+    {
+        "workflow_file": "master-branch-protection-drift-guard.yml",
+        "workflow_name": "Master Branch Protection Drift Guard",
+        "required_artifacts": [
+            "master-branch-protection-drift-guard",
+            "master-branch-protection-drift-issue-upsert",
+        ],
+    },
+    {
+        "workflow_file": "master-release-gate-runtime-early-warning.yml",
+        "workflow_name": "Master Release Gate Runtime Early Warning",
+        "required_artifacts": [
+            "release-gate-runtime-early-warning",
+            "release-gate-runtime-early-warning-issue-upsert",
+            "release-gate-runtime-alert-age-slo-issue-upsert",
+        ],
+    },
+    {
+        "workflow_file": "master-guard-workflow-health.yml",
+        "workflow_name": "Master Guard Workflow Health",
+        "required_artifacts": [
+            "master-guard-workflow-health-check",
+            "master-guard-workflow-health-issue-upsert",
+            "master-guard-workflow-health-selftest",
+        ],
+    },
+    {
+        "workflow_file": "master-watchdog-rehearsal-slo-guard.yml",
+        "workflow_name": "Master Watchdog Rehearsal SLO Guard",
+        "required_artifacts": [
+            "master-watchdog-rehearsal-slo-guard",
+            "master-watchdog-rehearsal-slo-guard-issue-upsert",
+            "master-watchdog-rehearsal-slo-guard-selftest",
+        ],
+    },
+    {
+        "workflow_file": "master-watchdog-rehearsal-drill.yml",
+        "workflow_name": "Master Watchdog Rehearsal Drill",
+        "required_artifacts": [
+            "master-guard-workflow-health-rehearsal-check",
+            "master-guard-workflow-health-rehearsal-issue-upsert",
+            "master-guard-workflow-health-rehearsal-drill",
+        ],
+        "required_successful_runs": 1,
+    },
+    {
+        "workflow_file": "master-reliability-digest.yml",
+        "workflow_name": "Master Reliability Digest",
+        "required_artifacts": [
+            "master-reliability-digest",
+            "master-reliability-digest-warning-issue-upsert",
+        ],
+        "required_successful_runs": 1,
+    },
+    {
+        "workflow_file": "master-reliability-digest-guard.yml",
+        "workflow_name": "Master Reliability Digest Guard",
+        "required_artifacts": [
+            "master-reliability-digest-guard",
+            "master-reliability-digest-guard-issue-upsert",
+            "master-reliability-digest-guard-selftest",
+        ],
+    },
+]
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _run_gh_api(path: str) -> dict[str, Any]:
+    command = ["gh", "api", path]
+    completed = subprocess.run(command, capture_output=True, text=True)
+    _expect(
+        completed.returncode == 0,
+        f"gh api failed ({completed.returncode}) for '{path}': {completed.stderr.strip()}",
+    )
+    payload = json.loads(completed.stdout)
+    _expect(isinstance(payload, dict), f"Expected JSON object from gh api path '{path}'.")
+    return payload
+
+
+def _load_json_file(path: Path) -> dict[str, Any]:
+    _expect(path.exists(), f"JSON file not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    _expect(isinstance(payload, dict), f"Expected JSON object in file: {path}")
+    return payload
+
+
+def _parse_utc_timestamp(value: str) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _format_utc(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _resolve_now_utc(now_utc_text: str | None) -> datetime:
+    if not now_utc_text:
+        return datetime.now(timezone.utc)
+    parsed = _parse_utc_timestamp(now_utc_text)
+    _expect(parsed is not None, f"Invalid --now-utc timestamp: {now_utc_text}")
+    return parsed
+
+
+def _fetch_workflow_id(*, repo: str, workflow_name: str) -> int:
+    payload = _run_gh_api(f"repos/{repo}/actions/workflows?per_page=100")
+    workflows = payload.get("workflows") or []
+    _expect(isinstance(workflows, list), "Invalid workflows payload format.")
+    for workflow in workflows:
+        if not isinstance(workflow, dict):
+            continue
+        if str(workflow.get("name") or "").strip() == workflow_name:
+            workflow_id = int(workflow.get("id") or 0)
+            _expect(workflow_id > 0, f"Workflow '{workflow_name}' has invalid id.")
+            return workflow_id
+    raise RuntimeError(f"Workflow '{workflow_name}' not found in repo '{repo}'.")
+
+
+def _fetch_runs_from_github(
+    *,
+    repo: str,
+    branch: str,
+    workflow_name: str,
+    per_page: int,
+) -> list[dict[str, Any]]:
+    workflow_id = _fetch_workflow_id(repo=repo, workflow_name=workflow_name)
+    payload = _run_gh_api(
+        f"repos/{repo}/actions/workflows/{workflow_id}/runs?branch={branch}&status=completed&per_page={per_page}"
+    )
+    runs = payload.get("workflow_runs") or []
+    _expect(isinstance(runs, list), f"Invalid workflow runs payload for workflow '{workflow_name}'.")
+    return [item for item in runs if isinstance(item, dict)]
+
+
+def _fetch_run_artifacts_from_github(*, repo: str, run_id: int) -> list[dict[str, Any]]:
+    payload = _run_gh_api(f"repos/{repo}/actions/runs/{run_id}/artifacts?per_page=100")
+    artifacts = payload.get("artifacts") or []
+    _expect(isinstance(artifacts, list), f"Invalid artifacts payload for run {run_id}.")
+    return [item for item in artifacts if isinstance(item, dict)]
+
+
+def _load_fixture_runs(*, payload: dict[str, Any], workflow_name: str) -> list[dict[str, Any]]:
+    workflow_runs = payload.get("workflow_runs")
+    if isinstance(workflow_runs, dict):
+        runs = workflow_runs.get(workflow_name) or []
+    elif isinstance(workflow_runs, list):
+        runs = workflow_runs
+    else:
+        runs = payload.get("runs") or []
+    _expect(isinstance(runs, list), f"fixtures.workflow_runs['{workflow_name}'] must be a list when present.")
+    return [item for item in runs if isinstance(item, dict)]
+
+
+def _load_fixture_artifacts(*, payload: dict[str, Any], run_id: int) -> list[dict[str, Any]]:
+    run_artifacts = payload.get("run_artifacts") if isinstance(payload.get("run_artifacts"), dict) else {}
+    entry = run_artifacts.get(str(run_id)) if isinstance(run_artifacts, dict) else None
+    if entry is None:
+        return []
+    if isinstance(entry, dict):
+        artifacts = entry.get("artifacts") or []
+    else:
+        artifacts = entry
+    _expect(isinstance(artifacts, list), f"fixtures.run_artifacts['{run_id}'] must resolve to a list.")
+    return [item for item in artifacts if isinstance(item, dict)]
+
+
+def _extract_artifact_names(artifacts: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
+    available: list[str] = []
+    expired: list[str] = []
+    for artifact in artifacts:
+        name = str(artifact.get("name") or "").strip()
+        if not name:
+            continue
+        if bool(artifact.get("expired")):
+            expired.append(name)
+        else:
+            available.append(name)
+    return sorted(available), sorted(expired)
+
+
+def _normalize_workflow_specs(raw_specs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for index, raw in enumerate(raw_specs):
+        _expect(isinstance(raw, dict), f"workflow spec #{index + 1} must be an object.")
+        workflow_name = str(raw.get("workflow_name") or "").strip()
+        _expect(workflow_name != "", f"workflow spec #{index + 1} missing non-empty 'workflow_name'.")
+        workflow_file = str(raw.get("workflow_file") or "").strip()
+        required_artifacts_raw = raw.get("required_artifacts") or []
+        _expect(
+            isinstance(required_artifacts_raw, list),
+            f"workflow spec '{workflow_name}' field 'required_artifacts' must be a list.",
+        )
+        required_artifacts = sorted(
+            {
+                str(item).strip()
+                for item in required_artifacts_raw
+                if str(item).strip()
+            }
+        )
+        required_successful_runs_raw = raw.get("required_successful_runs")
+        required_successful_runs: int | None = None
+        if required_successful_runs_raw is not None:
+            required_successful_runs = int(required_successful_runs_raw)
+            _expect(
+                required_successful_runs > 0,
+                f"workflow spec '{workflow_name}' required_successful_runs must be > 0 when set.",
+            )
+        normalized.append(
+            {
+                "workflow_name": workflow_name,
+                "workflow_file": workflow_file,
+                "required_artifacts": required_artifacts,
+                "required_successful_runs": required_successful_runs,
+            }
+        )
+    _expect(normalized, "At least one workflow spec must be configured.")
+    return normalized
+
+
+def _load_workflow_specs_file(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    if isinstance(payload, dict):
+        raw_specs = payload.get("workflow_specs") or []
+    else:
+        raw_specs = payload
+    _expect(isinstance(raw_specs, list), "workflow-specs file must be a list or object with 'workflow_specs'.")
+    raw_objects = [item for item in raw_specs if isinstance(item, dict)]
+    _expect(len(raw_objects) == len(raw_specs), "workflow-specs file contains non-object entries.")
+    return _normalize_workflow_specs(raw_objects)
+
+
+def _resolve_required_successful_runs(
+    *,
+    spec: dict[str, Any],
+    required_successful_runs: int,
+    digest_required_successful_runs: int,
+    drill_required_successful_runs: int,
+) -> int:
+    from_spec = spec.get("required_successful_runs")
+    if from_spec is not None:
+        resolved = int(from_spec)
+        _expect(resolved > 0, "resolved required_successful_runs must be > 0.")
+        return resolved
+    workflow_name = str(spec.get("workflow_name") or "")
+    if workflow_name == "Master Reliability Digest":
+        return int(digest_required_successful_runs)
+    if workflow_name == "Master Watchdog Rehearsal Drill":
+        return int(drill_required_successful_runs)
+    return int(required_successful_runs)
+
+
+def _evaluate_workflow_burnin(
+    *,
+    spec: dict[str, Any],
+    runs: list[dict[str, Any]],
+    required_successful_runs: int,
+    load_artifacts_for_run: Any,
+) -> tuple[dict[str, Any], dict[str, int]]:
+    sorted_runs = sorted(
+        runs,
+        key=lambda item: _parse_utc_timestamp(str(item.get("updated_at") or ""))
+        or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
+    considered_runs = sorted_runs[:required_successful_runs]
+    has_sufficient_runs = len(considered_runs) >= required_successful_runs
+    required_artifacts = [str(item) for item in spec.get("required_artifacts") or []]
+
+    run_snapshots: list[dict[str, Any]] = []
+    non_success_runs_total = 0
+    missing_artifacts_total = 0
+    healthy_runs_total = 0
+    for run in considered_runs:
+        run_id = int(run.get("id") or 0)
+        run_status = str(run.get("status") or "")
+        run_conclusion = str(run.get("conclusion") or "")
+        run_updated_at = _parse_utc_timestamp(str(run.get("updated_at") or ""))
+        run_artifacts = load_artifacts_for_run(run_id) if run_id > 0 else []
+        available_artifacts, expired_artifacts = _extract_artifact_names(run_artifacts)
+        missing_required_artifacts = [item for item in required_artifacts if item not in available_artifacts]
+        run_success = run_status == "completed" and run_conclusion == "success"
+        run_healthy = bool(run_success and not missing_required_artifacts)
+        if not run_success:
+            non_success_runs_total += 1
+        if missing_required_artifacts:
+            missing_artifacts_total += len(missing_required_artifacts)
+        if run_healthy:
+            healthy_runs_total += 1
+        run_snapshots.append(
+            {
+                "run_id": run_id,
+                "status": run_status,
+                "conclusion": run_conclusion,
+                "updated_at": str(run.get("updated_at") or ""),
+                "updated_at_parsed_utc": _format_utc(run_updated_at),
+                "url": str(run.get("html_url") or ""),
+                "required_artifacts": required_artifacts,
+                "available_artifacts": available_artifacts,
+                "expired_artifacts": expired_artifacts,
+                "missing_required_artifacts": missing_required_artifacts,
+                "run_healthy": bool(run_healthy),
+            }
+        )
+
+    degraded_reasons: list[str] = []
+    if not has_sufficient_runs:
+        degraded_reasons.append("insufficient_completed_runs")
+    if non_success_runs_total > 0:
+        degraded_reasons.append("non_success_run_in_burnin_window")
+    if missing_artifacts_total > 0:
+        degraded_reasons.append("required_artifacts_missing_in_burnin_window")
+
+    is_healthy = bool(
+        has_sufficient_runs and healthy_runs_total == required_successful_runs and non_success_runs_total == 0
+    )
+    evaluation = {
+        "workflow_name": str(spec.get("workflow_name") or ""),
+        "workflow_file": str(spec.get("workflow_file") or ""),
+        "required_successful_runs": int(required_successful_runs),
+        "required_artifacts": required_artifacts,
+        "runs_total_fetched": int(len(runs)),
+        "burnin_runs_observed": int(len(considered_runs)),
+        "healthy_runs_in_burnin_window": int(healthy_runs_total),
+        "non_success_runs_in_burnin_window": int(non_success_runs_total),
+        "missing_required_artifacts_in_burnin_window": int(missing_artifacts_total),
+        "has_sufficient_runs": bool(has_sufficient_runs),
+        "is_healthy": bool(is_healthy),
+        "degraded_reasons": degraded_reasons,
+        "runs": run_snapshots,
+    }
+    counters = {
+        "non_success_runs_total": int(non_success_runs_total),
+        "missing_required_artifacts_total": int(missing_artifacts_total),
+    }
+    return evaluation, counters
+
+
+def run_guard_burnin_check(
+    *,
+    label: str,
+    repo: str,
+    branch: str,
+    per_page: int,
+    required_successful_runs: int,
+    digest_required_successful_runs: int,
+    drill_required_successful_runs: int,
+    fixtures_file: Path | None,
+    workflow_specs_file: Path | None,
+    now_utc: datetime,
+    allow_degraded: bool,
+    output_file: Path,
+) -> dict[str, Any]:
+    _expect(per_page > 0, "per_page must be > 0.")
+    _expect(required_successful_runs > 0, "required_successful_runs must be > 0.")
+    _expect(digest_required_successful_runs > 0, "digest_required_successful_runs must be > 0.")
+    _expect(drill_required_successful_runs > 0, "drill_required_successful_runs must be > 0.")
+
+    started = time.perf_counter()
+    fixtures_payload = _load_json_file(fixtures_file) if fixtures_file is not None else None
+    workflow_specs = (
+        _load_workflow_specs_file(workflow_specs_file)
+        if workflow_specs_file is not None
+        else _normalize_workflow_specs(DEFAULT_GUARD_BURNIN_WORKFLOW_SPECS)
+    )
+
+    def load_runs_for_workflow(workflow_name: str) -> list[dict[str, Any]]:
+        if fixtures_payload is not None:
+            return _load_fixture_runs(payload=fixtures_payload, workflow_name=workflow_name)
+        return _fetch_runs_from_github(
+            repo=repo,
+            branch=branch,
+            workflow_name=workflow_name,
+            per_page=per_page,
+        )
+
+    def load_artifacts_for_run(run_id: int) -> list[dict[str, Any]]:
+        if fixtures_payload is not None:
+            return _load_fixture_artifacts(payload=fixtures_payload, run_id=run_id)
+        return _fetch_run_artifacts_from_github(repo=repo, run_id=run_id)
+
+    evaluations: list[dict[str, Any]] = []
+    aggregate_non_success_runs_total = 0
+    aggregate_missing_required_artifacts_total = 0
+    for spec in workflow_specs:
+        workflow_name = str(spec.get("workflow_name") or "")
+        resolved_required_runs = _resolve_required_successful_runs(
+            spec=spec,
+            required_successful_runs=required_successful_runs,
+            digest_required_successful_runs=digest_required_successful_runs,
+            drill_required_successful_runs=drill_required_successful_runs,
+        )
+        runs = load_runs_for_workflow(workflow_name)
+        evaluation, counters = _evaluate_workflow_burnin(
+            spec=spec,
+            runs=runs,
+            required_successful_runs=resolved_required_runs,
+            load_artifacts_for_run=load_artifacts_for_run,
+        )
+        evaluations.append(evaluation)
+        aggregate_non_success_runs_total += int(counters["non_success_runs_total"])
+        aggregate_missing_required_artifacts_total += int(counters["missing_required_artifacts_total"])
+
+    degraded_workflows = [item for item in evaluations if not bool(item.get("is_healthy"))]
+    workflows_below_burnin = [item for item in evaluations if not bool(item.get("has_sufficient_runs"))]
+    degraded_workflow_names = [str(item.get("workflow_name") or "") for item in degraded_workflows]
+    runs_evaluated_total = sum(int(item.get("burnin_runs_observed") or 0) for item in evaluations)
+
+    criteria = [
+        {
+            "name": "workflows_configured_for_guard_burnin",
+            "passed": bool(len(workflow_specs) > 0),
+            "details": f"workflow_specs_total={len(workflow_specs)}",
+        },
+        {
+            "name": "guard_burnin_window_healthy",
+            "passed": bool((len(degraded_workflows) == 0) or allow_degraded),
+            "details": (
+                f"degraded_workflows_total={len(degraded_workflows)}, "
+                f"allow_degraded={allow_degraded}"
+            ),
+        },
+    ]
+    failed_criteria = [item for item in criteria if not bool(item.get("passed"))]
+    success = len(failed_criteria) == 0
+
+    report = {
+        "label": label,
+        "success": bool(success),
+        "config": {
+            "repo": repo,
+            "branch": branch,
+            "per_page": int(per_page),
+            "required_successful_runs": int(required_successful_runs),
+            "digest_required_successful_runs": int(digest_required_successful_runs),
+            "drill_required_successful_runs": int(drill_required_successful_runs),
+            "allow_degraded": bool(allow_degraded),
+            "now_utc": _format_utc(now_utc),
+            "fixtures_file": str(fixtures_file) if fixtures_file is not None else None,
+            "workflow_specs_file": str(workflow_specs_file) if workflow_specs_file is not None else None,
+            "workflow_specs": workflow_specs,
+            "output_file": str(output_file),
+        },
+        "metrics": {
+            "workflows_total": int(len(evaluations)),
+            "workflows_healthy_total": int(len(evaluations) - len(degraded_workflows)),
+            "workflows_degraded_total": int(len(degraded_workflows)),
+            "workflows_below_burnin_total": int(len(workflows_below_burnin)),
+            "runs_evaluated_total": int(runs_evaluated_total),
+            "non_success_runs_total": int(aggregate_non_success_runs_total),
+            "missing_required_artifacts_total": int(aggregate_missing_required_artifacts_total),
+            "criteria_failed": int(len(failed_criteria)),
+        },
+        "criteria": criteria,
+        "failed_criteria": failed_criteria,
+        "evaluations": evaluations,
+        "degraded_workflow_names": degraded_workflow_names,
+        "decision": {
+            "guard_burnin_degraded": bool(len(degraded_workflows) > 0),
+            "recommended_action": (
+                "guard_burnin_healthy"
+                if len(degraded_workflows) == 0
+                else "guard_burnin_rehearsal_required"
+            ),
+        },
+        "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "duration_ms": int((time.perf_counter() - started) * 1000),
+    }
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2), encoding="utf-8")
+
+    if not success:
+        raise RuntimeError(f"Master guard burn-in check failed: {json.dumps(report, sort_keys=True)}")
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate burn-in health for master guard/digest workflows by requiring N recent "
+            "successful runs with required artifacts."
+        )
+    )
+    parser.add_argument("--label", default="master-guard-burnin-check")
+    parser.add_argument("--repo", default="donatomaurizio99-collab/GOC")
+    parser.add_argument("--branch", default="master")
+    parser.add_argument("--per-page", type=int, default=20)
+    parser.add_argument("--required-successful-runs", type=int, default=3)
+    parser.add_argument("--digest-required-successful-runs", type=int, default=1)
+    parser.add_argument("--drill-required-successful-runs", type=int, default=1)
+    parser.add_argument("--fixtures-file")
+    parser.add_argument("--workflow-specs-file")
+    parser.add_argument("--now-utc")
+    parser.add_argument("--allow-degraded", action="store_true")
+    parser.add_argument("--output-file", default="artifacts/master-guard-burnin-check.json")
+    args = parser.parse_args(argv)
+
+    if int(args.per_page) <= 0:
+        print("[master-guard-burnin-check] ERROR: --per-page must be > 0.", file=sys.stderr)
+        return 2
+    if int(args.required_successful_runs) <= 0:
+        print("[master-guard-burnin-check] ERROR: --required-successful-runs must be > 0.", file=sys.stderr)
+        return 2
+    if int(args.digest_required_successful_runs) <= 0:
+        print(
+            "[master-guard-burnin-check] ERROR: --digest-required-successful-runs must be > 0.",
+            file=sys.stderr,
+        )
+        return 2
+    if int(args.drill_required_successful_runs) <= 0:
+        print(
+            "[master-guard-burnin-check] ERROR: --drill-required-successful-runs must be > 0.",
+            file=sys.stderr,
+        )
+        return 2
+
+    fixtures_file = Path(str(args.fixtures_file)).expanduser() if args.fixtures_file else None
+    workflow_specs_file = Path(str(args.workflow_specs_file)).expanduser() if args.workflow_specs_file else None
+    output_file = Path(str(args.output_file)).expanduser()
+    try:
+        report = run_guard_burnin_check(
+            label=str(args.label),
+            repo=str(args.repo),
+            branch=str(args.branch),
+            per_page=int(args.per_page),
+            required_successful_runs=int(args.required_successful_runs),
+            digest_required_successful_runs=int(args.digest_required_successful_runs),
+            drill_required_successful_runs=int(args.drill_required_successful_runs),
+            fixtures_file=fixtures_file,
+            workflow_specs_file=workflow_specs_file,
+            now_utc=_resolve_now_utc(args.now_utc),
+            allow_degraded=bool(args.allow_degraded),
+            output_file=output_file,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"[master-guard-burnin-check] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/master-guard-workflow-health-check.py
+++ b/scripts/master-guard-workflow-health-check.py
@@ -51,6 +51,13 @@ DEFAULT_GUARD_WORKFLOW_SPECS = [
         ],
     },
     {
+        "workflow_file": "master-guard-burnin-check.yml",
+        "workflow_name": "Master Guard Burn-in Check",
+        "required_artifacts": [
+            "master-guard-burnin-check",
+        ],
+    },
+    {
         "workflow_file": "master-reliability-digest-guard.yml",
         "workflow_name": "Master Reliability Digest Guard",
         "required_artifacts": [

--- a/scripts/master-production-readiness-gate.py
+++ b/scripts/master-production-readiness-gate.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _load_json_file(path: Path) -> dict[str, Any]:
+    _expect(path.exists(), f"JSON file not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    _expect(isinstance(payload, dict), f"Expected JSON object in file: {path}")
+    return payload
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return int(default)
+
+
+def _safe_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "y", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "n", "off"}:
+            return False
+    return bool(default)
+
+
+def run_production_readiness_gate(
+    *,
+    label: str,
+    required_checks_report_file: Path,
+    branch_protection_report_file: Path,
+    guard_health_report_file: Path,
+    guard_burnin_report_file: Path,
+    allow_not_ready: bool,
+    output_file: Path,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    errors: list[str] = []
+
+    def load(path: Path, key: str) -> dict[str, Any] | None:
+        try:
+            return _load_json_file(path)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"{key}: {exc}")
+            return None
+
+    required_checks_payload = load(required_checks_report_file, "required_checks")
+    branch_protection_payload = load(branch_protection_report_file, "branch_protection")
+    guard_health_payload = load(guard_health_report_file, "guard_health")
+    guard_burnin_payload = load(guard_burnin_report_file, "guard_burnin")
+
+    reports_present = bool(
+        required_checks_payload is not None
+        and branch_protection_payload is not None
+        and guard_health_payload is not None
+        and guard_burnin_payload is not None
+    )
+
+    required_checks_non_green_total = _safe_int(
+        ((required_checks_payload or {}).get("metrics") or {}).get("non_green_runs_total"),
+        0,
+    )
+    required_checks_release_blocked = _safe_bool(
+        ((required_checks_payload or {}).get("decision") or {}).get("release_blocked"),
+        False,
+    )
+    required_checks_green = bool(
+        required_checks_payload is not None
+        and required_checks_non_green_total == 0
+        and not required_checks_release_blocked
+    )
+
+    branch_protection_drift_detected = _safe_bool(
+        ((branch_protection_payload or {}).get("decision") or {}).get("branch_protection_drift_detected"),
+        True,
+    )
+    branch_protection_integrity = bool(
+        branch_protection_payload is not None and not branch_protection_drift_detected
+    )
+
+    guard_workflow_health_degraded = _safe_bool(
+        ((guard_health_payload or {}).get("decision") or {}).get("guard_workflow_health_degraded"),
+        True,
+    )
+    guard_workflow_coverage_contract_ok = _safe_bool(
+        ((guard_health_payload or {}).get("decision") or {}).get("guard_workflow_coverage_contract_ok"),
+        False,
+    )
+    guard_workflow_health_integrity = bool(
+        guard_health_payload is not None
+        and not guard_workflow_health_degraded
+        and guard_workflow_coverage_contract_ok
+    )
+
+    guard_burnin_degraded = _safe_bool(
+        ((guard_burnin_payload or {}).get("decision") or {}).get("guard_burnin_degraded"),
+        True,
+    )
+    guard_burnin_integrity = bool(
+        guard_burnin_payload is not None and not guard_burnin_degraded
+    )
+
+    production_ready = bool(
+        reports_present
+        and required_checks_green
+        and branch_protection_integrity
+        and guard_workflow_health_integrity
+        and guard_burnin_integrity
+    )
+
+    criteria = [
+        {
+            "name": "readiness_reports_present",
+            "passed": bool(reports_present or allow_not_ready),
+            "details": f"reports_present={reports_present}, allow_not_ready={allow_not_ready}",
+        },
+        {
+            "name": "required_checks_integrity",
+            "passed": bool(required_checks_green or allow_not_ready),
+            "details": (
+                f"required_checks_non_green_total={required_checks_non_green_total}, "
+                f"required_checks_release_blocked={required_checks_release_blocked}, "
+                f"allow_not_ready={allow_not_ready}"
+            ),
+        },
+        {
+            "name": "branch_protection_integrity",
+            "passed": bool(branch_protection_integrity or allow_not_ready),
+            "details": (
+                f"branch_protection_drift_detected={branch_protection_drift_detected}, "
+                f"allow_not_ready={allow_not_ready}"
+            ),
+        },
+        {
+            "name": "guard_workflow_health_integrity",
+            "passed": bool(guard_workflow_health_integrity or allow_not_ready),
+            "details": (
+                f"guard_workflow_health_degraded={guard_workflow_health_degraded}, "
+                f"guard_workflow_coverage_contract_ok={guard_workflow_coverage_contract_ok}, "
+                f"allow_not_ready={allow_not_ready}"
+            ),
+        },
+        {
+            "name": "guard_burnin_integrity",
+            "passed": bool(guard_burnin_integrity or allow_not_ready),
+            "details": (
+                f"guard_burnin_degraded={guard_burnin_degraded}, "
+                f"allow_not_ready={allow_not_ready}"
+            ),
+        },
+    ]
+    failed_criteria = [item for item in criteria if not bool(item.get("passed"))]
+    success = len(failed_criteria) == 0
+
+    summary_lines = [
+        f"production_ready={str(production_ready).lower()}",
+        f"required_checks_non_green_total={required_checks_non_green_total}",
+        f"branch_protection_drift_detected={str(branch_protection_drift_detected).lower()}",
+        f"guard_workflow_health_degraded={str(guard_workflow_health_degraded).lower()}",
+        f"guard_burnin_degraded={str(guard_burnin_degraded).lower()}",
+    ]
+
+    report = {
+        "label": label,
+        "success": bool(success),
+        "config": {
+            "required_checks_report_file": str(required_checks_report_file),
+            "branch_protection_report_file": str(branch_protection_report_file),
+            "guard_health_report_file": str(guard_health_report_file),
+            "guard_burnin_report_file": str(guard_burnin_report_file),
+            "allow_not_ready": bool(allow_not_ready),
+            "output_file": str(output_file),
+        },
+        "metrics": {
+            "required_checks_non_green_total": int(required_checks_non_green_total),
+            "required_checks_release_blocked": bool(required_checks_release_blocked),
+            "branch_protection_drift_detected": bool(branch_protection_drift_detected),
+            "guard_workflow_health_degraded": bool(guard_workflow_health_degraded),
+            "guard_workflow_coverage_contract_ok": bool(guard_workflow_coverage_contract_ok),
+            "guard_burnin_degraded": bool(guard_burnin_degraded),
+            "reports_load_errors_total": int(len(errors)),
+            "criteria_failed": int(len(failed_criteria)),
+        },
+        "criteria": criteria,
+        "failed_criteria": failed_criteria,
+        "load_errors": errors,
+        "decision": {
+            "production_ready": bool(production_ready),
+            "release_blocked": not bool(production_ready),
+            "allow_not_ready_effective": bool(allow_not_ready and not production_ready),
+            "recommended_action": (
+                "production_readiness_gate_green"
+                if production_ready
+                else "production_readiness_gate_not_ready"
+            ),
+        },
+        "summary_lines": summary_lines,
+        "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "duration_ms": int((time.perf_counter() - started) * 1000),
+    }
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2), encoding="utf-8")
+
+    if not success:
+        raise RuntimeError(f"Master production readiness gate failed: {json.dumps(report, sort_keys=True)}")
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Aggregate required-check integrity, branch-protection drift, guard-workflow health, "
+            "and guard burn-in into a single production-readiness go/no-go signal."
+        )
+    )
+    parser.add_argument("--label", default="master-production-readiness-gate")
+    parser.add_argument(
+        "--required-checks-report-file",
+        default="artifacts/master-required-checks-24h-report-readiness.json",
+    )
+    parser.add_argument(
+        "--branch-protection-report-file",
+        default="artifacts/master-branch-protection-drift-guard-readiness.json",
+    )
+    parser.add_argument(
+        "--guard-health-report-file",
+        default="artifacts/master-guard-workflow-health-check-readiness.json",
+    )
+    parser.add_argument(
+        "--guard-burnin-report-file",
+        default="artifacts/master-guard-burnin-check-readiness.json",
+    )
+    parser.add_argument("--allow-not-ready", action="store_true")
+    parser.add_argument("--output-file", default="artifacts/master-production-readiness-gate.json")
+    args = parser.parse_args(argv)
+
+    output_file = Path(str(args.output_file)).expanduser()
+    try:
+        report = run_production_readiness_gate(
+            label=str(args.label),
+            required_checks_report_file=Path(str(args.required_checks_report_file)).expanduser(),
+            branch_protection_report_file=Path(str(args.branch_protection_report_file)).expanduser(),
+            guard_health_report_file=Path(str(args.guard_health_report_file)).expanduser(),
+            guard_burnin_report_file=Path(str(args.guard_burnin_report_file)).expanduser(),
+            allow_not_ready=bool(args.allow_not_ready),
+            output_file=output_file,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"[master-production-readiness-gate] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-master-guard-burnin-check.ps1
+++ b/scripts/run-master-guard-burnin-check.ps1
@@ -1,0 +1,41 @@
+param(
+    [string]$Label = "master-guard-burnin-check",
+    [string]$Repo = "donatomaurizio99-collab/GOC",
+    [string]$Branch = "master",
+    [int]$PerPage = 20,
+    [int]$RequiredSuccessfulRuns = 3,
+    [int]$DigestRequiredSuccessfulRuns = 1,
+    [int]$DrillRequiredSuccessfulRuns = 1,
+    [string]$FixturesFile = "",
+    [string]$WorkflowSpecsFile = "",
+    [string]$OutputFile = "artifacts\\master-guard-burnin-check.json",
+    [switch]$AllowDegraded
+)
+
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptDir "..")
+$scriptPath = Join-Path $repoRoot "scripts\\master-guard-burnin-check.py"
+
+$args = @(
+    $scriptPath,
+    "--label", $Label,
+    "--repo", $Repo,
+    "--branch", $Branch,
+    "--per-page", [string]$PerPage,
+    "--required-successful-runs", [string]$RequiredSuccessfulRuns,
+    "--digest-required-successful-runs", [string]$DigestRequiredSuccessfulRuns,
+    "--drill-required-successful-runs", [string]$DrillRequiredSuccessfulRuns,
+    "--output-file", $OutputFile
+)
+if ($FixturesFile) {
+    $args += @("--fixtures-file", $FixturesFile)
+}
+if ($WorkflowSpecsFile) {
+    $args += @("--workflow-specs-file", $WorkflowSpecsFile)
+}
+if ($AllowDegraded) {
+    $args += "--allow-degraded"
+}
+
+& python @args

--- a/scripts/run-master-production-readiness-gate.ps1
+++ b/scripts/run-master-production-readiness-gate.ps1
@@ -1,0 +1,29 @@
+param(
+    [string]$Label = "master-production-readiness-gate",
+    [string]$RequiredChecksReportFile = "artifacts\\master-required-checks-24h-report-readiness.json",
+    [string]$BranchProtectionReportFile = "artifacts\\master-branch-protection-drift-guard-readiness.json",
+    [string]$GuardHealthReportFile = "artifacts\\master-guard-workflow-health-check-readiness.json",
+    [string]$GuardBurninReportFile = "artifacts\\master-guard-burnin-check-readiness.json",
+    [string]$OutputFile = "artifacts\\master-production-readiness-gate.json",
+    [switch]$AllowNotReady
+)
+
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptDir "..")
+$scriptPath = Join-Path $repoRoot "scripts\\master-production-readiness-gate.py"
+
+$args = @(
+    $scriptPath,
+    "--label", $Label,
+    "--required-checks-report-file", $RequiredChecksReportFile,
+    "--branch-protection-report-file", $BranchProtectionReportFile,
+    "--guard-health-report-file", $GuardHealthReportFile,
+    "--guard-burnin-report-file", $GuardBurninReportFile,
+    "--output-file", $OutputFile
+)
+if ($AllowNotReady) {
+    $args += "--allow-not-ready"
+}
+
+& python @args

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -12404,6 +12404,14 @@ def test_240_master_guard_workflow_health_check_fails_on_degraded_guard_workflow
                             "updated_at": "2026-04-18T03:55:00Z",
                         }
                     ],
+                    "Master Guard Burn-in Check": [
+                        {
+                            "id": 9107,
+                            "status": "completed",
+                            "conclusion": "success",
+                            "updated_at": "2026-04-18T03:57:00Z",
+                        }
+                    ],
                 },
                 "run_artifacts": {
                     "9101": {
@@ -12443,6 +12451,11 @@ def test_240_master_guard_workflow_health_check_fails_on_degraded_guard_workflow
                             {"name": "master-reliability-digest-guard-selftest", "expired": False},
                         ]
                     },
+                    "9107": {
+                        "artifacts": [
+                            {"name": "master-guard-burnin-check", "expired": False},
+                        ]
+                    },
                 },
             },
             ensure_ascii=True,
@@ -12477,7 +12490,7 @@ def test_240_master_guard_workflow_health_check_fails_on_degraded_guard_workflow
     payload_text = completed.stderr.split(marker, 1)[1].strip()
     payload = json.loads(payload_text)
     assert payload["success"] is False
-    assert payload["metrics"]["guard_workflows_total"] == 6
+    assert payload["metrics"]["guard_workflows_total"] == 7
     assert payload["metrics"]["guard_workflows_degraded_total"] == 2
     assert payload["metrics"]["guard_workflows_missing_required_artifacts_total"] == 1
     assert payload["metrics"]["guard_workflows_non_success_total"] == 1
@@ -12773,6 +12786,14 @@ def test_243_master_guard_workflow_health_contract_fails_on_uncovered_workflow_f
                             "updated_at": "2026-04-18T03:55:00Z",
                         }
                     ],
+                    "Master Guard Burn-in Check": [
+                        {
+                            "id": 9307,
+                            "status": "completed",
+                            "conclusion": "success",
+                            "updated_at": "2026-04-18T03:58:00Z",
+                        }
+                    ],
                 },
                 "run_artifacts": {
                     "9301": {
@@ -12813,6 +12834,11 @@ def test_243_master_guard_workflow_health_contract_fails_on_uncovered_workflow_f
                             {"name": "master-reliability-digest-guard-selftest", "expired": False},
                         ]
                     },
+                    "9307": {
+                        "artifacts": [
+                            {"name": "master-guard-burnin-check", "expired": False},
+                        ]
+                    },
                 },
             },
             ensure_ascii=True,
@@ -12837,6 +12863,7 @@ def test_243_master_guard_workflow_health_contract_fails_on_uncovered_workflow_f
             "master-required-checks-24h.yml,master-branch-protection-drift-guard.yml,"
             "master-release-gate-runtime-early-warning.yml,master-guard-workflow-health.yml,"
             "master-watchdog-rehearsal-slo-guard.yml,master-reliability-digest-guard.yml,"
+            "master-guard-burnin-check.yml,"
             "master-extra-guard-contract-probe.yml"
         ),
     ]
@@ -13739,6 +13766,261 @@ def test_255_master_guard_chain_selftest_supports_reliability_digest_guard_signa
     assert payload["decision"]["expected_alert_triggered"] is True
     assert payload["decision"]["issue_alert_triggered"] is True
     assert payload["decision"]["issue_action"] == "created"
+    assert output_file.exists()
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_256_master_guard_burnin_workflow_wrapper_and_docs_wiring():
+    project_root = Path(__file__).resolve().parents[1]
+    workflow = (project_root / ".github" / "workflows" / "master-guard-burnin-check.yml").read_text(
+        encoding="utf-8"
+    )
+    wrapper = (project_root / "scripts" / "run-master-guard-burnin-check.ps1").read_text(encoding="utf-8")
+    readme = (project_root / "README.md").read_text(encoding="utf-8")
+
+    assert "name: Master Guard Burn-in Check" in workflow
+    assert 'cron: "40 5 * * *"' in workflow
+    assert ".\\scripts\\run-master-guard-burnin-check.ps1" in workflow
+    assert "master-guard-burnin-check.json" in workflow
+    assert "master-guard-burnin-check" in workflow
+    assert "required_successful_runs" in workflow
+    assert "digest_required_successful_runs" in workflow
+    assert "drill_required_successful_runs" in workflow
+    assert "allow_degraded" in workflow
+    assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" in workflow
+
+    assert "master-guard-burnin-check.py" in wrapper
+    assert "--required-successful-runs" in wrapper
+    assert "--digest-required-successful-runs" in wrapper
+    assert "--drill-required-successful-runs" in wrapper
+    assert "--workflow-specs-file" in wrapper
+    assert "--allow-degraded" in wrapper
+
+    assert "master-guard-burnin-check.yml" in readme
+    assert "run-master-guard-burnin-check.ps1" in readme
+    assert "burn-in health for master guard/digest workflows" in readme
+
+
+def test_257_master_guard_burnin_check_detects_insufficient_runs():
+    workspace = _local_test_dir("pytest-master-guard-burnin-check-insufficient-runs").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    fixtures_file = workspace / "fixtures.json"
+    workflow_specs_file = workspace / "workflow-specs.json"
+
+    workflow_specs_file.write_text(
+        json.dumps(
+            [
+                {
+                    "workflow_name": "Master Guard Burn-in Probe",
+                    "workflow_file": "master-guard-burnin-probe.yml",
+                    "required_artifacts": ["master-guard-burnin-probe-artifact"],
+                }
+            ],
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    fixtures_file.write_text(
+        json.dumps(
+            {
+                "workflow_runs": {
+                    "Master Guard Burn-in Probe": [
+                        {
+                            "id": 981001,
+                            "status": "completed",
+                            "conclusion": "success",
+                            "updated_at": "2026-04-18T05:00:00Z",
+                        },
+                        {
+                            "id": 981002,
+                            "status": "completed",
+                            "conclusion": "success",
+                            "updated_at": "2026-04-18T04:00:00Z",
+                        },
+                    ]
+                },
+                "run_artifacts": {
+                    "981001": {
+                        "artifacts": [
+                            {"name": "master-guard-burnin-probe-artifact", "expired": False},
+                        ]
+                    },
+                    "981002": {
+                        "artifacts": [
+                            {"name": "master-guard-burnin-probe-artifact", "expired": False},
+                        ]
+                    },
+                },
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "master-guard-burnin-check.py"),
+        "--label",
+        "pytest-master-guard-burnin-insufficient-runs",
+        "--repo",
+        "donatomaurizio99-collab/GOC",
+        "--branch",
+        "master",
+        "--fixtures-file",
+        str(fixtures_file.resolve()),
+        "--workflow-specs-file",
+        str(workflow_specs_file.resolve()),
+        "--required-successful-runs",
+        "3",
+        "--now-utc",
+        "2026-04-18T06:00:00Z",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "Master guard burn-in check failed: "
+    assert marker in completed.stderr
+    payload = json.loads(completed.stderr.split(marker, 1)[1].strip())
+    assert payload["success"] is False
+    assert payload["metrics"]["workflows_total"] == 1
+    assert payload["metrics"]["workflows_below_burnin_total"] == 1
+    assert payload["decision"]["guard_burnin_degraded"] is True
+    assert payload["degraded_workflow_names"] == ["Master Guard Burn-in Probe"]
+    assert payload["evaluations"][0]["has_sufficient_runs"] is False
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_258_master_production_readiness_gate_workflow_wrapper_and_docs_wiring():
+    project_root = Path(__file__).resolve().parents[1]
+    workflow = (project_root / ".github" / "workflows" / "master-production-readiness-gate.yml").read_text(
+        encoding="utf-8"
+    )
+    wrapper = (project_root / "scripts" / "run-master-production-readiness-gate.ps1").read_text(encoding="utf-8")
+    script = (project_root / "scripts" / "master-production-readiness-gate.py").read_text(encoding="utf-8")
+    ci_workflow = (project_root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    readme = (project_root / "README.md").read_text(encoding="utf-8")
+
+    assert "name: Master Production Readiness Gate" in workflow
+    assert 'cron: "55 5 * * *"' in workflow
+    assert ".\\scripts\\run-master-required-checks-24h-report.ps1" in workflow
+    assert ".\\scripts\\run-master-branch-protection-drift-guard.ps1" in workflow
+    assert ".\\scripts\\run-master-guard-workflow-health-check.ps1" in workflow
+    assert ".\\scripts\\run-master-guard-burnin-check.ps1" in workflow
+    assert ".\\scripts\\run-master-production-readiness-gate.ps1" in workflow
+    assert "master-production-readiness-gate.json" in workflow
+    assert "allow_not_ready" in workflow
+    assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" in workflow
+
+    assert "master-production-readiness-gate.py" in wrapper
+    assert "--required-checks-report-file" in wrapper
+    assert "--branch-protection-report-file" in wrapper
+    assert "--guard-health-report-file" in wrapper
+    assert "--guard-burnin-report-file" in wrapper
+    assert "--allow-not-ready" in wrapper
+
+    assert "production_ready" in script
+    assert "guard_burnin_integrity" in script
+    assert "guard_workflow_health_integrity" in script
+    assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" in ci_workflow
+
+    assert "master-production-readiness-gate.yml" in readme
+    assert "run-master-production-readiness-gate.ps1" in readme
+    assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true" in readme
+
+
+def test_259_master_production_readiness_gate_fails_when_guard_burnin_degraded():
+    workspace = _local_test_dir("pytest-master-production-readiness-gate-failure").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    required_checks_file = workspace / "required-checks.json"
+    branch_protection_file = workspace / "branch-protection.json"
+    guard_health_file = workspace / "guard-health.json"
+    guard_burnin_file = workspace / "guard-burnin.json"
+    output_file = workspace / "master-production-readiness-gate.json"
+
+    required_checks_file.write_text(
+        json.dumps(
+            {
+                "metrics": {"non_green_runs_total": 0},
+                "decision": {"release_blocked": False},
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    branch_protection_file.write_text(
+        json.dumps(
+            {
+                "decision": {"branch_protection_drift_detected": False},
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    guard_health_file.write_text(
+        json.dumps(
+            {
+                "decision": {
+                    "guard_workflow_health_degraded": False,
+                    "guard_workflow_coverage_contract_ok": True,
+                },
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    guard_burnin_file.write_text(
+        json.dumps(
+            {
+                "metrics": {"workflows_degraded_total": 1},
+                "decision": {"guard_burnin_degraded": True},
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "master-production-readiness-gate.py"),
+        "--label",
+        "pytest-master-production-readiness-gate-failure",
+        "--required-checks-report-file",
+        str(required_checks_file.resolve()),
+        "--branch-protection-report-file",
+        str(branch_protection_file.resolve()),
+        "--guard-health-report-file",
+        str(guard_health_file.resolve()),
+        "--guard-burnin-report-file",
+        str(guard_burnin_file.resolve()),
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "Master production readiness gate failed: "
+    assert marker in completed.stderr
+    payload = json.loads(completed.stderr.split(marker, 1)[1].strip())
+    assert payload["success"] is False
+    assert payload["decision"]["production_ready"] is False
+    assert payload["metrics"]["guard_burnin_degraded"] is True
+    assert "guard_burnin_integrity" in [item["name"] for item in payload["failed_criteria"]]
     assert output_file.exists()
 
     shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
## Summary
- add nightly `master-guard-burnin-check.yml` with new `master-guard-burnin-check.py`/wrapper to verify recent successful guard/digest runs include required artifacts
- add daily hard gate `master-production-readiness-gate.yml` with new `master-production-readiness-gate.py`/wrapper that aggregates required-check integrity + branch-protection drift + guard-workflow health + guard burn-in
- extend `master-guard-workflow-health-check.py` coverage contract/specs to include `master-guard-burnin-check.yml`
- enable proactive Node-24 action runtime pinning (`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`) in CI and master guard/reliability workflows to remove Node-20 deprecation drift risk
- update README and focused tests (new tests 256-259 + updated 240/243 fixtures)

## Validation
- `python -m py_compile scripts/master-guard-burnin-check.py scripts/master-production-readiness-gate.py scripts/master-guard-workflow-health-check.py tests/test_goal_ops.py`
- `pytest -q tests/test_goal_ops.py::test_231_ci_alert_issue_upsert_workflow_wrapper_and_docs_wiring tests/test_goal_ops.py::test_240_master_guard_workflow_health_check_fails_on_degraded_guard_workflows tests/test_goal_ops.py::test_241_master_guard_workflow_health_workflow_wrapper_and_docs_wiring tests/test_goal_ops.py::test_243_master_guard_workflow_health_contract_fails_on_uncovered_workflow_file tests/test_goal_ops.py::test_250_master_reliability_digest_workflow_wrapper_and_docs_wiring tests/test_goal_ops.py::test_253_master_reliability_digest_guard_workflow_wrapper_and_docs_wiring tests/test_goal_ops.py::test_256_master_guard_burnin_workflow_wrapper_and_docs_wiring tests/test_goal_ops.py::test_257_master_guard_burnin_check_detects_insufficient_runs tests/test_goal_ops.py::test_258_master_production_readiness_gate_workflow_wrapper_and_docs_wiring tests/test_goal_ops.py::test_259_master_production_readiness_gate_fails_when_guard_burnin_degraded`
- `python .\scripts\p0-runbook-contract-check.py --label local-prepr-production-readiness-gate --project-root .`