### PR TITLE
Fix master workflow argument binding for wrapper scripts

### DIFF
--- a/.github/workflows/master-branch-protection-drift-guard.yml
+++ b/.github/workflows/master-branch-protection-drift-guard.yml
@@ -42,13 +42,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           ALLOW_DRIFT: ${{ github.event.inputs.allow_drift || 'false' }}
         run: |
-          $arguments = @(
-            "-OutputFile", "artifacts\\master-branch-protection-drift-guard.json"
-          )
           if ($env:ALLOW_DRIFT -eq "true") {
-            $arguments += "-AllowDrift"
+            .\scripts\run-master-branch-protection-drift-guard.ps1 `
+              -OutputFile "artifacts\master-branch-protection-drift-guard.json" `
+              -AllowDrift
+          } else {
+            .\scripts\run-master-branch-protection-drift-guard.ps1 `
+              -OutputFile "artifacts\master-branch-protection-drift-guard.json"
           }
-          .\scripts\run-master-branch-protection-drift-guard.ps1 @arguments
 
       - name: Upsert drift alert issue
         if: always()

--- a/.github/workflows/master-guard-burnin-check.yml
+++ b/.github/workflows/master-guard-burnin-check.yml
@@ -59,18 +59,24 @@ jobs:
           DRILL_REQUIRED_SUCCESSFUL_RUNS: ${{ github.event.inputs.drill_required_successful_runs || '1' }}
           ALLOW_DEGRADED: ${{ github.event.inputs.allow_degraded || 'false' }}
         run: |
-          $arguments = @(
-            "-Repo", "$env:REPO_FULL",
-            "-PerPage", "$env:PER_PAGE",
-            "-RequiredSuccessfulRuns", "$env:REQUIRED_SUCCESSFUL_RUNS",
-            "-DigestRequiredSuccessfulRuns", "$env:DIGEST_REQUIRED_SUCCESSFUL_RUNS",
-            "-DrillRequiredSuccessfulRuns", "$env:DRILL_REQUIRED_SUCCESSFUL_RUNS",
-            "-OutputFile", "artifacts\master-guard-burnin-check.json"
-          )
           if ($env:ALLOW_DEGRADED -eq "true") {
-            $arguments += "-AllowDegraded"
+            .\scripts\run-master-guard-burnin-check.ps1 `
+              -Repo "$env:REPO_FULL" `
+              -PerPage "$env:PER_PAGE" `
+              -RequiredSuccessfulRuns "$env:REQUIRED_SUCCESSFUL_RUNS" `
+              -DigestRequiredSuccessfulRuns "$env:DIGEST_REQUIRED_SUCCESSFUL_RUNS" `
+              -DrillRequiredSuccessfulRuns "$env:DRILL_REQUIRED_SUCCESSFUL_RUNS" `
+              -OutputFile "artifacts\master-guard-burnin-check.json" `
+              -AllowDegraded
+          } else {
+            .\scripts\run-master-guard-burnin-check.ps1 `
+              -Repo "$env:REPO_FULL" `
+              -PerPage "$env:PER_PAGE" `
+              -RequiredSuccessfulRuns "$env:REQUIRED_SUCCESSFUL_RUNS" `
+              -DigestRequiredSuccessfulRuns "$env:DIGEST_REQUIRED_SUCCESSFUL_RUNS" `
+              -DrillRequiredSuccessfulRuns "$env:DRILL_REQUIRED_SUCCESSFUL_RUNS" `
+              -OutputFile "artifacts\master-guard-burnin-check.json"
           }
-          .\scripts\run-master-guard-burnin-check.ps1 @arguments
 
       - name: Upload guard burn-in report
         if: always()

--- a/.github/workflows/master-guard-workflow-health.yml
+++ b/.github/workflows/master-guard-workflow-health.yml
@@ -56,15 +56,18 @@ jobs:
           PER_PAGE: ${{ github.event.inputs.per_page || '50' }}
           ALLOW_DEGRADED: ${{ github.event.inputs.allow_degraded || 'false' }}
         run: |
-          $arguments = @(
-            "-LookbackHours", "$env:LOOKBACK_HOURS",
-            "-PerPage", "$env:PER_PAGE",
-            "-OutputFile", "artifacts\\master-guard-workflow-health-check.json"
-          )
           if ($env:ALLOW_DEGRADED -eq "true") {
-            $arguments += "-AllowDegraded"
+            .\scripts\run-master-guard-workflow-health-check.ps1 `
+              -LookbackHours "$env:LOOKBACK_HOURS" `
+              -PerPage "$env:PER_PAGE" `
+              -OutputFile "artifacts\master-guard-workflow-health-check.json" `
+              -AllowDegraded
+          } else {
+            .\scripts\run-master-guard-workflow-health-check.ps1 `
+              -LookbackHours "$env:LOOKBACK_HOURS" `
+              -PerPage "$env:PER_PAGE" `
+              -OutputFile "artifacts\master-guard-workflow-health-check.json"
           }
-          .\scripts\run-master-guard-workflow-health-check.ps1 @arguments
 
       - name: Upsert guard-health alert issue
         if: always()

--- a/.github/workflows/master-production-readiness-gate.yml
+++ b/.github/workflows/master-production-readiness-gate.yml
@@ -126,17 +126,22 @@ jobs:
         env:
           ALLOW_NOT_READY: ${{ github.event.inputs.allow_not_ready || 'false' }}
         run: |
-          $arguments = @(
-            "-RequiredChecksReportFile", "artifacts\master-required-checks-24h-report-readiness.json",
-            "-BranchProtectionReportFile", "artifacts\master-branch-protection-drift-guard-readiness.json",
-            "-GuardHealthReportFile", "artifacts\master-guard-workflow-health-check-readiness.json",
-            "-GuardBurninReportFile", "artifacts\master-guard-burnin-check-readiness.json",
-            "-OutputFile", "artifacts\master-production-readiness-gate.json"
-          )
           if ($env:ALLOW_NOT_READY -eq "true") {
-            $arguments += "-AllowNotReady"
+            .\scripts\run-master-production-readiness-gate.ps1 `
+              -RequiredChecksReportFile "artifacts\master-required-checks-24h-report-readiness.json" `
+              -BranchProtectionReportFile "artifacts\master-branch-protection-drift-guard-readiness.json" `
+              -GuardHealthReportFile "artifacts\master-guard-workflow-health-check-readiness.json" `
+              -GuardBurninReportFile "artifacts\master-guard-burnin-check-readiness.json" `
+              -OutputFile "artifacts\master-production-readiness-gate.json" `
+              -AllowNotReady
+          } else {
+            .\scripts\run-master-production-readiness-gate.ps1 `
+              -RequiredChecksReportFile "artifacts\master-required-checks-24h-report-readiness.json" `
+              -BranchProtectionReportFile "artifacts\master-branch-protection-drift-guard-readiness.json" `
+              -GuardHealthReportFile "artifacts\master-guard-workflow-health-check-readiness.json" `
+              -GuardBurninReportFile "artifacts\master-guard-burnin-check-readiness.json" `
+              -OutputFile "artifacts\master-production-readiness-gate.json"
           }
-          .\scripts\run-master-production-readiness-gate.ps1 @arguments
 
       - name: Publish production readiness summary
         if: always()

--- a/.github/workflows/master-release-gate-runtime-early-warning.yml
+++ b/.github/workflows/master-release-gate-runtime-early-warning.yml
@@ -66,17 +66,22 @@ jobs:
           SUSTAINED_RUNS: ${{ github.event.inputs.sustained_runs || '3' }}
           FAIL_ON_WARNING: ${{ github.event.inputs.fail_on_warning || 'false' }}
         run: |
-          $arguments = @(
-            "-LookbackHours", "$env:LOOKBACK_HOURS",
-            "-PerPage", "$env:PER_PAGE",
-            "-ThresholdSeconds", "$env:THRESHOLD_SECONDS",
-            "-SustainedRuns", "$env:SUSTAINED_RUNS",
-            "-OutputFile", "artifacts\\release-gate-runtime-early-warning.json"
-          )
           if ($env:FAIL_ON_WARNING -eq "true") {
-            $arguments += "-FailOnWarning"
+            .\scripts\run-release-gate-runtime-early-warning.ps1 `
+              -LookbackHours "$env:LOOKBACK_HOURS" `
+              -PerPage "$env:PER_PAGE" `
+              -ThresholdSeconds "$env:THRESHOLD_SECONDS" `
+              -SustainedRuns "$env:SUSTAINED_RUNS" `
+              -OutputFile "artifacts\release-gate-runtime-early-warning.json" `
+              -FailOnWarning
+          } else {
+            .\scripts\run-release-gate-runtime-early-warning.ps1 `
+              -LookbackHours "$env:LOOKBACK_HOURS" `
+              -PerPage "$env:PER_PAGE" `
+              -ThresholdSeconds "$env:THRESHOLD_SECONDS" `
+              -SustainedRuns "$env:SUSTAINED_RUNS" `
+              -OutputFile "artifacts\release-gate-runtime-early-warning.json"
           }
-          .\scripts\run-release-gate-runtime-early-warning.ps1 @arguments
 
       - name: Upsert runtime warning issue
         if: always()

--- a/.github/workflows/master-reliability-digest-guard.yml
+++ b/.github/workflows/master-reliability-digest-guard.yml
@@ -57,16 +57,20 @@ jobs:
           PER_PAGE: ${{ github.event.inputs.per_page || '20' }}
           ALLOW_BREACH: ${{ github.event.inputs.allow_breach || 'false' }}
         run: |
-          $arguments = @(
-            "-Repo", "$env:REPO_FULL",
-            "-MaxAgeHours", "$env:MAX_AGE_HOURS",
-            "-PerPage", "$env:PER_PAGE",
-            "-OutputFile", "artifacts\\master-reliability-digest-guard.json"
-          )
           if ($env:ALLOW_BREACH -eq "true") {
-            $arguments += "-AllowBreach"
+            .\scripts\run-master-reliability-digest-guard.ps1 `
+              -Repo "$env:REPO_FULL" `
+              -MaxAgeHours "$env:MAX_AGE_HOURS" `
+              -PerPage "$env:PER_PAGE" `
+              -OutputFile "artifacts\master-reliability-digest-guard.json" `
+              -AllowBreach
+          } else {
+            .\scripts\run-master-reliability-digest-guard.ps1 `
+              -Repo "$env:REPO_FULL" `
+              -MaxAgeHours "$env:MAX_AGE_HOURS" `
+              -PerPage "$env:PER_PAGE" `
+              -OutputFile "artifacts\master-reliability-digest-guard.json"
           }
-          .\scripts\run-master-reliability-digest-guard.ps1 @arguments
 
       - name: Upsert reliability-digest guard issue
         if: always()

--- a/.github/workflows/master-reliability-digest.yml
+++ b/.github/workflows/master-reliability-digest.yml
@@ -78,21 +78,30 @@ jobs:
           WARNING_SUSTAINED_RUNS: ${{ github.event.inputs.warning_sustained_runs || '3' }}
           FAIL_ON_WARNING: ${{ github.event.inputs.fail_on_warning || 'false' }}
         run: |
-          $arguments = @(
-            "-Repo", "$env:REPO_FULL",
-            "-CiPerPage", "$env:CI_PER_PAGE",
-            "-GuardPerPage", "$env:GUARD_PER_PAGE",
-            "-TrendRuns", "$env:TREND_RUNS",
-            "-GuardTrendRuns", "$env:GUARD_TREND_RUNS",
-            "-ReleaseGateWarningSeconds", "$env:RELEASE_GATE_WARNING_SECONDS",
-            "-WarningSustainedRuns", "$env:WARNING_SUSTAINED_RUNS",
-            "-OutputFile", "artifacts\master-reliability-digest.json",
-            "-MarkdownOutputFile", "artifacts\master-reliability-digest.md"
-          )
           if ($env:FAIL_ON_WARNING -eq "true") {
-            $arguments += "-FailOnWarning"
+            .\scripts\run-master-reliability-digest.ps1 `
+              -Repo "$env:REPO_FULL" `
+              -CiPerPage "$env:CI_PER_PAGE" `
+              -GuardPerPage "$env:GUARD_PER_PAGE" `
+              -TrendRuns "$env:TREND_RUNS" `
+              -GuardTrendRuns "$env:GUARD_TREND_RUNS" `
+              -ReleaseGateWarningSeconds "$env:RELEASE_GATE_WARNING_SECONDS" `
+              -WarningSustainedRuns "$env:WARNING_SUSTAINED_RUNS" `
+              -OutputFile "artifacts\master-reliability-digest.json" `
+              -MarkdownOutputFile "artifacts\master-reliability-digest.md" `
+              -FailOnWarning
+          } else {
+            .\scripts\run-master-reliability-digest.ps1 `
+              -Repo "$env:REPO_FULL" `
+              -CiPerPage "$env:CI_PER_PAGE" `
+              -GuardPerPage "$env:GUARD_PER_PAGE" `
+              -TrendRuns "$env:TREND_RUNS" `
+              -GuardTrendRuns "$env:GUARD_TREND_RUNS" `
+              -ReleaseGateWarningSeconds "$env:RELEASE_GATE_WARNING_SECONDS" `
+              -WarningSustainedRuns "$env:WARNING_SUSTAINED_RUNS" `
+              -OutputFile "artifacts\master-reliability-digest.json" `
+              -MarkdownOutputFile "artifacts\master-reliability-digest.md"
           }
-          .\scripts\run-master-reliability-digest.ps1 @arguments
 
       - name: Publish digest summary
         if: always()

--- a/.github/workflows/master-required-checks-24h.yml
+++ b/.github/workflows/master-required-checks-24h.yml
@@ -52,16 +52,20 @@ jobs:
           MAX_NON_GREEN_RUNS: ${{ github.event.inputs.max_non_green_runs || '0' }}
           ALLOW_NON_GREEN: ${{ github.event.inputs.allow_non_green || 'false' }}
         run: |
-          $arguments = @(
-            "-LookbackHours", "$env:LOOKBACK_HOURS",
-            "-PerPage", "$env:PER_PAGE",
-            "-MaxNonGreenRuns", "$env:MAX_NON_GREEN_RUNS",
-            "-OutputFile", "artifacts\\master-required-checks-24h-report.json"
-          )
           if ($env:ALLOW_NON_GREEN -eq "true") {
-            $arguments += "-AllowNonGreen"
+            .\scripts\run-master-required-checks-24h-report.ps1 `
+              -LookbackHours "$env:LOOKBACK_HOURS" `
+              -PerPage "$env:PER_PAGE" `
+              -MaxNonGreenRuns "$env:MAX_NON_GREEN_RUNS" `
+              -OutputFile "artifacts\master-required-checks-24h-report.json" `
+              -AllowNonGreen
+          } else {
+            .\scripts\run-master-required-checks-24h-report.ps1 `
+              -LookbackHours "$env:LOOKBACK_HOURS" `
+              -PerPage "$env:PER_PAGE" `
+              -MaxNonGreenRuns "$env:MAX_NON_GREEN_RUNS" `
+              -OutputFile "artifacts\master-required-checks-24h-report.json"
           }
-          .\scripts\run-master-required-checks-24h-report.ps1 @arguments
 
       - name: Upload 24h required checks report
         if: always()

--- a/.github/workflows/master-watchdog-rehearsal-slo-guard.yml
+++ b/.github/workflows/master-watchdog-rehearsal-slo-guard.yml
@@ -57,16 +57,20 @@ jobs:
           PER_PAGE: ${{ github.event.inputs.per_page || '20' }}
           ALLOW_BREACH: ${{ github.event.inputs.allow_breach || 'false' }}
         run: |
-          $arguments = @(
-            "-Repo", "$env:REPO_FULL",
-            "-MaxAgeHours", "$env:MAX_AGE_HOURS",
-            "-PerPage", "$env:PER_PAGE",
-            "-OutputFile", "artifacts\\master-watchdog-rehearsal-slo-guard.json"
-          )
           if ($env:ALLOW_BREACH -eq "true") {
-            $arguments += "-AllowBreach"
+            .\scripts\run-master-watchdog-rehearsal-slo-guard.ps1 `
+              -Repo "$env:REPO_FULL" `
+              -MaxAgeHours "$env:MAX_AGE_HOURS" `
+              -PerPage "$env:PER_PAGE" `
+              -OutputFile "artifacts\master-watchdog-rehearsal-slo-guard.json" `
+              -AllowBreach
+          } else {
+            .\scripts\run-master-watchdog-rehearsal-slo-guard.ps1 `
+              -Repo "$env:REPO_FULL" `
+              -MaxAgeHours "$env:MAX_AGE_HOURS" `
+              -PerPage "$env:PER_PAGE" `
+              -OutputFile "artifacts\master-watchdog-rehearsal-slo-guard.json"
           }
-          .\scripts\run-master-watchdog-rehearsal-slo-guard.ps1 @arguments
 
       - name: Upsert watchdog rehearsal SLO issue
         if: always()

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -14024,3 +14024,23 @@ def test_259_master_production_readiness_gate_fails_when_guard_burnin_degraded()
     assert output_file.exists()
 
     shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_260_master_workflow_wrapper_invocations_use_named_parameters():
+    project_root = Path(__file__).resolve().parents[1]
+    workflows = [
+        project_root / ".github" / "workflows" / "master-required-checks-24h.yml",
+        project_root / ".github" / "workflows" / "master-branch-protection-drift-guard.yml",
+        project_root / ".github" / "workflows" / "master-release-gate-runtime-early-warning.yml",
+        project_root / ".github" / "workflows" / "master-guard-workflow-health.yml",
+        project_root / ".github" / "workflows" / "master-watchdog-rehearsal-slo-guard.yml",
+        project_root / ".github" / "workflows" / "master-reliability-digest.yml",
+        project_root / ".github" / "workflows" / "master-reliability-digest-guard.yml",
+        project_root / ".github" / "workflows" / "master-guard-burnin-check.yml",
+        project_root / ".github" / "workflows" / "master-production-readiness-gate.yml",
+    ]
+
+    for path in workflows:
+        text = path.read_text(encoding="utf-8")
+        assert "$arguments = @(" not in text
+        assert "@arguments" not in text


### PR DESCRIPTION
## Summary
- fix PowerShell workflow wrapper invocations that previously used string-array splatting (`@arguments`) and broke typed wrapper parameters in GitHub Actions
- switch affected master workflows to explicit named-parameter invocations with guarded switch handling
- add regression test `test_260_master_workflow_wrapper_invocations_use_named_parameters` to prevent reintroduction

## Why
Bootstrap dispatch runs revealed runtime failures such as:
- `Cannot process argument transformation on parameter 'PerPage'. Cannot convert value '-OutputFile' to type 'System.Int32'`

## Validation
- `python -m py_compile tests/test_goal_ops.py`
- `pytest -q tests/test_goal_ops.py::test_250_master_reliability_digest_workflow_wrapper_and_docs_wiring tests/test_goal_ops.py::test_253_master_reliability_digest_guard_workflow_wrapper_and_docs_wiring tests/test_goal_ops.py::test_256_master_guard_burnin_workflow_wrapper_and_docs_wiring tests/test_goal_ops.py::test_258_master_production_readiness_gate_workflow_wrapper_and_docs_wiring tests/test_goal_ops.py::test_260_master_workflow_wrapper_invocations_use_named_parameters`
- `python .\scripts\p0-runbook-contract-check.py --label local-prepr-workflow-wrapper-invocation-fix --project-root .`