### PR TITLE
Harden master guard API resilience and label upsert fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,6 +945,7 @@ It also enforces registry attestation-gate invariants over sync-report mode/drif
 P0 burn-in CI-check evaluation now dedupes duplicate check names per run and keeps failure-biased conclusions for stability-first gating.
 Nightly master required-checks monitoring now hard-fails on non-green required CI checks in the last 24h (with duplicate-check-name handling).
 Nightly branch-protection drift guard now verifies that `master` keeps exactly the 5 required checks (no missing or unexpected status contexts).
+The drift guard reads required status checks from the branch API payload and still emits a drift report artifact even when branch-protection payload loading fails (for example token-scope/API-access errors), so issue upsert and artifact diagnostics stay intact.
 Nightly guard-workflow health watchdog now verifies that the guard workflows themselves run successfully on `master` and publish their expected artifacts.
 It also enforces a coverage contract so all relevant `master-*` guard/warning/required-checks workflow files are declared in the watchdog with expected artifact contracts.
 Guard-health issue summaries now include per-degraded-workflow diagnostics (reason(s), missing required artifacts, and latest run ID/URL) so on-call can triage directly from the issue.

--- a/scripts/ci-alert-issue-upsert.py
+++ b/scripts/ci-alert-issue-upsert.py
@@ -10,6 +10,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 
 SIGNAL_SPECS: dict[str, dict[str, Any]] = {
@@ -173,7 +174,22 @@ def _ensure_label_exists(*, repo: str, label: str) -> None:
         return
     if "unprocessable entity" in stderr and "already exists" in stderr:
         return
-    raise RuntimeError(f"Failed to ensure label '{label}' in repo '{repo}': {completed.stderr.strip()}")
+
+    # GitHub sometimes returns a generic 422 text for an existing label.
+    # Verify by reading the label endpoint before failing hard.
+    encoded_label = quote(label, safe="")
+    verify_command = ["gh", "api", f"repos/{repo}/labels/{encoded_label}"]
+    verify = subprocess.run(
+        verify_command,
+        capture_output=True,
+        text=True,
+    )
+    if verify.returncode == 0:
+        return
+    raise RuntimeError(
+        f"Failed to ensure label '{label}' in repo '{repo}': {completed.stderr.strip()} "
+        f"(verify failed: {verify.stderr.strip()})"
+    )
 
 
 def _issue_state(issue: dict[str, Any]) -> str:

--- a/scripts/master-branch-protection-drift-guard.py
+++ b/scripts/master-branch-protection-drift-guard.py
@@ -35,6 +35,23 @@ def _run_gh_api(path: str) -> dict[str, Any]:
     return payload
 
 
+def _resolve_required_status_checks_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    if "contexts" in payload or "checks" in payload:
+        return payload
+
+    protection = payload.get("protection")
+    _expect(
+        isinstance(protection, dict),
+        "Branch payload missing 'protection' field while resolving required status checks.",
+    )
+    required_status_checks = protection.get("required_status_checks")
+    _expect(
+        isinstance(required_status_checks, dict),
+        "Branch payload missing 'protection.required_status_checks' field.",
+    )
+    return required_status_checks
+
+
 def _load_json_file(path: Path) -> dict[str, Any]:
     _expect(path.exists(), f"JSON file not found: {path}")
     payload = json.loads(path.read_text(encoding="utf-8"))
@@ -100,10 +117,18 @@ def run_drift_guard(
     resolved_required_checks, duplicate_required_checks = _dedupe_ordered_strings(required_checks)
     _expect(resolved_required_checks, "At least one required check must be configured.")
 
-    if required_status_checks_file is not None:
-        payload = _load_json_file(required_status_checks_file)
-    else:
-        payload = _run_gh_api(f"repos/{repo}/branches/{branch}/protection/required_status_checks")
+    payload_load_error: str | None = None
+    payload_source = "fixture_file" if required_status_checks_file is not None else "branch_api"
+    payload: dict[str, Any]
+    try:
+        if required_status_checks_file is not None:
+            raw_payload = _load_json_file(required_status_checks_file)
+        else:
+            raw_payload = _run_gh_api(f"repos/{repo}/branches/{branch}")
+        payload = _resolve_required_status_checks_payload(raw_payload)
+    except Exception as exc:
+        payload_load_error = str(exc)
+        payload = {"contexts": [], "checks": []}
 
     observed_contexts, observed_context_duplicates = _extract_contexts_from_contexts_field(payload)
     checks_contexts, checks_context_duplicates = _extract_contexts_from_checks(payload)
@@ -118,6 +143,11 @@ def run_drift_guard(
     )
 
     criteria = [
+        {
+            "name": "required_status_checks_payload_loaded",
+            "passed": bool(payload_load_error is None),
+            "details": "payload_loaded" if payload_load_error is None else payload_load_error,
+        },
         {
             "name": "required_checks_exact_match",
             "passed": bool(not missing_required_checks and not unexpected_required_checks),
@@ -155,6 +185,7 @@ def run_drift_guard(
             "required_checks_duplicates_removed": duplicate_required_checks,
             "allow_drift": bool(allow_drift),
             "required_status_checks_file": str(required_status_checks_file) if required_status_checks_file else None,
+            "required_status_checks_payload_source": payload_source,
             "output_file": str(output_file),
         },
         "metrics": {
@@ -163,10 +194,12 @@ def run_drift_guard(
             "unexpected_required_checks_total": int(len(unexpected_required_checks)),
             "contexts_duplicates_total": int(len(observed_context_duplicates)),
             "checks_context_duplicates_total": int(len(checks_context_duplicates)),
+            "payload_load_errors_total": int(1 if payload_load_error is not None else 0),
             "criteria_failed": int(len(failed_criteria)),
         },
         "criteria": criteria,
         "failed_criteria": failed_criteria,
+        "load_error": payload_load_error,
         "observed": {
             "strict": payload.get("strict"),
             "contexts": observed_contexts,
@@ -182,7 +215,15 @@ def run_drift_guard(
         },
         "decision": {
             "branch_protection_drift_detected": not bool(success),
-            "recommended_action": "branch_protection_in_sync" if success else "branch_protection_drift_detected",
+            "recommended_action": (
+                "branch_protection_in_sync"
+                if success
+                else (
+                    "branch_protection_payload_unavailable"
+                    if payload_load_error is not None
+                    else "branch_protection_drift_detected"
+                )
+            ),
         },
         "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "duration_ms": int((time.perf_counter() - started) * 1000),

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import sqlite3
@@ -14044,3 +14045,70 @@ def test_260_master_workflow_wrapper_invocations_use_named_parameters():
         text = path.read_text(encoding="utf-8")
         assert "$arguments = @(" not in text
         assert "@arguments" not in text
+
+
+def test_261_master_branch_protection_drift_guard_writes_report_when_payload_load_fails():
+    workspace = _local_test_dir("pytest-master-branch-protection-drift-guard-payload-load-failure").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    missing_required_status_checks_file = workspace / "missing-required-status-checks.json"
+    output_file = workspace / "master-branch-protection-drift-guard.json"
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "master-branch-protection-drift-guard.py"),
+        "--label",
+        "pytest-branch-protection-payload-load-failure",
+        "--required-status-checks-file",
+        str(missing_required_status_checks_file.resolve()),
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "Master branch-protection drift guard failed: "
+    assert marker in completed.stderr
+    payload = json.loads(completed.stderr.split(marker, 1)[1].strip())
+    assert payload["success"] is False
+    assert payload["load_error"] is not None
+    assert "JSON file not found" in str(payload["load_error"])
+    assert payload["metrics"]["payload_load_errors_total"] == 1
+    assert payload["metrics"]["missing_required_checks_total"] == 5
+    assert payload["decision"]["recommended_action"] == "branch_protection_payload_unavailable"
+    assert "required_status_checks_payload_loaded" in [item["name"] for item in payload["failed_criteria"]]
+    assert output_file.exists()
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_262_ci_alert_issue_upsert_label_ensure_accepts_generic_422_when_label_exists(monkeypatch):
+    project_root = Path(__file__).resolve().parents[1]
+    script_path = project_root / "scripts" / "ci-alert-issue-upsert.py"
+    spec = importlib.util.spec_from_file_location("ci_alert_issue_upsert_script", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    calls: list[list[str]] = []
+
+    def _fake_run(command, input=None, capture_output=True, text=True):
+        _ = input
+        _ = capture_output
+        _ = text
+        calls.append([str(item) for item in command])
+        if len(calls) == 1:
+            return subprocess.CompletedProcess(command, 1, "", "gh: Validation Failed (HTTP 422)")
+        if len(calls) == 2:
+            return subprocess.CompletedProcess(command, 0, '{"name":"ci-drift"}', "")
+        raise AssertionError("Unexpected subprocess.run invocation.")
+
+    monkeypatch.setattr(module.subprocess, "run", _fake_run)
+    module._ensure_label_exists(repo="donatomaurizio99-collab/GOC", label="ci-drift")
+
+    assert len(calls) == 2
+    assert calls[0][0:4] == ["gh", "api", "repos/donatomaurizio99-collab/GOC/labels", "-X"]
+    assert calls[1][0:3] == ["gh", "api", "repos/donatomaurizio99-collab/GOC/labels/ci-drift"]


### PR DESCRIPTION
﻿## Summary
- switch branch-protection drift guard API lookup to `repos/{repo}/branches/{branch}` and normalize nested `protection.required_status_checks` payloads
- ensure branch-protection drift guard always emits a report artifact even when payload loading fails (records `load_error`, fails criteria, and keeps actionable diagnostics)
- harden CI alert label ensure flow: when `POST /labels` returns generic `422`, verify with `GET /labels/{name}` before failing
- add regression tests for both resilience paths and document the new drift-guard artifact behavior in README

## Validation
- `python -m py_compile scripts/master-branch-protection-drift-guard.py scripts/ci-alert-issue-upsert.py tests/test_goal_ops.py`
- `pytest -q tests/test_goal_ops.py -k "test_224_master_branch_protection_drift_guard_fails_on_required_check_drift or test_225_master_branch_protection_drift_guard_workflow_wrapper_and_docs_wiring or test_229_ci_alert_issue_upsert_creates_issue_for_branch_protection_drift or test_261_master_branch_protection_drift_guard_writes_report_when_payload_load_fails or test_262_ci_alert_issue_upsert_label_ensure_accepts_generic_422_when_label_exists or test_260_master_workflow_wrapper_invocations_use_named_parameters"`
- `python .\scripts\p0-runbook-contract-check.py --label local-prepr-master-guard-api-resilience --project-root .`
