### PR TITLE
Harden reliability-digest noise policy and add daily ci-drift status report

### DIFF
--- a/.github/workflows/master-ci-drift-status-report.yml
+++ b/.github/workflows/master-ci-drift-status-report.yml
@@ -1,0 +1,70 @@
+name: Master CI Drift Status Report
+
+on:
+  schedule:
+    - cron: "40 6 * * *"
+  workflow_dispatch:
+    inputs:
+      blocked_age_hours:
+        description: "Issue age threshold (hours) after which unknown signals are classified as blocked"
+        required: false
+        default: "24"
+      per_page:
+        description: "Maximum number of open ci-drift issues fetched"
+        required: false
+        default: "100"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  ci-drift-status-report:
+    name: CI Drift Status Report
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Build CI-drift status report
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_FULL: ${{ github.repository }}
+          BLOCKED_AGE_HOURS: ${{ github.event.inputs.blocked_age_hours || '24' }}
+          PER_PAGE: ${{ github.event.inputs.per_page || '100' }}
+        run: |
+          .\scripts\run-master-ci-drift-status-report.ps1 `
+            -Repo "$env:REPO_FULL" `
+            -BlockedAgeHours "$env:BLOCKED_AGE_HOURS" `
+            -PerPage "$env:PER_PAGE" `
+            -OutputFile "artifacts\master-ci-drift-status-report.json" `
+            -MarkdownOutputFile "artifacts\master-ci-drift-status-report.md"
+
+      - name: Publish CI-drift status summary
+        if: always()
+        shell: pwsh
+        run: |
+          if (Test-Path "artifacts\master-ci-drift-status-report.md") {
+            Get-Content "artifacts\master-ci-drift-status-report.md" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          }
+
+      - name: Upload CI-drift status report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: master-ci-drift-status-report
+          path: |
+            artifacts/master-ci-drift-status-report.json
+            artifacts/master-ci-drift-status-report.md
+          if-no-files-found: error

--- a/.github/workflows/master-reliability-digest.yml
+++ b/.github/workflows/master-reliability-digest.yml
@@ -29,6 +29,10 @@ on:
         description: "Consecutive over-threshold runs to flag runtime warning"
         required: false
         default: "3"
+      guard_warning_sustained_runs:
+        description: "Consecutive degraded guard-health runs required for digest warning"
+        required: false
+        default: "2"
       fail_on_warning:
         description: "Fail digest workflow when warning-level findings are present"
         required: false
@@ -76,6 +80,7 @@ jobs:
           GUARD_TREND_RUNS: ${{ github.event.inputs.guard_trend_runs || '10' }}
           RELEASE_GATE_WARNING_SECONDS: ${{ github.event.inputs.release_gate_warning_seconds || '540' }}
           WARNING_SUSTAINED_RUNS: ${{ github.event.inputs.warning_sustained_runs || '3' }}
+          GUARD_WARNING_SUSTAINED_RUNS: ${{ github.event.inputs.guard_warning_sustained_runs || '2' }}
           FAIL_ON_WARNING: ${{ github.event.inputs.fail_on_warning || 'false' }}
         run: |
           if ($env:FAIL_ON_WARNING -eq "true") {
@@ -87,6 +92,7 @@ jobs:
               -GuardTrendRuns "$env:GUARD_TREND_RUNS" `
               -ReleaseGateWarningSeconds "$env:RELEASE_GATE_WARNING_SECONDS" `
               -WarningSustainedRuns "$env:WARNING_SUSTAINED_RUNS" `
+              -GuardWarningSustainedRuns "$env:GUARD_WARNING_SUSTAINED_RUNS" `
               -OutputFile "artifacts\master-reliability-digest.json" `
               -MarkdownOutputFile "artifacts\master-reliability-digest.md" `
               -FailOnWarning
@@ -99,6 +105,7 @@ jobs:
               -GuardTrendRuns "$env:GUARD_TREND_RUNS" `
               -ReleaseGateWarningSeconds "$env:RELEASE_GATE_WARNING_SECONDS" `
               -WarningSustainedRuns "$env:WARNING_SUSTAINED_RUNS" `
+              -GuardWarningSustainedRuns "$env:GUARD_WARNING_SUSTAINED_RUNS" `
               -OutputFile "artifacts\master-reliability-digest.json" `
               -MarkdownOutputFile "artifacts\master-reliability-digest.md"
           }

--- a/README.md
+++ b/README.md
@@ -956,8 +956,10 @@ Nightly [master-watchdog-rehearsal-slo-guard.yml](.github/workflows/master-watch
 Nightly release-gate runtime early warning now flags sustained runtime slowdown (default: 3 consecutive runs >= 540s) before it escalates into flaky failures, and escalates when an active runtime warning issue stays open beyond the alert-age SLO (default: 72h).
 Nightly drift/warning workflows now upsert deduplicated GitHub issues (labels: `ci-drift` + signal label), enforce the invariant of at most one open issue per signal, reset recovery streak on active alerts, and auto-close recovered issues after 2 healthy nightly runs (configurable threshold). Active-alert comments are cooldown-throttled for unchanged failure states (default every 3 runs), while issue bodies continue to refresh each run. The runtime alert-age SLO escalation issue now carries a mandatory parent runtime-warning reference in its issue body and closes immediately when parent-coupled escalation criteria are no longer met.
 Weekly [master-reliability-digest.yml](.github/workflows/master-reliability-digest.yml) publishes a trend digest (Release Gate runtime, guard degradations, active-comment suppression totals) as artifact + workflow summary for proactive reliability tracking and feeds the deduped warning signal `master-reliability-digest-warning`.
+Reliability-digest guard degradation warnings are now based on consecutive head failures (default: 2) instead of any historical non-success sample in the trend window to reduce alert noise after successful recovery.
 Nightly [master-guard-burnin-check.yml](.github/workflows/master-guard-burnin-check.yml) enforces burn-in health for master guard/digest workflows by requiring recent successful runs with required artifacts (including weekly digest/rehearsal bootstrap windows).
 Daily [master-production-readiness-gate.yml](.github/workflows/master-production-readiness-gate.yml) aggregates required-check integrity, branch-protection drift, guard-workflow health, and guard burn-in into one hard go/no-go production readiness gate.
+Daily [master-ci-drift-status-report.yml](.github/workflows/master-ci-drift-status-report.yml) publishes an operations report for open `ci-drift` issues with blocked/residual classification and issue-age context.
 Core CI and master guard/reliability workflows now set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to proactively avoid Node-20 action-runtime deprecation drift.
 
 Release Gate workflow artifact includes `p0-release-evidence-bundle` (manifest + copied evidence reports, including safe-mode/A11y/runtime/flake stage outputs, + closure report), Stage-L/M evidence artifacts (`release-gate-evidence-freshness-release-gate.json`, `release-gate-evidence-hash-manifest-release-gate.json`, `release-gate-evidence-manifest-release-gate.json`), Stage-N/O timing-history artifacts (`release-gate-step-timing-schema-release-gate.json`, `release-gate-performance-history-release-gate.json`), Stage-K/P artifacts (`release-gate-step-timings-release-gate.json`, `release-gate-performance-budget-release-gate.json`, `release-gate-stability-final-readiness-release-gate.json`), Stage-Q/R readiness artifacts (`release-gate-staging-soak-readiness-release-gate.json`, `release-gate-rc-canary-rollout-release-gate.json`), Stage-S/T readiness artifacts (`release-gate-evidence-lineage-release-gate.json`, `release-gate-production-readiness-certification-release-gate.json`), Stage-U/AB expanded readiness artifacts (`release-gate-slo-burn-rate-v2-release-gate.json`, `release-gate-deploy-rehearsal-release-gate.json`, `release-gate-chaos-matrix-continuous-release-gate.json`, `release-gate-supply-chain-artifact-trust-release-gate.json`, `release-gate-operations-handoff-readiness-release-gate.json`, `release-gate-evidence-attestation-release-gate.json`, `release-gate-release-train-readiness-release-gate.json`, `release-gate-production-final-attestation-release-gate.json`), Stage-AC/AJ cutover-to-sustainability artifacts (`release-gate-production-cutover-readiness-release-gate.json`, `release-gate-hypercare-activation-release-gate.json`, `release-gate-rollback-trigger-integrity-release-gate.json`, `release-gate-post-cutover-finalization-release-gate.json`, `release-gate-post-release-watch-release-gate.json`, `release-gate-steady-state-certification-release-gate.json`, `release-gate-post-release-continuity-release-gate.json`, `release-gate-production-sustainability-certification-release-gate.json`), and registry attestation artifacts (`release-gate-registry-sync-ci.json`, `release-gate-registry-attestation-gate-ci.json`).
@@ -991,6 +993,9 @@ Weekly master reliability digest workflow:
 
 Nightly master reliability digest guard workflow:
 [master-reliability-digest-guard.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/master-reliability-digest-guard.yml)
+
+Daily master CI-drift status report workflow:
+[master-ci-drift-status-report.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/master-ci-drift-status-report.yml)
 
 Nightly master guard burn-in workflow:
 [master-guard-burnin-check.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/master-guard-burnin-check.yml)
@@ -1060,7 +1065,7 @@ Local master reliability digest command:
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\run-master-reliability-digest.ps1 -ReleaseGateWarningSeconds 540 -WarningSustainedRuns 3
+.\scripts\run-master-reliability-digest.ps1 -ReleaseGateWarningSeconds 540 -WarningSustainedRuns 3 -GuardWarningSustainedRuns 2
 ```
 
 Local master reliability digest guard command:
@@ -1068,6 +1073,13 @@ Local master reliability digest guard command:
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-master-reliability-digest-guard.ps1 -MaxAgeHours 192 -RequiredArtifact master-reliability-digest
+```
+
+Local master CI-drift status report command:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-master-ci-drift-status-report.ps1 -BlockedAgeHours 24 -PerPage 100
 ```
 
 Local alert-to-action issue upsert command (dry run example):

--- a/scripts/master-ci-drift-status-report.py
+++ b/scripts/master-ci-drift-status-report.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+BLOCKING_SIGNAL_IDS = {
+    "master-branch-protection-drift",
+    "master-guard-workflow-health",
+    "release-gate-runtime-alert-age-slo",
+    "master-watchdog-rehearsal-drill-slo",
+    "master-reliability-digest-guard",
+}
+
+RESIDUAL_SIGNAL_IDS = {
+    "release-gate-runtime-early-warning",
+    "master-reliability-digest-warning",
+}
+
+SIGNAL_MARKER_PATTERN = re.compile(
+    r"ci-alert-key:(?P<signal>[a-z0-9\-]+):(?P<repo>[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+):(?P<branch>[A-Za-z0-9_.\-/]+)"
+)
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _parse_utc_timestamp(value: str) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _hours_between(started_at: datetime | None, ended_at: datetime | None) -> float | None:
+    if started_at is None or ended_at is None:
+        return None
+    return max(0.0, float((ended_at - started_at).total_seconds()) / 3600.0)
+
+
+def _run_gh_api(path: str) -> list[dict[str, Any]]:
+    command = ["gh", "api", path]
+    completed = subprocess.run(command, capture_output=True, text=True)
+    _expect(
+        completed.returncode == 0,
+        f"gh api failed ({completed.returncode}) for '{path}': {completed.stderr.strip()}",
+    )
+    payload = json.loads(completed.stdout)
+    _expect(isinstance(payload, list), f"Expected JSON list from gh api path '{path}'.")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def _load_json_file(path: Path) -> list[dict[str, Any]]:
+    _expect(path.exists(), f"JSON file not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    _expect(isinstance(payload, list), f"Expected JSON list in file: {path}")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def _extract_signal_id(body: str) -> str:
+    text = str(body or "")
+    match = SIGNAL_MARKER_PATTERN.search(text)
+    if not match:
+        return "unknown"
+    return str(match.group("signal") or "unknown")
+
+
+def _coerce_label_names(labels_value: Any) -> list[str]:
+    if not isinstance(labels_value, list):
+        return []
+    names: list[str] = []
+    for item in labels_value:
+        if isinstance(item, dict):
+            name = str(item.get("name") or "").strip()
+            if name:
+                names.append(name)
+            continue
+        text = str(item or "").strip()
+        if text:
+            names.append(text)
+    return names
+
+
+def _classify_issue_status(
+    *,
+    signal_id: str,
+    issue_age_hours: float | None,
+    blocked_age_hours: float,
+) -> str:
+    if signal_id in BLOCKING_SIGNAL_IDS:
+        return "blocked"
+    if signal_id in RESIDUAL_SIGNAL_IDS:
+        return "residual"
+    if issue_age_hours is not None and float(issue_age_hours) >= float(blocked_age_hours):
+        return "blocked"
+    return "residual"
+
+
+def _build_markdown_summary(
+    *,
+    generated_at_utc: str,
+    open_issues_total: int,
+    blocked_total: int,
+    residual_total: int,
+    unknown_signal_total: int,
+    oldest_open_issue_age_hours: float | None,
+    issues: list[dict[str, Any]],
+) -> str:
+    lines: list[str] = [
+        "# Master CI Drift Status Report",
+        "",
+        f"- Generated at (UTC): `{generated_at_utc}`",
+        f"- Open `ci-drift` issues: `{open_issues_total}`",
+        f"- Blocked: `{blocked_total}`",
+        f"- Residual: `{residual_total}`",
+        f"- Unknown signal-id: `{unknown_signal_total}`",
+        (
+            f"- Oldest open issue age: `{oldest_open_issue_age_hours:.2f}h`"
+            if oldest_open_issue_age_hours is not None
+            else "- Oldest open issue age: `unknown`"
+        ),
+        "",
+    ]
+    if not issues:
+        lines += ["No open `ci-drift` issues.", ""]
+        return "\n".join(lines).strip() + "\n"
+
+    lines += [
+        "| Issue | Signal | Class | Age (h) | Updated (UTC) | Title |",
+        "|---|---|---|---:|---|---|",
+    ]
+    for issue in issues:
+        issue_number = int(issue.get("number") or 0)
+        issue_url = str(issue.get("url") or "").strip()
+        issue_ref = f"[#{issue_number}]({issue_url})" if issue_number > 0 and issue_url else f"#{issue_number}"
+        signal_id = str(issue.get("signal_id") or "unknown")
+        status_class = str(issue.get("status_class") or "residual")
+        issue_age_hours = issue.get("issue_age_hours")
+        age_text = f"{float(issue_age_hours):.2f}" if issue_age_hours is not None else "unknown"
+        updated_at = str(issue.get("updated_at") or "")
+        title = str(issue.get("title") or "")
+        lines.append(f"| {issue_ref} | `{signal_id}` | `{status_class}` | {age_text} | `{updated_at}` | {title} |")
+    lines.append("")
+    return "\n".join(lines).strip() + "\n"
+
+
+def run_master_ci_drift_status_report(
+    *,
+    label: str,
+    repo: str,
+    blocked_age_hours: float,
+    per_page: int,
+    issues_file: Path | None,
+    output_file: Path,
+    markdown_output_file: Path,
+) -> dict[str, Any]:
+    _expect(per_page > 0, "per_page must be > 0.")
+    _expect(float(blocked_age_hours) > 0, "blocked_age_hours must be > 0.")
+    started = time.perf_counter()
+
+    if issues_file is not None:
+        issues_payload = _load_json_file(issues_file)
+    else:
+        issues_payload = _run_gh_api(f"repos/{repo}/issues?state=open&labels=ci-drift&per_page={per_page}")
+
+    evaluation_now = datetime.now(timezone.utc)
+    issue_rows: list[dict[str, Any]] = []
+    for issue in issues_payload:
+        labels = _coerce_label_names(issue.get("labels"))
+        if "ci-drift" not in labels:
+            continue
+        number = int(issue.get("number") or 0)
+        created_at = _parse_utc_timestamp(str(issue.get("created_at") or ""))
+        updated_at = _parse_utc_timestamp(str(issue.get("updated_at") or ""))
+        issue_age_hours = _hours_between(created_at, evaluation_now)
+        signal_id = _extract_signal_id(str(issue.get("body") or ""))
+        status_class = _classify_issue_status(
+            signal_id=signal_id,
+            issue_age_hours=issue_age_hours,
+            blocked_age_hours=float(blocked_age_hours),
+        )
+        issue_rows.append(
+            {
+                "number": number,
+                "title": str(issue.get("title") or ""),
+                "url": str(issue.get("html_url") or ""),
+                "signal_id": signal_id,
+                "status_class": status_class,
+                "issue_age_hours": round(float(issue_age_hours), 3) if issue_age_hours is not None else None,
+                "created_at": created_at.strftime("%Y-%m-%dT%H:%M:%SZ") if created_at is not None else "",
+                "updated_at": updated_at.strftime("%Y-%m-%dT%H:%M:%SZ") if updated_at is not None else "",
+                "labels": labels,
+            }
+        )
+
+    issue_rows.sort(
+        key=lambda item: (
+            0 if str(item.get("status_class")) == "blocked" else 1,
+            -(float(item.get("issue_age_hours") or 0.0)),
+            int(item.get("number") or 0),
+        )
+    )
+
+    blocked_issues = [item for item in issue_rows if str(item.get("status_class")) == "blocked"]
+    residual_issues = [item for item in issue_rows if str(item.get("status_class")) == "residual"]
+    unknown_signal_total = sum(1 for item in issue_rows if str(item.get("signal_id") or "unknown") == "unknown")
+    oldest_open_issue_age_hours = max(
+        [float(item.get("issue_age_hours") or 0.0) for item in issue_rows],
+        default=None,
+    )
+
+    criteria = [
+        {
+            "name": "report_generated",
+            "passed": True,
+            "details": f"open_ci_drift_issues_total={len(issue_rows)}",
+        }
+    ]
+    failed_criteria = [item for item in criteria if not bool(item.get("passed"))]
+    success = len(failed_criteria) == 0
+    generated_at_utc = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    markdown = _build_markdown_summary(
+        generated_at_utc=generated_at_utc,
+        open_issues_total=int(len(issue_rows)),
+        blocked_total=int(len(blocked_issues)),
+        residual_total=int(len(residual_issues)),
+        unknown_signal_total=int(unknown_signal_total),
+        oldest_open_issue_age_hours=oldest_open_issue_age_hours,
+        issues=issue_rows,
+    )
+
+    report = {
+        "label": label,
+        "success": bool(success),
+        "config": {
+            "repo": repo,
+            "blocked_age_hours": float(blocked_age_hours),
+            "per_page": int(per_page),
+            "issues_file": str(issues_file) if issues_file is not None else None,
+            "output_file": str(output_file),
+            "markdown_output_file": str(markdown_output_file),
+            "blocking_signal_ids": sorted(BLOCKING_SIGNAL_IDS),
+            "residual_signal_ids": sorted(RESIDUAL_SIGNAL_IDS),
+        },
+        "metrics": {
+            "open_ci_drift_issues_total": int(len(issue_rows)),
+            "blocked_issues_total": int(len(blocked_issues)),
+            "residual_issues_total": int(len(residual_issues)),
+            "unknown_signal_issues_total": int(unknown_signal_total),
+            "oldest_open_issue_age_hours": (
+                round(float(oldest_open_issue_age_hours), 3)
+                if oldest_open_issue_age_hours is not None
+                else None
+            ),
+            "criteria_failed": int(len(failed_criteria)),
+        },
+        "criteria": criteria,
+        "failed_criteria": failed_criteria,
+        "decision": {
+            "attention_required": bool(len(blocked_issues) > 0),
+            "recommended_action": (
+                "ci_drift_blocked_incident_review_required"
+                if len(blocked_issues) > 0
+                else (
+                    "ci_drift_residual_monitoring"
+                    if len(residual_issues) > 0
+                    else "ci_drift_clear"
+                )
+            ),
+        },
+        "issues": issue_rows,
+        "markdown_summary": markdown,
+        "generated_at_utc": generated_at_utc,
+        "duration_ms": int((time.perf_counter() - started) * 1000),
+    }
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    markdown_output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2), encoding="utf-8")
+    markdown_output_file.write_text(markdown, encoding="utf-8")
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build a daily CI-drift issue status report with blocked/residual classification and issue age signals."
+        )
+    )
+    parser.add_argument("--label", default="master-ci-drift-status-report")
+    parser.add_argument("--repo", default="donatomaurizio99-collab/GOC")
+    parser.add_argument("--blocked-age-hours", type=float, default=24.0)
+    parser.add_argument("--per-page", type=int, default=100)
+    parser.add_argument("--issues-file")
+    parser.add_argument("--output-file", default="artifacts/master-ci-drift-status-report.json")
+    parser.add_argument("--markdown-output-file", default="artifacts/master-ci-drift-status-report.md")
+    args = parser.parse_args(argv)
+
+    if int(args.per_page) <= 0:
+        print("[master-ci-drift-status-report] ERROR: --per-page must be > 0.", file=sys.stderr)
+        return 2
+    if float(args.blocked_age_hours) <= 0:
+        print("[master-ci-drift-status-report] ERROR: --blocked-age-hours must be > 0.", file=sys.stderr)
+        return 2
+
+    try:
+        report = run_master_ci_drift_status_report(
+            label=str(args.label),
+            repo=str(args.repo),
+            blocked_age_hours=float(args.blocked_age_hours),
+            per_page=int(args.per_page),
+            issues_file=Path(str(args.issues_file)).expanduser() if args.issues_file else None,
+            output_file=Path(str(args.output_file)).expanduser(),
+            markdown_output_file=Path(str(args.markdown_output_file)).expanduser(),
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"[master-ci-drift-status-report] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/master-reliability-digest.py
+++ b/scripts/master-reliability-digest.py
@@ -342,6 +342,9 @@ def _build_reliability_markdown(
     warning_sustained_runs: int,
     release_gate_warning_triggered: bool,
     release_gate_consecutive_over_threshold: int,
+    guard_warning_sustained_runs: int,
+    guard_consecutive_non_success: int,
+    guard_warning_triggered: bool,
     release_gate_samples: list[dict[str, Any]],
     guard_samples: list[dict[str, Any]],
     guard_non_success_runs: list[dict[str, Any]],
@@ -397,6 +400,11 @@ def _build_reliability_markdown(
         f"- Guard samples: {len(guard_samples)}",
         f"- Non-success guard runs: {len(guard_non_success_runs)}",
         (
+            "- Consecutive non-success guard runs (head): "
+            f"{guard_consecutive_non_success} (threshold={guard_warning_sustained_runs})"
+        ),
+        f"- Guard warning triggered: {'yes' if guard_warning_triggered else 'no'}",
+        (
             f"- Latest degraded guard run: `#{degraded_run_id}` ({degraded_run_url}) "
             f"conclusion=`{degraded_conclusion or 'unknown'}`"
             if degraded_run_id > 0 and degraded_run_url
@@ -451,6 +459,7 @@ def run_master_reliability_digest(
     guard_trend_runs: int,
     release_gate_warning_seconds: int,
     warning_sustained_runs: int,
+    guard_warning_sustained_runs: int,
     fail_on_warning: bool,
     ci_runs_file: Path | None,
     ci_jobs_dir: Path | None,
@@ -465,6 +474,7 @@ def run_master_reliability_digest(
     _expect(guard_trend_runs > 0, "guard_trend_runs must be > 0.")
     _expect(release_gate_warning_seconds > 0, "release_gate_warning_seconds must be > 0.")
     _expect(warning_sustained_runs > 0, "warning_sustained_runs must be > 0.")
+    _expect(guard_warning_sustained_runs > 0, "guard_warning_sustained_runs must be > 0.")
 
     started = time.perf_counter()
     ci_runs = (
@@ -506,6 +516,20 @@ def run_master_reliability_digest(
         if str(item.get("status") or "") == "completed"
         and str(item.get("conclusion") or "").strip().lower() != "success"
     ]
+
+    guard_consecutive_non_success = 0
+    for sample in guard_samples:
+        sample_status = str(sample.get("status") or "").strip().lower()
+        sample_conclusion = str(sample.get("conclusion") or "").strip().lower()
+        if sample_status == "completed" and sample_conclusion != "success":
+            guard_consecutive_non_success += 1
+        else:
+            break
+
+    guard_warning_triggered = bool(
+        guard_consecutive_non_success >= guard_warning_sustained_runs
+        and len(guard_samples) >= guard_warning_sustained_runs
+    )
 
     release_gate_consecutive_over_threshold = 0
     for sample in release_gate_duration_samples:
@@ -598,12 +622,13 @@ def run_master_reliability_digest(
             "name": "warning_policy",
             "passed": bool(
                 (not fail_on_warning)
-                or (not release_gate_warning_triggered and len(guard_non_success_runs) == 0)
+                or (not release_gate_warning_triggered and not guard_warning_triggered)
             ),
             "details": (
                 f"fail_on_warning={fail_on_warning}, "
                 f"release_gate_warning_triggered={release_gate_warning_triggered}, "
-                f"guard_non_success_total={len(guard_non_success_runs)}"
+                f"guard_warning_triggered={guard_warning_triggered}, "
+                f"guard_consecutive_non_success={guard_consecutive_non_success}"
             ),
         },
     ]
@@ -612,7 +637,7 @@ def run_master_reliability_digest(
 
     latest_release_sample = release_gate_duration_samples[0] if release_gate_duration_samples else {}
     latest_guard_non_success = guard_non_success_runs[0] if guard_non_success_runs else {}
-    if release_gate_warning_triggered and len(guard_non_success_runs) > 0:
+    if release_gate_warning_triggered and guard_warning_triggered:
         top_cause = "compound_runtime_and_guard_degradation"
         top_cause_detail = (
             "Sustained Release Gate slowdown and degraded guard workflow(s) observed simultaneously."
@@ -622,9 +647,12 @@ def run_master_reliability_digest(
         top_cause_detail = (
             "Release Gate runtime stayed above threshold for sustained runs."
         )
-    elif len(guard_non_success_runs) > 0:
-        top_cause = "guard_workflow_degraded"
-        top_cause_detail = "Guard workflow reported non-success conclusion."
+    elif guard_warning_triggered:
+        top_cause = "guard_workflow_consecutive_degradation"
+        top_cause_detail = (
+            f"Guard workflow reported {guard_consecutive_non_success} consecutive non-success runs "
+            f"(threshold={guard_warning_sustained_runs})."
+        )
     else:
         top_cause = "none"
         top_cause_detail = "No warning-level signal in digest window."
@@ -636,6 +664,9 @@ def run_master_reliability_digest(
         warning_sustained_runs=warning_sustained_runs,
         release_gate_warning_triggered=release_gate_warning_triggered,
         release_gate_consecutive_over_threshold=release_gate_consecutive_over_threshold,
+        guard_warning_sustained_runs=guard_warning_sustained_runs,
+        guard_consecutive_non_success=guard_consecutive_non_success,
+        guard_warning_triggered=guard_warning_triggered,
         release_gate_samples=release_gate_duration_samples,
         guard_samples=guard_samples,
         guard_non_success_runs=guard_non_success_runs,
@@ -677,6 +708,7 @@ def run_master_reliability_digest(
             "guard_trend_runs": int(guard_trend_runs),
             "release_gate_warning_seconds": int(release_gate_warning_seconds),
             "warning_sustained_runs": int(warning_sustained_runs),
+            "guard_warning_sustained_runs": int(guard_warning_sustained_runs),
             "fail_on_warning": bool(fail_on_warning),
             "ci_runs_file": str(ci_runs_file) if ci_runs_file is not None else None,
             "ci_jobs_dir": str(ci_jobs_dir) if ci_jobs_dir is not None else None,
@@ -695,6 +727,9 @@ def run_master_reliability_digest(
             ),
             "guard_samples_total": int(len(guard_samples)),
             "guard_non_success_total": int(len(guard_non_success_runs)),
+            "guard_consecutive_non_success": int(guard_consecutive_non_success),
+            "guard_warning_sustained_runs": int(guard_warning_sustained_runs),
+            "guard_warning_triggered": 1 if guard_warning_triggered else 0,
             "issue_upsert_samples_total": int(len(issue_upsert_samples)),
             "upsert_artifacts_missing_total": int(upsert_artifacts_missing_total),
             "active_comment_suppressed_total_sum": int(active_comment_suppressed_total_sum),
@@ -721,7 +756,7 @@ def run_master_reliability_digest(
         "failed_criteria": failed_criteria,
         "decision": {
             "release_gate_warning_triggered": bool(release_gate_warning_triggered),
-            "guard_health_degraded": bool(len(guard_non_success_runs) > 0),
+            "guard_health_degraded": bool(guard_warning_triggered),
             "top_cause": top_cause,
             "top_cause_detail": top_cause_detail,
             "mttr_trend": str(mttr_summary.get("mttr_trend") or "insufficient_data"),
@@ -729,12 +764,12 @@ def run_master_reliability_digest(
             "latest_degraded_guard_run_url": str(latest_guard_non_success.get("run_url") or ""),
             "warning_level": (
                 "warning"
-                if release_gate_warning_triggered or len(guard_non_success_runs) > 0
+                if release_gate_warning_triggered or guard_warning_triggered
                 else "healthy"
             ),
             "recommended_action": (
                 "investigate_master_reliability_regression"
-                if release_gate_warning_triggered or len(guard_non_success_runs) > 0
+                if release_gate_warning_triggered or guard_warning_triggered
                 else "master_reliability_stable"
             ),
         },
@@ -778,6 +813,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--guard-trend-runs", type=int, default=10)
     parser.add_argument("--release-gate-warning-seconds", type=int, default=540)
     parser.add_argument("--warning-sustained-runs", type=int, default=3)
+    parser.add_argument("--guard-warning-sustained-runs", type=int, default=2)
     parser.add_argument("--ci-runs-file")
     parser.add_argument("--ci-jobs-dir")
     parser.add_argument("--guard-runs-file")
@@ -805,6 +841,9 @@ def main(argv: list[str] | None = None) -> int:
     if int(args.warning_sustained_runs) <= 0:
         print("[master-reliability-digest] ERROR: --warning-sustained-runs must be > 0.", file=sys.stderr)
         return 2
+    if int(args.guard_warning_sustained_runs) <= 0:
+        print("[master-reliability-digest] ERROR: --guard-warning-sustained-runs must be > 0.", file=sys.stderr)
+        return 2
 
     try:
         report = run_master_reliability_digest(
@@ -821,6 +860,7 @@ def main(argv: list[str] | None = None) -> int:
             guard_trend_runs=int(args.guard_trend_runs),
             release_gate_warning_seconds=int(args.release_gate_warning_seconds),
             warning_sustained_runs=int(args.warning_sustained_runs),
+            guard_warning_sustained_runs=int(args.guard_warning_sustained_runs),
             fail_on_warning=bool(args.fail_on_warning),
             ci_runs_file=Path(str(args.ci_runs_file)).expanduser() if args.ci_runs_file else None,
             ci_jobs_dir=Path(str(args.ci_jobs_dir)).expanduser() if args.ci_jobs_dir else None,

--- a/scripts/run-master-ci-drift-status-report.ps1
+++ b/scripts/run-master-ci-drift-status-report.ps1
@@ -1,0 +1,35 @@
+param(
+    [string]$Label = "master-ci-drift-status-report",
+    [string]$Repo = "donatomaurizio99-collab/GOC",
+    [double]$BlockedAgeHours = 24,
+    [int]$PerPage = 100,
+    [string]$IssuesFile = "",
+    [string]$OutputFile = "artifacts\\master-ci-drift-status-report.json",
+    [string]$MarkdownOutputFile = "artifacts\\master-ci-drift-status-report.md",
+    [string]$PythonExe = "python"
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$args = @(
+    ".\\scripts\\master-ci-drift-status-report.py",
+    "--label", $Label,
+    "--repo", $Repo,
+    "--blocked-age-hours", [string]$BlockedAgeHours,
+    "--per-page", [string]$PerPage,
+    "--output-file", $OutputFile,
+    "--markdown-output-file", $MarkdownOutputFile
+)
+if ($IssuesFile) {
+    $args += @("--issues-file", $IssuesFile)
+}
+
+& $PythonExe @args
+if ($LASTEXITCODE -ne 0) {
+    throw "Master CI-drift status report failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Master CI-drift status report completed." -ForegroundColor Green

--- a/scripts/run-master-reliability-digest.ps1
+++ b/scripts/run-master-reliability-digest.ps1
@@ -8,6 +8,7 @@ param(
     [int]$GuardTrendRuns = 10,
     [int]$ReleaseGateWarningSeconds = 540,
     [int]$WarningSustainedRuns = 3,
+    [int]$GuardWarningSustainedRuns = 2,
     [string]$CiRunsFile = "",
     [string]$CiJobsDir = "",
     [string]$GuardRunsFile = "",
@@ -33,6 +34,7 @@ $args = @(
     "--guard-trend-runs", [string]$GuardTrendRuns,
     "--release-gate-warning-seconds", [string]$ReleaseGateWarningSeconds,
     "--warning-sustained-runs", [string]$WarningSustainedRuns,
+    "--guard-warning-sustained-runs", [string]$GuardWarningSustainedRuns,
     "--output-file", $OutputFile,
     "--markdown-output-file", $MarkdownOutputFile
 )

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -13273,11 +13273,13 @@ def test_250_master_reliability_digest_workflow_wrapper_and_docs_wiring():
     assert "master-reliability-digest-warning" in workflow
     assert ".\\scripts\\run-ci-alert-issue-upsert.ps1" in workflow
     assert "active_comment_cooldown" in workflow
+    assert "guard_warning_sustained_runs" in workflow
     assert "master-reliability-digest" in workflow
 
     assert "master-reliability-digest.py" in wrapper
     assert "--release-gate-warning-seconds" in wrapper
     assert "--warning-sustained-runs" in wrapper
+    assert "--guard-warning-sustained-runs" in wrapper
     assert "--guard-upsert-reports-dir" in wrapper
     assert "MarkdownOutputFile" in wrapper
 
@@ -13395,7 +13397,7 @@ def test_251_master_reliability_digest_computes_trends_from_fixtures():
                         "id": 9902,
                         "updated_at": "2026-04-18T02:40:00Z",
                         "status": "completed",
-                        "conclusion": "success",
+                        "conclusion": "failure",
                         "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/9902",
                     },
                     {
@@ -13471,6 +13473,8 @@ def test_251_master_reliability_digest_computes_trends_from_fixtures():
         "540",
         "--warning-sustained-runs",
         "2",
+        "--guard-warning-sustained-runs",
+        "2",
         "--output-file",
         str(output_file.resolve()),
         "--markdown-output-file",
@@ -13487,7 +13491,10 @@ def test_251_master_reliability_digest_computes_trends_from_fixtures():
     assert payload["success"] is True
     assert payload["decision"]["release_gate_warning_triggered"] is True
     assert payload["metrics"]["release_gate_consecutive_over_threshold"] == 2
-    assert payload["metrics"]["guard_non_success_total"] == 1
+    assert payload["metrics"]["guard_non_success_total"] == 2
+    assert payload["metrics"]["guard_consecutive_non_success"] == 2
+    assert payload["metrics"]["guard_warning_triggered"] == 1
+    assert payload["decision"]["guard_health_degraded"] is True
     assert payload["metrics"]["active_comment_suppressed_total_sum"] == 3
     assert payload["metrics"]["upsert_artifacts_missing_total"] == 0
     assert payload["metrics"]["mttr_samples_total"] == 0
@@ -14036,6 +14043,7 @@ def test_260_master_workflow_wrapper_invocations_use_named_parameters():
         project_root / ".github" / "workflows" / "master-guard-workflow-health.yml",
         project_root / ".github" / "workflows" / "master-watchdog-rehearsal-slo-guard.yml",
         project_root / ".github" / "workflows" / "master-reliability-digest.yml",
+        project_root / ".github" / "workflows" / "master-ci-drift-status-report.yml",
         project_root / ".github" / "workflows" / "master-reliability-digest-guard.yml",
         project_root / ".github" / "workflows" / "master-guard-burnin-check.yml",
         project_root / ".github" / "workflows" / "master-production-readiness-gate.yml",
@@ -14112,3 +14120,310 @@ def test_262_ci_alert_issue_upsert_label_ensure_accepts_generic_422_when_label_e
     assert len(calls) == 2
     assert calls[0][0:4] == ["gh", "api", "repos/donatomaurizio99-collab/GOC/labels", "-X"]
     assert calls[1][0:3] == ["gh", "api", "repos/donatomaurizio99-collab/GOC/labels/ci-drift"]
+
+
+def test_263_master_reliability_digest_ignores_non_consecutive_guard_failures_for_warning():
+    workspace = _local_test_dir("pytest-master-reliability-digest-non-consecutive-guard-failures").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    ci_runs_file = workspace / "ci-runs.json"
+    ci_jobs_dir = workspace / "ci-jobs"
+    guard_runs_file = workspace / "guard-runs.json"
+    guard_upsert_dir = workspace / "guard-upsert"
+    output_file = workspace / "master-reliability-digest.json"
+    markdown_output_file = workspace / "master-reliability-digest.md"
+
+    ci_jobs_dir.mkdir(parents=True, exist_ok=True)
+    guard_upsert_dir.mkdir(parents=True, exist_ok=True)
+
+    ci_runs_file.write_text(
+        json.dumps(
+            {
+                "workflow_runs": [
+                    {
+                        "id": 7711,
+                        "updated_at": "2026-04-18T04:00:00Z",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/7711",
+                    },
+                    {
+                        "id": 7712,
+                        "updated_at": "2026-04-18T03:00:00Z",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/7712",
+                    },
+                ]
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (ci_jobs_dir / "7711.json").write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "name": "Release Gate (Windows)",
+                        "started_at": "2026-04-18T04:00:00Z",
+                        "completed_at": "2026-04-18T04:07:00Z",
+                    }
+                ]
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (ci_jobs_dir / "7712.json").write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "name": "Release Gate (Windows)",
+                        "started_at": "2026-04-18T03:00:00Z",
+                        "completed_at": "2026-04-18T03:08:00Z",
+                    }
+                ]
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    guard_runs_file.write_text(
+        json.dumps(
+            {
+                "workflow_runs": [
+                    {
+                        "id": 8811,
+                        "updated_at": "2026-04-18T03:50:00Z",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/8811",
+                    },
+                    {
+                        "id": 8812,
+                        "updated_at": "2026-04-18T02:50:00Z",
+                        "status": "completed",
+                        "conclusion": "failure",
+                        "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/8812",
+                    },
+                    {
+                        "id": 8813,
+                        "updated_at": "2026-04-18T01:50:00Z",
+                        "status": "completed",
+                        "conclusion": "failure",
+                        "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/8813",
+                    },
+                ]
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (guard_upsert_dir / "8811.json").write_text(
+        json.dumps(
+            {
+                "metrics": {"active_comment_suppressed_total": 0},
+                "decision": {"issue_action": "recovery_progress", "alert_triggered": False},
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (guard_upsert_dir / "8812.json").write_text(
+        json.dumps(
+            {
+                "metrics": {"active_comment_suppressed_total": 0},
+                "decision": {"issue_action": "commented", "alert_triggered": True},
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (guard_upsert_dir / "8813.json").write_text(
+        json.dumps(
+            {
+                "metrics": {"active_comment_suppressed_total": 0},
+                "decision": {"issue_action": "commented", "alert_triggered": True},
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "master-reliability-digest.py"),
+        "--label",
+        "pytest-master-reliability-digest-non-consecutive-guard-failures",
+        "--repo",
+        "donatomaurizio99-collab/GOC",
+        "--branch",
+        "master",
+        "--ci-runs-file",
+        str(ci_runs_file.resolve()),
+        "--ci-jobs-dir",
+        str(ci_jobs_dir.resolve()),
+        "--guard-runs-file",
+        str(guard_runs_file.resolve()),
+        "--guard-upsert-reports-dir",
+        str(guard_upsert_dir.resolve()),
+        "--trend-runs",
+        "2",
+        "--guard-trend-runs",
+        "3",
+        "--release-gate-warning-seconds",
+        "540",
+        "--warning-sustained-runs",
+        "2",
+        "--guard-warning-sustained-runs",
+        "2",
+        "--output-file",
+        str(output_file.resolve()),
+        "--markdown-output-file",
+        str(markdown_output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["decision"]["warning_level"] == "healthy"
+    assert payload["decision"]["guard_health_degraded"] is False
+    assert payload["decision"]["top_cause"] == "none"
+    assert payload["metrics"]["guard_non_success_total"] == 2
+    assert payload["metrics"]["guard_consecutive_non_success"] == 0
+    assert payload["metrics"]["guard_warning_triggered"] == 0
+    assert payload["metrics"]["release_gate_warning_triggered"] == 0
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_264_master_ci_drift_status_report_workflow_wrapper_and_docs_wiring():
+    project_root = Path(__file__).resolve().parents[1]
+    workflow = (project_root / ".github" / "workflows" / "master-ci-drift-status-report.yml").read_text(
+        encoding="utf-8"
+    )
+    wrapper = (project_root / "scripts" / "run-master-ci-drift-status-report.ps1").read_text(encoding="utf-8")
+    script = (project_root / "scripts" / "master-ci-drift-status-report.py").read_text(encoding="utf-8")
+    readme = (project_root / "README.md").read_text(encoding="utf-8")
+
+    assert "name: Master CI Drift Status Report" in workflow
+    assert 'cron: "40 6 * * *"' in workflow
+    assert ".\\scripts\\run-master-ci-drift-status-report.ps1" in workflow
+    assert "master-ci-drift-status-report.json" in workflow
+    assert "master-ci-drift-status-report.md" in workflow
+    assert "blocked_age_hours" in workflow
+    assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" in workflow
+
+    assert "master-ci-drift-status-report.py" in wrapper
+    assert "--blocked-age-hours" in wrapper
+    assert "--per-page" in wrapper
+    assert "--issues-file" in wrapper
+
+    assert "BLOCKING_SIGNAL_IDS" in script
+    assert "RESIDUAL_SIGNAL_IDS" in script
+    assert "status_class" in script
+
+    assert "master-ci-drift-status-report.yml" in readme
+    assert "run-master-ci-drift-status-report.ps1" in readme
+
+
+def test_265_master_ci_drift_status_report_classifies_blocked_and_residual_from_fixtures():
+    workspace = _local_test_dir("pytest-master-ci-drift-status-report-fixtures").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    issues_file = workspace / "issues.json"
+    output_file = workspace / "master-ci-drift-status-report.json"
+    markdown_output_file = workspace / "master-ci-drift-status-report.md"
+
+    issues_file.write_text(
+        json.dumps(
+            [
+                {
+                    "number": 2001,
+                    "title": "[CI Drift] master branch protection required checks drift",
+                    "html_url": "https://github.com/donatomaurizio99-collab/GOC/issues/2001",
+                    "created_at": "2026-04-18T00:00:00Z",
+                    "updated_at": "2026-04-18T04:00:00Z",
+                    "labels": [{"name": "ci-drift"}, {"name": "branch-protection"}],
+                    "body": (
+                        "<!-- ci-alert-key:master-branch-protection-drift:"
+                        "donatomaurizio99-collab/GOC:master -->"
+                    ),
+                },
+                {
+                    "number": 2002,
+                    "title": "[CI Drift] master reliability digest warning detected",
+                    "html_url": "https://github.com/donatomaurizio99-collab/GOC/issues/2002",
+                    "created_at": "2026-04-18T05:00:00Z",
+                    "updated_at": "2026-04-18T05:30:00Z",
+                    "labels": [{"name": "ci-drift"}, {"name": "reliability-digest"}],
+                    "body": (
+                        "<!-- ci-alert-key:master-reliability-digest-warning:"
+                        "donatomaurizio99-collab/GOC:master -->"
+                    ),
+                },
+            ],
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "master-ci-drift-status-report.py"),
+        "--label",
+        "pytest-master-ci-drift-status-report",
+        "--repo",
+        "donatomaurizio99-collab/GOC",
+        "--blocked-age-hours",
+        "24",
+        "--issues-file",
+        str(issues_file.resolve()),
+        "--output-file",
+        str(output_file.resolve()),
+        "--markdown-output-file",
+        str(markdown_output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["metrics"]["open_ci_drift_issues_total"] == 2
+    assert payload["metrics"]["blocked_issues_total"] == 1
+    assert payload["metrics"]["residual_issues_total"] == 1
+    assert payload["decision"]["attention_required"] is True
+    assert payload["decision"]["recommended_action"] == "ci_drift_blocked_incident_review_required"
+    assert output_file.exists()
+    assert markdown_output_file.exists()
+
+    issues = payload["issues"]
+    assert issues[0]["signal_id"] == "master-branch-protection-drift"
+    assert issues[0]["status_class"] == "blocked"
+    assert issues[1]["signal_id"] == "master-reliability-digest-warning"
+    assert issues[1]["status_class"] == "residual"
+
+    markdown = markdown_output_file.read_text(encoding="utf-8")
+    assert "Master CI Drift Status Report" in markdown
+    assert "`blocked`" in markdown
+    assert "`residual`" in markdown
+
+    shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
﻿## Summary
- reduce reliability-digest warning noise by basing guard degradation warnings on consecutive head failures (`--guard-warning-sustained-runs`, default `2`) instead of any historical non-success sample
- keep historical non-success samples for context metrics while using warning-only signal logic for alert triggering and recommended action
- add daily `master-ci-drift-status-report` automation (script + wrapper + workflow) that reports open `ci-drift` issues with issue age and blocked/residual classification
- publish CI-drift markdown summary to workflow summary and artifact for on-call visibility
- document new knobs/workflow/local commands and extend regression tests

## Validation
- `python -m py_compile scripts/master-reliability-digest.py scripts/master-ci-drift-status-report.py tests/test_goal_ops.py`
- `pytest -q tests/test_goal_ops.py -k "test_250_master_reliability_digest_workflow_wrapper_and_docs_wiring or test_251_master_reliability_digest_computes_trends_from_fixtures or test_260_master_workflow_wrapper_invocations_use_named_parameters or test_263_master_reliability_digest_ignores_non_consecutive_guard_failures_for_warning or test_264_master_ci_drift_status_report_workflow_wrapper_and_docs_wiring or test_265_master_ci_drift_status_report_classifies_blocked_and_residual_from_fixtures or test_262_ci_alert_issue_upsert_label_ensure_accepts_generic_422_when_label_exists"`
- `python .\scripts\p0-runbook-contract-check.py --label local-prepr-master-reliability-noise-and-drift-status --project-root .`
