### PR TITLE
Add hard release-gate runtime SLO guard chain

### DIFF
--- a/.github/workflows/master-release-gate-runtime-slo-guard.yml
+++ b/.github/workflows/master-release-gate-runtime-slo-guard.yml
@@ -1,0 +1,140 @@
+name: Master Release Gate Runtime SLO Guard
+
+on:
+  schedule:
+    - cron: "20 3 * * *"
+  workflow_dispatch:
+    inputs:
+      lookback_hours:
+        description: "Hours of master CI history to inspect"
+        required: false
+        default: "72"
+      per_page:
+        description: "Maximum completed CI runs to fetch"
+        required: false
+        default: "80"
+      threshold_seconds:
+        description: "Hard SLO guard threshold for Release Gate runtime in seconds"
+        required: false
+        default: "600"
+      sustained_runs:
+        description: "Consecutive runs over threshold needed to breach guard"
+        required: false
+        default: "3"
+      allow_breach:
+        description: "Do not fail workflow when runtime SLO guard is breached"
+        required: false
+        default: "false"
+      recovery_threshold:
+        description: "Healthy nightly runs required before auto-closing an open runtime SLO guard issue"
+        required: false
+        default: "2"
+      active_comment_cooldown:
+        description: "Comment cooldown for unchanged active alerts (comment every N runs)"
+        required: false
+        default: "3"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  runtime-slo-guard:
+    name: Release Gate Runtime SLO Guard
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Run release-gate runtime SLO guard
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_FULL: ${{ github.repository }}
+          LOOKBACK_HOURS: ${{ github.event.inputs.lookback_hours || '72' }}
+          PER_PAGE: ${{ github.event.inputs.per_page || '80' }}
+          THRESHOLD_SECONDS: ${{ github.event.inputs.threshold_seconds || '600' }}
+          SUSTAINED_RUNS: ${{ github.event.inputs.sustained_runs || '3' }}
+          ALLOW_BREACH: ${{ github.event.inputs.allow_breach || 'false' }}
+        run: |
+          if ($env:ALLOW_BREACH -eq "true") {
+            .\scripts\run-master-release-gate-runtime-slo-guard.ps1 `
+              -Repo "$env:REPO_FULL" `
+              -LookbackHours "$env:LOOKBACK_HOURS" `
+              -PerPage "$env:PER_PAGE" `
+              -ThresholdSeconds "$env:THRESHOLD_SECONDS" `
+              -SustainedRuns "$env:SUSTAINED_RUNS" `
+              -OutputFile "artifacts\release-gate-runtime-slo-guard.json" `
+              -AllowBreach
+          } else {
+            .\scripts\run-master-release-gate-runtime-slo-guard.ps1 `
+              -Repo "$env:REPO_FULL" `
+              -LookbackHours "$env:LOOKBACK_HOURS" `
+              -PerPage "$env:PER_PAGE" `
+              -ThresholdSeconds "$env:THRESHOLD_SECONDS" `
+              -SustainedRuns "$env:SUSTAINED_RUNS" `
+              -OutputFile "artifacts\release-gate-runtime-slo-guard.json"
+          }
+
+      - name: Upsert runtime SLO guard issue
+        if: always()
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_FULL: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RECOVERY_THRESHOLD: ${{ github.event.inputs.recovery_threshold || '2' }}
+          ACTIVE_COMMENT_COOLDOWN: ${{ github.event.inputs.active_comment_cooldown || '3' }}
+        run: |
+          .\scripts\run-ci-alert-issue-upsert.ps1 `
+            -SignalId "release-gate-runtime-slo-guard" `
+            -Repo "$env:REPO_FULL" `
+            -ReportFile "artifacts\release-gate-runtime-slo-guard.json" `
+            -RunUrl "$env:RUN_URL" `
+            -RecoveryThreshold "$env:RECOVERY_THRESHOLD" `
+            -ActiveCommentCooldown "$env:ACTIVE_COMMENT_COOLDOWN" `
+            -OutputFile "artifacts\release-gate-runtime-slo-guard-issue-upsert.json"
+
+      - name: Run runtime SLO guard chain selftest
+        if: always()
+        shell: pwsh
+        run: |
+          .\scripts\run-master-guard-chain-selftest.ps1 `
+            -SignalId "release-gate-runtime-slo-guard" `
+            -GuardReportFile "artifacts\release-gate-runtime-slo-guard.json" `
+            -IssueUpsertReportFile "artifacts\release-gate-runtime-slo-guard-issue-upsert.json" `
+            -OutputFile "artifacts\release-gate-runtime-slo-guard-selftest.json"
+
+      - name: Upload runtime SLO guard report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-gate-runtime-slo-guard
+          path: artifacts/release-gate-runtime-slo-guard.json
+          if-no-files-found: error
+
+      - name: Upload runtime SLO guard issue upsert report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-gate-runtime-slo-guard-issue-upsert
+          path: artifacts/release-gate-runtime-slo-guard-issue-upsert.json
+          if-no-files-found: error
+
+      - name: Upload runtime SLO guard chain selftest report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-gate-runtime-slo-guard-selftest
+          path: artifacts/release-gate-runtime-slo-guard-selftest.json
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -954,6 +954,7 @@ Nightly guard workflows now execute `run-master-guard-chain-selftest.ps1` to val
 Weekly [master-watchdog-rehearsal-drill.yml](.github/workflows/master-watchdog-rehearsal-drill.yml) runs an injected-failure drill for the watchdog chain and verifies guard-health alert upsert behavior in dry-run mode.
 Nightly [master-watchdog-rehearsal-slo-guard.yml](.github/workflows/master-watchdog-rehearsal-slo-guard.yml) verifies the rehearsal drill SLO (>=1 successful run in 8 days) and raises a deduped `ci-drift` issue with explicit `stale`/`failed` reason plus latest run reference.
 Nightly release-gate runtime early warning now flags sustained runtime slowdown (default: 3 consecutive runs >= 540s) before it escalates into flaky failures, and escalates when an active runtime warning issue stays open beyond the alert-age SLO (default: 72h).
+Nightly [master-release-gate-runtime-slo-guard.yml](.github/workflows/master-release-gate-runtime-slo-guard.yml) enforces a hard runtime guard (default: 3 consecutive runs >= 600s) and raises a deduped `ci-drift` blocking issue when breached.
 Nightly drift/warning workflows now upsert deduplicated GitHub issues (labels: `ci-drift` + signal label), enforce the invariant of at most one open issue per signal, reset recovery streak on active alerts, and auto-close recovered issues after 2 healthy nightly runs (configurable threshold). Active-alert comments are cooldown-throttled for unchanged failure states (default every 3 runs), while issue bodies continue to refresh each run. The runtime alert-age SLO escalation issue now carries a mandatory parent runtime-warning reference in its issue body and closes immediately when parent-coupled escalation criteria are no longer met.
 Weekly [master-reliability-digest.yml](.github/workflows/master-reliability-digest.yml) publishes a trend digest (Release Gate runtime, guard degradations, active-comment suppression totals) as artifact + workflow summary for proactive reliability tracking and feeds the deduped warning signal `master-reliability-digest-warning`.
 Reliability-digest guard degradation warnings are now based on consecutive head failures (default: 2) instead of any historical non-success sample in the trend window to reduce alert noise after successful recovery.
@@ -987,6 +988,9 @@ Nightly guard-workflow health watchdog:
 
 Nightly release-gate runtime early warning workflow:
 [master-release-gate-runtime-early-warning.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/master-release-gate-runtime-early-warning.yml)
+
+Nightly release-gate runtime SLO guard workflow:
+[master-release-gate-runtime-slo-guard.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/master-release-gate-runtime-slo-guard.yml)
 
 Weekly master reliability digest workflow:
 [master-reliability-digest.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/master-reliability-digest.yml)
@@ -1059,6 +1063,13 @@ Local release-gate runtime early warning command:
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-release-gate-runtime-early-warning.ps1 -ThresholdSeconds 540 -SustainedRuns 3
+```
+
+Local release-gate runtime SLO guard command:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-master-release-gate-runtime-slo-guard.ps1 -ThresholdSeconds 600 -SustainedRuns 3
 ```
 
 Local master reliability digest command:

--- a/scripts/ci-alert-issue-upsert.py
+++ b/scripts/ci-alert-issue-upsert.py
@@ -26,6 +26,10 @@ SIGNAL_SPECS: dict[str, dict[str, Any]] = {
         "title": "[Release Gate Runtime] sustained runtime warning on master",
         "labels": ["ci-drift", "release-gate-runtime"],
     },
+    "release-gate-runtime-slo-guard": {
+        "title": "[CI Drift] release gate runtime SLO guard breached on master",
+        "labels": ["ci-drift", "release-gate-runtime", "release-gate-runtime-guard"],
+    },
     "release-gate-runtime-alert-age-slo": {
         "title": "[Release Gate Runtime] alert issue age SLO breached on master",
         "labels": ["ci-drift", "release-gate-runtime", "alert-age-slo"],
@@ -60,6 +64,10 @@ LABEL_DEFINITIONS: dict[str, dict[str, str]] = {
     "release-gate-runtime": {
         "color": "0E8A16",
         "description": "Sustained Release Gate runtime warning on master CI",
+    },
+    "release-gate-runtime-guard": {
+        "color": "B60205",
+        "description": "Release Gate runtime SLO guard breach on master CI",
     },
     "alert-age-slo": {
         "color": "FBCA04",
@@ -465,18 +473,23 @@ def _signal_alert_state(
         ]
         return alert_triggered, summary, branch, {}
 
-    if signal_id == "release-gate-runtime-early-warning":
+    if signal_id in {"release-gate-runtime-early-warning", "release-gate-runtime-slo-guard"}:
         decision = report.get("decision") if isinstance(report.get("decision"), dict) else {}
         metrics = report.get("metrics") if isinstance(report.get("metrics"), dict) else {}
         warning_message = str(report.get("warning_message") or "")
         threshold_seconds = config.get("threshold_seconds")
         sustained_runs = config.get("sustained_runs")
         alert_triggered = bool(decision.get("warning_triggered"))
+        signal_prefix = (
+            "Runtime SLO guard breach"
+            if signal_id == "release-gate-runtime-slo-guard"
+            else "Runtime warning"
+        )
         summary = [
             (
                 f"- Warning: {warning_message}"
                 if warning_message
-                else "- Warning: Release Gate runtime warning triggered without explicit message"
+                else f"- {signal_prefix}: triggered without explicit message"
             ),
             (
                 "- Consecutive runs over threshold: "

--- a/scripts/master-ci-drift-status-report.py
+++ b/scripts/master-ci-drift-status-report.py
@@ -14,6 +14,7 @@ from typing import Any
 BLOCKING_SIGNAL_IDS = {
     "master-branch-protection-drift",
     "master-guard-workflow-health",
+    "release-gate-runtime-slo-guard",
     "release-gate-runtime-alert-age-slo",
     "master-watchdog-rehearsal-drill-slo",
     "master-reliability-digest-guard",

--- a/scripts/master-guard-burnin-check.py
+++ b/scripts/master-guard-burnin-check.py
@@ -34,6 +34,15 @@ DEFAULT_GUARD_BURNIN_WORKFLOW_SPECS = [
         ],
     },
     {
+        "workflow_file": "master-release-gate-runtime-slo-guard.yml",
+        "workflow_name": "Master Release Gate Runtime SLO Guard",
+        "required_artifacts": [
+            "release-gate-runtime-slo-guard",
+            "release-gate-runtime-slo-guard-issue-upsert",
+            "release-gate-runtime-slo-guard-selftest",
+        ],
+    },
+    {
         "workflow_file": "master-guard-workflow-health.yml",
         "workflow_name": "Master Guard Workflow Health",
         "required_artifacts": [

--- a/scripts/master-guard-chain-selftest.py
+++ b/scripts/master-guard-chain-selftest.py
@@ -10,6 +10,7 @@ from typing import Any
 
 SIGNAL_ALERT_DECISION_KEY = {
     "master-guard-workflow-health": "guard_workflow_health_degraded",
+    "release-gate-runtime-slo-guard": "warning_triggered",
     "master-watchdog-rehearsal-drill-slo": "watchdog_rehearsal_slo_breached",
     "master-reliability-digest-guard": "reliability_digest_guard_breached",
 }

--- a/scripts/master-guard-workflow-health-check.py
+++ b/scripts/master-guard-workflow-health-check.py
@@ -34,6 +34,15 @@ DEFAULT_GUARD_WORKFLOW_SPECS = [
         ],
     },
     {
+        "workflow_file": "master-release-gate-runtime-slo-guard.yml",
+        "workflow_name": "Master Release Gate Runtime SLO Guard",
+        "required_artifacts": [
+            "release-gate-runtime-slo-guard",
+            "release-gate-runtime-slo-guard-issue-upsert",
+            "release-gate-runtime-slo-guard-selftest",
+        ],
+    },
+    {
         "workflow_file": "master-guard-workflow-health.yml",
         "workflow_name": "Master Guard Workflow Health",
         "required_artifacts": [

--- a/scripts/run-ci-alert-issue-upsert.ps1
+++ b/scripts/run-ci-alert-issue-upsert.ps1
@@ -1,6 +1,6 @@
 ﻿param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("master-branch-protection-drift", "master-guard-workflow-health", "release-gate-runtime-early-warning", "release-gate-runtime-alert-age-slo", "master-watchdog-rehearsal-drill-slo", "master-reliability-digest-warning", "master-reliability-digest-guard")]
+    [ValidateSet("master-branch-protection-drift", "master-guard-workflow-health", "release-gate-runtime-early-warning", "release-gate-runtime-slo-guard", "release-gate-runtime-alert-age-slo", "master-watchdog-rehearsal-drill-slo", "master-reliability-digest-warning", "master-reliability-digest-guard")]
     [string]$SignalId,
     [Parameter(Mandatory = $true)]
     [string]$ReportFile,

--- a/scripts/run-master-guard-chain-selftest.ps1
+++ b/scripts/run-master-guard-chain-selftest.ps1
@@ -1,6 +1,6 @@
 param(
     [string]$Label = "master-guard-chain-selftest",
-    [ValidateSet("master-guard-workflow-health", "master-watchdog-rehearsal-drill-slo", "master-reliability-digest-guard")]
+    [ValidateSet("master-guard-workflow-health", "release-gate-runtime-slo-guard", "master-watchdog-rehearsal-drill-slo", "master-reliability-digest-guard")]
     [string]$SignalId = "master-guard-workflow-health",
     [string]$GuardReportFile = "artifacts\\master-guard-workflow-health-check.json",
     [string]$IssueUpsertReportFile = "artifacts\\master-guard-workflow-health-issue-upsert.json",

--- a/scripts/run-master-release-gate-runtime-slo-guard.ps1
+++ b/scripts/run-master-release-gate-runtime-slo-guard.ps1
@@ -1,0 +1,43 @@
+param(
+    [string]$PythonExe = "python",
+    [string]$Label = "master-release-gate-runtime-slo-guard",
+    [string]$Repo = "donatomaurizio99-collab/GOC",
+    [string]$Branch = "master",
+    [string]$WorkflowName = "CI",
+    [string]$ReleaseGateJobName = "Release Gate (Windows)",
+    [int]$LookbackHours = 72,
+    [int]$PerPage = 80,
+    [int]$ThresholdSeconds = 600,
+    [int]$SustainedRuns = 3,
+    [string]$OutputFile = "artifacts\\release-gate-runtime-slo-guard.json",
+    [switch]$AllowBreach
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $ProjectRoot
+
+$args = @(
+    ".\\scripts\\release-gate-runtime-early-warning.py",
+    "--label", $Label,
+    "--repo", $Repo,
+    "--branch", $Branch,
+    "--workflow-name", $WorkflowName,
+    "--release-gate-job-name", $ReleaseGateJobName,
+    "--lookback-hours", [string]$LookbackHours,
+    "--per-page", [string]$PerPage,
+    "--threshold-seconds", [string]$ThresholdSeconds,
+    "--sustained-runs", [string]$SustainedRuns,
+    "--output-file", $OutputFile
+)
+if (-not $AllowBreach) {
+    $args += "--fail-on-warning"
+}
+
+& $PythonExe @args
+if ($LASTEXITCODE -ne 0) {
+    throw "Master release-gate runtime SLO guard failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Master release-gate runtime SLO guard completed." -ForegroundColor Green

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -11470,6 +11470,9 @@ def test_231_ci_alert_issue_upsert_workflow_wrapper_and_docs_wiring():
     runtime_workflow = (
         project_root / ".github" / "workflows" / "master-release-gate-runtime-early-warning.yml"
     ).read_text(encoding="utf-8")
+    runtime_slo_guard_workflow = (
+        project_root / ".github" / "workflows" / "master-release-gate-runtime-slo-guard.yml"
+    ).read_text(encoding="utf-8")
     rehearsal_slo_workflow = (
         project_root / ".github" / "workflows" / "master-watchdog-rehearsal-slo-guard.yml"
     ).read_text(encoding="utf-8")
@@ -11492,6 +11495,7 @@ def test_231_ci_alert_issue_upsert_workflow_wrapper_and_docs_wiring():
     assert "master-branch-protection-drift" in wrapper
     assert "master-guard-workflow-health" in wrapper
     assert "release-gate-runtime-early-warning" in wrapper
+    assert "release-gate-runtime-slo-guard" in wrapper
     assert "release-gate-runtime-alert-age-slo" in wrapper
     assert "master-watchdog-rehearsal-drill-slo" in wrapper
     assert "master-reliability-digest-warning" in wrapper
@@ -11514,6 +11518,13 @@ def test_231_ci_alert_issue_upsert_workflow_wrapper_and_docs_wiring():
     assert "recovery_threshold" in runtime_workflow
     assert "alert_age_hours" in runtime_workflow
 
+    assert "issues: write" in runtime_slo_guard_workflow
+    assert ".\\scripts\\run-master-release-gate-runtime-slo-guard.ps1" in runtime_slo_guard_workflow
+    assert "release-gate-runtime-slo-guard" in runtime_slo_guard_workflow
+    assert "release-gate-runtime-slo-guard-issue-upsert.json" in runtime_slo_guard_workflow
+    assert "release-gate-runtime-slo-guard-selftest.json" in runtime_slo_guard_workflow
+    assert "active_comment_cooldown" in runtime_slo_guard_workflow
+
     assert "issues: write" in rehearsal_slo_workflow
     assert ".\\scripts\\run-ci-alert-issue-upsert.ps1" in rehearsal_slo_workflow
     assert "master-watchdog-rehearsal-drill-slo" in rehearsal_slo_workflow
@@ -11534,6 +11545,7 @@ def test_231_ci_alert_issue_upsert_workflow_wrapper_and_docs_wiring():
 
     assert "run-ci-alert-issue-upsert.ps1" in readme
     assert "labels: `ci-drift` + signal label" in readme
+    assert "master-release-gate-runtime-slo-guard.yml" in readme
     assert "[master-guard-workflow-health.yml]" in readme
     assert "guard-workflow health watchdog" in readme
     assert "Immediate Actions" in readme
@@ -12381,6 +12393,14 @@ def test_240_master_guard_workflow_health_check_fails_on_degraded_guard_workflow
                             "updated_at": "2026-04-18T03:20:00Z",
                         }
                     ],
+                    "Master Release Gate Runtime SLO Guard": [
+                        {
+                            "id": 9108,
+                            "status": "completed",
+                            "conclusion": "success",
+                            "updated_at": "2026-04-18T03:25:00Z",
+                        }
+                    ],
                     "Master Guard Workflow Health": [
                         {
                             "id": 9104,
@@ -12438,6 +12458,13 @@ def test_240_master_guard_workflow_health_check_fails_on_degraded_guard_workflow
                             {"name": "master-guard-workflow-health-issue-upsert", "expired": False},
                         ]
                     },
+                    "9108": {
+                        "artifacts": [
+                            {"name": "release-gate-runtime-slo-guard", "expired": False},
+                            {"name": "release-gate-runtime-slo-guard-issue-upsert", "expired": False},
+                            {"name": "release-gate-runtime-slo-guard-selftest", "expired": False},
+                        ]
+                    },
                     "9105": {
                         "artifacts": [
                             {"name": "master-watchdog-rehearsal-slo-guard", "expired": False},
@@ -12491,7 +12518,7 @@ def test_240_master_guard_workflow_health_check_fails_on_degraded_guard_workflow
     payload_text = completed.stderr.split(marker, 1)[1].strip()
     payload = json.loads(payload_text)
     assert payload["success"] is False
-    assert payload["metrics"]["guard_workflows_total"] == 7
+    assert payload["metrics"]["guard_workflows_total"] == 8
     assert payload["metrics"]["guard_workflows_degraded_total"] == 2
     assert payload["metrics"]["guard_workflows_missing_required_artifacts_total"] == 1
     assert payload["metrics"]["guard_workflows_non_success_total"] == 1
@@ -12763,6 +12790,14 @@ def test_243_master_guard_workflow_health_contract_fails_on_uncovered_workflow_f
                             "updated_at": "2026-04-18T03:20:00Z",
                         }
                     ],
+                    "Master Release Gate Runtime SLO Guard": [
+                        {
+                            "id": 9308,
+                            "status": "completed",
+                            "conclusion": "success",
+                            "updated_at": "2026-04-18T03:25:00Z",
+                        }
+                    ],
                     "Master Guard Workflow Health": [
                         {
                             "id": 9304,
@@ -12821,6 +12856,13 @@ def test_243_master_guard_workflow_health_contract_fails_on_uncovered_workflow_f
                             {"name": "master-guard-workflow-health-issue-upsert", "expired": False},
                         ]
                     },
+                    "9308": {
+                        "artifacts": [
+                            {"name": "release-gate-runtime-slo-guard", "expired": False},
+                            {"name": "release-gate-runtime-slo-guard-issue-upsert", "expired": False},
+                            {"name": "release-gate-runtime-slo-guard-selftest", "expired": False},
+                        ]
+                    },
                     "9305": {
                         "artifacts": [
                             {"name": "master-watchdog-rehearsal-slo-guard", "expired": False},
@@ -12862,7 +12904,8 @@ def test_243_master_guard_workflow_health_contract_fails_on_uncovered_workflow_f
         "--contract-workflow-files",
         (
             "master-required-checks-24h.yml,master-branch-protection-drift-guard.yml,"
-            "master-release-gate-runtime-early-warning.yml,master-guard-workflow-health.yml,"
+            "master-release-gate-runtime-early-warning.yml,master-release-gate-runtime-slo-guard.yml,"
+            "master-guard-workflow-health.yml,"
             "master-watchdog-rehearsal-slo-guard.yml,master-reliability-digest-guard.yml,"
             "master-guard-burnin-check.yml,"
             "master-extra-guard-contract-probe.yml"
@@ -14040,6 +14083,7 @@ def test_260_master_workflow_wrapper_invocations_use_named_parameters():
         project_root / ".github" / "workflows" / "master-required-checks-24h.yml",
         project_root / ".github" / "workflows" / "master-branch-protection-drift-guard.yml",
         project_root / ".github" / "workflows" / "master-release-gate-runtime-early-warning.yml",
+        project_root / ".github" / "workflows" / "master-release-gate-runtime-slo-guard.yml",
         project_root / ".github" / "workflows" / "master-guard-workflow-health.yml",
         project_root / ".github" / "workflows" / "master-watchdog-rehearsal-slo-guard.yml",
         project_root / ".github" / "workflows" / "master-reliability-digest.yml",
@@ -14444,3 +14488,33 @@ def test_266_workflows_use_node24_ready_artifact_action_major():
 
     assert modern_artifact_refs > 0
     assert legacy_artifact_refs == []
+
+
+def test_267_master_release_gate_runtime_slo_guard_workflow_wrapper_and_docs_wiring():
+    project_root = Path(__file__).resolve().parents[1]
+    workflow = (
+        project_root / ".github" / "workflows" / "master-release-gate-runtime-slo-guard.yml"
+    ).read_text(encoding="utf-8")
+    wrapper = (project_root / "scripts" / "run-master-release-gate-runtime-slo-guard.ps1").read_text(
+        encoding="utf-8"
+    )
+    readme = (project_root / "README.md").read_text(encoding="utf-8")
+
+    assert "name: Master Release Gate Runtime SLO Guard" in workflow
+    assert 'cron: "20 3 * * *"' in workflow
+    assert ".\\scripts\\run-master-release-gate-runtime-slo-guard.ps1" in workflow
+    assert "release-gate-runtime-slo-guard.json" in workflow
+    assert "release-gate-runtime-slo-guard-issue-upsert.json" in workflow
+    assert "release-gate-runtime-slo-guard-selftest.json" in workflow
+    assert "release-gate-runtime-slo-guard" in workflow
+    assert "active_comment_cooldown" in workflow
+    assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" in workflow
+
+    assert "release-gate-runtime-early-warning.py" in wrapper
+    assert "--threshold-seconds" in wrapper
+    assert "--sustained-runs" in wrapper
+    assert "--fail-on-warning" in wrapper
+    assert "AllowBreach" in wrapper
+
+    assert "master-release-gate-runtime-slo-guard.yml" in readme
+    assert "run-master-release-gate-runtime-slo-guard.ps1" in readme


### PR DESCRIPTION
﻿## Summary
- add a new nightly `Master Release Gate Runtime SLO Guard` workflow with hard-fail behavior for sustained runtime regressions (default: 3 consecutive runs >= 600s)
- wire the new guard into deduped issue upsert + guard-chain selftest + artifacts
- integrate the new signal into guard-health/burn-in contracts and CI-drift blocked classification
- extend docs and tests for wiring/coverage updates

## Validation
- `python -m py_compile scripts\\ci-alert-issue-upsert.py scripts\\master-ci-drift-status-report.py scripts\\master-guard-burnin-check.py scripts\\master-guard-chain-selftest.py scripts\\master-guard-workflow-health-check.py tests\\test_goal_ops.py`
- `python -m pytest tests\\test_goal_ops.py -k "test_228_release_gate_runtime_early_warning_workflow_wrapper_and_docs_wiring or test_231_ci_alert_issue_upsert_workflow_wrapper_and_docs_wiring or test_240_master_guard_workflow_health_check_fails_on_degraded_guard_workflows or test_241_master_guard_workflow_health_workflow_wrapper_and_docs_wiring or test_243_master_guard_workflow_health_contract_detects_uncovered_guard_workflow_file or test_258_master_production_readiness_gate_workflow_wrapper_and_docs_wiring or test_260_master_workflow_wrapper_invocations_use_named_parameters or test_264_master_ci_drift_status_report_workflow_wrapper_and_docs_wiring or test_265_master_ci_drift_status_report_classifies_blocked_and_residual_from_fixtures or test_267_master_release_gate_runtime_slo_guard_workflow_wrapper_and_docs_wiring"`
- `python .\\scripts\\p0-runbook-contract-check.py --label local-prepr-release-gate-runtime-slo-guard --project-root .`
