### PR TITLE
Harden watchdog MTTR guard and readiness gating

### DIFF
--- a/.github/workflows/master-production-readiness-gate.yml
+++ b/.github/workflows/master-production-readiness-gate.yml
@@ -37,6 +37,18 @@ on:
         description: "Required successful completed runs for weekly watchdog rehearsal drill workflow"
         required: false
         default: "1"
+      watchdog_max_age_hours:
+        description: "Maximum age (hours) for latest watchdog rehearsal drill run"
+        required: false
+        default: "192"
+      watchdog_per_page:
+        description: "Maximum completed watchdog rehearsal drill runs fetched"
+        required: false
+        default: "20"
+      watchdog_mttr_target_seconds:
+        description: "Alert-chain MTTR threshold (seconds) for watchdog rehearsal guard"
+        required: false
+        default: "300"
       allow_not_ready:
         description: "Do not fail workflow when production-readiness criteria are not met"
         required: false
@@ -120,6 +132,24 @@ jobs:
             -AllowDegraded `
             -OutputFile "artifacts\master-guard-burnin-check-readiness.json"
 
+      - name: Build watchdog rehearsal guard report
+        continue-on-error: true
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_FULL: ${{ github.repository }}
+          WATCHDOG_MAX_AGE_HOURS: ${{ github.event.inputs.watchdog_max_age_hours || '192' }}
+          WATCHDOG_PER_PAGE: ${{ github.event.inputs.watchdog_per_page || '20' }}
+          WATCHDOG_MTTR_TARGET_SECONDS: ${{ github.event.inputs.watchdog_mttr_target_seconds || '300' }}
+        run: |
+          .\scripts\run-master-watchdog-rehearsal-slo-guard.ps1 `
+            -Repo "$env:REPO_FULL" `
+            -MaxAgeHours "$env:WATCHDOG_MAX_AGE_HOURS" `
+            -PerPage "$env:WATCHDOG_PER_PAGE" `
+            -MttrTargetSeconds "$env:WATCHDOG_MTTR_TARGET_SECONDS" `
+            -AllowBreach `
+            -OutputFile "artifacts\master-watchdog-rehearsal-slo-guard-readiness.json"
+
       - name: Evaluate production readiness gate
         if: always()
         shell: pwsh
@@ -132,6 +162,7 @@ jobs:
               -BranchProtectionReportFile "artifacts\master-branch-protection-drift-guard-readiness.json" `
               -GuardHealthReportFile "artifacts\master-guard-workflow-health-check-readiness.json" `
               -GuardBurninReportFile "artifacts\master-guard-burnin-check-readiness.json" `
+              -WatchdogRehearsalGuardReportFile "artifacts\master-watchdog-rehearsal-slo-guard-readiness.json" `
               -OutputFile "artifacts\master-production-readiness-gate.json" `
               -AllowNotReady
           } else {
@@ -140,6 +171,7 @@ jobs:
               -BranchProtectionReportFile "artifacts\master-branch-protection-drift-guard-readiness.json" `
               -GuardHealthReportFile "artifacts\master-guard-workflow-health-check-readiness.json" `
               -GuardBurninReportFile "artifacts\master-guard-burnin-check-readiness.json" `
+              -WatchdogRehearsalGuardReportFile "artifacts\master-watchdog-rehearsal-slo-guard-readiness.json" `
               -OutputFile "artifacts\master-production-readiness-gate.json"
           }
 

--- a/.github/workflows/master-watchdog-rehearsal-slo-guard.yml
+++ b/.github/workflows/master-watchdog-rehearsal-slo-guard.yml
@@ -13,6 +13,14 @@ on:
         description: "Maximum completed runs fetched from watchdog rehearsal drill workflow"
         required: false
         default: "20"
+      mttr_target_seconds:
+        description: "Maximum alert-chain MTTR (seconds) from latest rehearsal drill evidence"
+        required: false
+        default: "300"
+      drill_artifact_name:
+        description: "Artifact name containing latest rehearsal drill JSON evidence"
+        required: false
+        default: "master-guard-workflow-health-rehearsal-drill"
       allow_breach:
         description: "Do not fail workflow when drill SLO breach is detected"
         required: false
@@ -54,21 +62,27 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO_FULL: ${{ github.repository }}
           MAX_AGE_HOURS: ${{ github.event.inputs.max_age_hours || '192' }}
+          MTTR_TARGET_SECONDS: ${{ github.event.inputs.mttr_target_seconds || '300' }}
           PER_PAGE: ${{ github.event.inputs.per_page || '20' }}
+          DRILL_ARTIFACT_NAME: ${{ github.event.inputs.drill_artifact_name || 'master-guard-workflow-health-rehearsal-drill' }}
           ALLOW_BREACH: ${{ github.event.inputs.allow_breach || 'false' }}
         run: |
           if ($env:ALLOW_BREACH -eq "true") {
             .\scripts\run-master-watchdog-rehearsal-slo-guard.ps1 `
               -Repo "$env:REPO_FULL" `
               -MaxAgeHours "$env:MAX_AGE_HOURS" `
+              -MttrTargetSeconds "$env:MTTR_TARGET_SECONDS" `
               -PerPage "$env:PER_PAGE" `
+              -DrillArtifactName "$env:DRILL_ARTIFACT_NAME" `
               -OutputFile "artifacts\master-watchdog-rehearsal-slo-guard.json" `
               -AllowBreach
           } else {
             .\scripts\run-master-watchdog-rehearsal-slo-guard.ps1 `
               -Repo "$env:REPO_FULL" `
               -MaxAgeHours "$env:MAX_AGE_HOURS" `
+              -MttrTargetSeconds "$env:MTTR_TARGET_SECONDS" `
               -PerPage "$env:PER_PAGE" `
+              -DrillArtifactName "$env:DRILL_ARTIFACT_NAME" `
               -OutputFile "artifacts\master-watchdog-rehearsal-slo-guard.json"
           }
 

--- a/README.md
+++ b/README.md
@@ -952,14 +952,14 @@ Guard-health issue summaries now include per-degraded-workflow diagnostics (reas
 Guard-health issue body/comments now include a dedicated `Immediate Actions` section with direct first-response steps and a local repro command.
 Nightly guard workflows now execute `run-master-guard-chain-selftest.ps1` to validate guard-report -> issue-upsert chain consistency and publish dedicated selftest artifacts.
 Weekly [master-watchdog-rehearsal-drill.yml](.github/workflows/master-watchdog-rehearsal-drill.yml) runs an injected-failure drill for the watchdog chain, verifies guard-health alert upsert behavior in dry-run mode, and publishes MTTR + run-link summary evidence for faster on-call triage.
-Nightly [master-watchdog-rehearsal-slo-guard.yml](.github/workflows/master-watchdog-rehearsal-slo-guard.yml) verifies the rehearsal drill SLO (>=1 successful run in 8 days) and raises a deduped `ci-drift` issue with explicit `stale`/`failed` reason plus latest run reference.
+Nightly [master-watchdog-rehearsal-slo-guard.yml](.github/workflows/master-watchdog-rehearsal-slo-guard.yml) verifies the rehearsal drill SLO (>=1 successful run in 8 days), enforces latest drill MTTR target evidence, and raises a deduped `ci-drift` issue with explicit `stale`/`failed`/`mttr` reason plus latest run reference.
 Nightly release-gate runtime early warning now flags sustained runtime slowdown (default: 3 consecutive runs >= 540s) before it escalates into flaky failures, and escalates when an active runtime warning issue stays open beyond the alert-age SLO (default: 72h).
 Nightly [master-release-gate-runtime-slo-guard.yml](.github/workflows/master-release-gate-runtime-slo-guard.yml) enforces a hard runtime guard (default: 3 consecutive runs >= 600s) and raises a deduped `ci-drift` blocking issue when breached.
 Nightly drift/warning workflows now upsert deduplicated GitHub issues (labels: `ci-drift` + signal label), enforce the invariant of at most one open issue per signal, reset recovery streak on active alerts, and auto-close recovered issues after 2 healthy nightly runs (configurable threshold). Active-alert comments are cooldown-throttled for unchanged failure states (default every 3 runs), while issue bodies continue to refresh each run. The runtime alert-age SLO escalation issue now carries a mandatory parent runtime-warning reference in its issue body and closes immediately when parent-coupled escalation criteria are no longer met.
 Weekly [master-reliability-digest.yml](.github/workflows/master-reliability-digest.yml) publishes a trend digest (Release Gate runtime, guard degradations, active-comment suppression totals) as artifact + workflow summary for proactive reliability tracking and feeds the deduped warning signal `master-reliability-digest-warning`.
 Reliability-digest guard degradation warnings are now based on consecutive head failures (default: 2) instead of any historical non-success sample in the trend window to reduce alert noise after successful recovery.
 Nightly [master-guard-burnin-check.yml](.github/workflows/master-guard-burnin-check.yml) enforces burn-in health for master guard/digest workflows by requiring recent successful runs with required artifacts (including weekly digest/rehearsal bootstrap windows).
-Daily [master-production-readiness-gate.yml](.github/workflows/master-production-readiness-gate.yml) aggregates required-check integrity, branch-protection drift, guard-workflow health, and guard burn-in into one hard go/no-go production readiness gate.
+Daily [master-production-readiness-gate.yml](.github/workflows/master-production-readiness-gate.yml) aggregates required-check integrity, branch-protection drift, guard-workflow health, guard burn-in, and watchdog rehearsal SLO/MTTR integrity into one hard go/no-go production readiness gate.
 Daily [master-ci-drift-status-report.yml](.github/workflows/master-ci-drift-status-report.yml) publishes an operations report for open `ci-drift` issues with blocked/residual classification and issue-age context.
 Core CI and master guard/reliability workflows now set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` and standardize artifact uploads on `actions/upload-artifact@v7` to proactively avoid Node-20 action-runtime deprecation drift.
 
@@ -1054,7 +1054,14 @@ Local production readiness gate command:
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\run-master-production-readiness-gate.ps1 -RequiredChecksReportFile artifacts\master-required-checks-24h-report-readiness.json -BranchProtectionReportFile artifacts\master-branch-protection-drift-guard-readiness.json -GuardHealthReportFile artifacts\master-guard-workflow-health-check-readiness.json -GuardBurninReportFile artifacts\master-guard-burnin-check-readiness.json
+.\scripts\run-master-production-readiness-gate.ps1 -RequiredChecksReportFile artifacts\master-required-checks-24h-report-readiness.json -BranchProtectionReportFile artifacts\master-branch-protection-drift-guard-readiness.json -GuardHealthReportFile artifacts\master-guard-workflow-health-check-readiness.json -GuardBurninReportFile artifacts\master-guard-burnin-check-readiness.json -WatchdogRehearsalGuardReportFile artifacts\master-watchdog-rehearsal-slo-guard-readiness.json
+```
+
+Local watchdog rehearsal SLO guard command:
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-master-watchdog-rehearsal-slo-guard.ps1 -MaxAgeHours 192 -MttrTargetSeconds 300 -PerPage 20
 ```
 
 Local guard-chain selftest command:
@@ -1069,6 +1076,13 @@ Local watchdog rehearsal drill command:
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
 .\scripts\run-master-watchdog-rehearsal-drill.ps1 -MttrTargetSeconds 300
+```
+
+Watchdog MTTR calibration command (use after 10-14 daily samples):
+
+```powershell
+Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
+.\scripts\run-watchdog-rehearsal-mttr-calibrate.ps1 -MinSamples 10 -MaxSamples 14 -WriteUpdates
 ```
 
 Local release-gate runtime early warning command:

--- a/docs/watchdog-rehearsal-mttr-policy.json
+++ b/docs/watchdog-rehearsal-mttr-policy.json
@@ -1,0 +1,12 @@
+{
+  "calibration_window": {
+    "headroom_percent": 10.0,
+    "max_samples": 14,
+    "min_samples": 10,
+    "percentile_target": 95.0
+  },
+  "generated_at_utc": "2026-04-19T00:00:00Z",
+  "samples_total": 0,
+  "target_mttr_seconds": 300.0,
+  "version": "1.0.0"
+}

--- a/scripts/ci-alert-issue-upsert.py
+++ b/scripts/ci-alert-issue-upsert.py
@@ -446,6 +446,11 @@ def _signal_alert_state(
         latest_run_conclusion = str(latest_run.get("conclusion") or "")
         latest_run_age_hours = metrics.get("latest_run_age_hours")
         max_age_hours = metrics.get("max_age_hours")
+        mttr_seconds = metrics.get("mttr_seconds")
+        mttr_target_seconds = metrics.get("mttr_target_seconds")
+        mttr_report_loaded = bool(metrics.get("mttr_report_loaded"))
+        mttr_report_source = str(metrics.get("mttr_report_source") or "none")
+        mttr_report_load_error = str(metrics.get("mttr_report_load_error") or "")
         breach_reason = str(decision.get("breach_reason") or "none")
         alert_triggered = bool(decision.get("watchdog_rehearsal_slo_breached"))
 
@@ -462,6 +467,16 @@ def _signal_alert_state(
             if latest_run_age_hours is not None
             else "unknown"
         )
+        mttr_text = (
+            f"{float(mttr_seconds):.3f}s"
+            if mttr_seconds is not None
+            else "unknown"
+        )
+        mttr_target_text = (
+            f"{float(mttr_target_seconds):.3f}s"
+            if mttr_target_seconds is not None
+            else "unknown"
+        )
 
         summary = [
             f"- Rehearsal drill SLO breached: {'yes' if alert_triggered else 'no'}",
@@ -469,6 +484,13 @@ def _signal_alert_state(
             f"- Latest rehearsal run: {latest_run_text}",
             f"- Latest rehearsal run status: {latest_run_status or 'unknown'} / {latest_run_conclusion or 'unknown'}",
             f"- Latest rehearsal run age: {age_text} (threshold={max_age_hours}h)",
+            f"- Latest alert-chain MTTR: {mttr_text} (target={mttr_target_text})",
+            f"- MTTR evidence loaded: {'yes' if mttr_report_loaded else 'no'} (source={mttr_report_source})",
+            (
+                f"- MTTR evidence load error: {mttr_report_load_error}"
+                if mttr_report_load_error
+                else "- MTTR evidence load error: none"
+            ),
             f"- Recommended action: {decision.get('recommended_action') or 'watchdog_rehearsal_slo_healthy'}",
         ]
         return alert_triggered, summary, branch, {}

--- a/scripts/master-ci-drift-status-report.py
+++ b/scripts/master-ci-drift-status-report.py
@@ -16,6 +16,7 @@ BLOCKING_SIGNAL_IDS = {
     "master-guard-workflow-health",
     "release-gate-runtime-slo-guard",
     "release-gate-runtime-alert-age-slo",
+    # Watchdog rehearsal SLO covers stale/failed and MTTR breach modes.
     "master-watchdog-rehearsal-drill-slo",
     "master-reliability-digest-guard",
 }

--- a/scripts/master-production-readiness-gate.py
+++ b/scripts/master-production-readiness-gate.py
@@ -46,6 +46,7 @@ def run_production_readiness_gate(
     branch_protection_report_file: Path,
     guard_health_report_file: Path,
     guard_burnin_report_file: Path,
+    watchdog_rehearsal_guard_report_file: Path,
     allow_not_ready: bool,
     output_file: Path,
 ) -> dict[str, Any]:
@@ -63,12 +64,14 @@ def run_production_readiness_gate(
     branch_protection_payload = load(branch_protection_report_file, "branch_protection")
     guard_health_payload = load(guard_health_report_file, "guard_health")
     guard_burnin_payload = load(guard_burnin_report_file, "guard_burnin")
+    watchdog_rehearsal_guard_payload = load(watchdog_rehearsal_guard_report_file, "watchdog_rehearsal_guard")
 
     reports_present = bool(
         required_checks_payload is not None
         and branch_protection_payload is not None
         and guard_health_payload is not None
         and guard_burnin_payload is not None
+        and watchdog_rehearsal_guard_payload is not None
     )
 
     required_checks_non_green_total = _safe_int(
@@ -115,12 +118,21 @@ def run_production_readiness_gate(
         guard_burnin_payload is not None and not guard_burnin_degraded
     )
 
+    watchdog_rehearsal_slo_breached = _safe_bool(
+        ((watchdog_rehearsal_guard_payload or {}).get("decision") or {}).get("watchdog_rehearsal_slo_breached"),
+        True,
+    )
+    watchdog_rehearsal_guard_integrity = bool(
+        watchdog_rehearsal_guard_payload is not None and not watchdog_rehearsal_slo_breached
+    )
+
     production_ready = bool(
         reports_present
         and required_checks_green
         and branch_protection_integrity
         and guard_workflow_health_integrity
         and guard_burnin_integrity
+        and watchdog_rehearsal_guard_integrity
     )
 
     criteria = [
@@ -163,6 +175,14 @@ def run_production_readiness_gate(
                 f"allow_not_ready={allow_not_ready}"
             ),
         },
+        {
+            "name": "watchdog_rehearsal_guard_integrity",
+            "passed": bool(watchdog_rehearsal_guard_integrity or allow_not_ready),
+            "details": (
+                f"watchdog_rehearsal_slo_breached={watchdog_rehearsal_slo_breached}, "
+                f"allow_not_ready={allow_not_ready}"
+            ),
+        },
     ]
     failed_criteria = [item for item in criteria if not bool(item.get("passed"))]
     success = len(failed_criteria) == 0
@@ -173,6 +193,7 @@ def run_production_readiness_gate(
         f"branch_protection_drift_detected={str(branch_protection_drift_detected).lower()}",
         f"guard_workflow_health_degraded={str(guard_workflow_health_degraded).lower()}",
         f"guard_burnin_degraded={str(guard_burnin_degraded).lower()}",
+        f"watchdog_rehearsal_slo_breached={str(watchdog_rehearsal_slo_breached).lower()}",
     ]
 
     report = {
@@ -183,6 +204,7 @@ def run_production_readiness_gate(
             "branch_protection_report_file": str(branch_protection_report_file),
             "guard_health_report_file": str(guard_health_report_file),
             "guard_burnin_report_file": str(guard_burnin_report_file),
+            "watchdog_rehearsal_guard_report_file": str(watchdog_rehearsal_guard_report_file),
             "allow_not_ready": bool(allow_not_ready),
             "output_file": str(output_file),
         },
@@ -193,6 +215,7 @@ def run_production_readiness_gate(
             "guard_workflow_health_degraded": bool(guard_workflow_health_degraded),
             "guard_workflow_coverage_contract_ok": bool(guard_workflow_coverage_contract_ok),
             "guard_burnin_degraded": bool(guard_burnin_degraded),
+            "watchdog_rehearsal_slo_breached": bool(watchdog_rehearsal_slo_breached),
             "reports_load_errors_total": int(len(errors)),
             "criteria_failed": int(len(failed_criteria)),
         },
@@ -226,7 +249,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
             "Aggregate required-check integrity, branch-protection drift, guard-workflow health, "
-            "and guard burn-in into a single production-readiness go/no-go signal."
+            "guard burn-in, and watchdog rehearsal guard integrity into a single production-readiness go/no-go signal."
         )
     )
     parser.add_argument("--label", default="master-production-readiness-gate")
@@ -246,6 +269,10 @@ def main(argv: list[str] | None = None) -> int:
         "--guard-burnin-report-file",
         default="artifacts/master-guard-burnin-check-readiness.json",
     )
+    parser.add_argument(
+        "--watchdog-rehearsal-guard-report-file",
+        default="artifacts/master-watchdog-rehearsal-slo-guard-readiness.json",
+    )
     parser.add_argument("--allow-not-ready", action="store_true")
     parser.add_argument("--output-file", default="artifacts/master-production-readiness-gate.json")
     args = parser.parse_args(argv)
@@ -258,6 +285,7 @@ def main(argv: list[str] | None = None) -> int:
             branch_protection_report_file=Path(str(args.branch_protection_report_file)).expanduser(),
             guard_health_report_file=Path(str(args.guard_health_report_file)).expanduser(),
             guard_burnin_report_file=Path(str(args.guard_burnin_report_file)).expanduser(),
+            watchdog_rehearsal_guard_report_file=Path(str(args.watchdog_rehearsal_guard_report_file)).expanduser(),
             allow_not_ready=bool(args.allow_not_ready),
             output_file=output_file,
         )

--- a/scripts/master-watchdog-rehearsal-slo-guard.py
+++ b/scripts/master-watchdog-rehearsal-slo-guard.py
@@ -4,10 +4,15 @@ import argparse
 import json
 import subprocess
 import sys
+import tempfile
 import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+DEFAULT_MTTR_TARGET_SECONDS = 300.0
+DEFAULT_DRILL_ARTIFACT_NAME = "master-guard-workflow-health-rehearsal-drill"
+DEFAULT_DRILL_REPORT_FILENAME = "master-guard-workflow-health-rehearsal-drill.json"
 
 
 def _expect(condition: bool, message: str) -> None:
@@ -122,6 +127,55 @@ def _resolve_latest_run_url(*, repo: str, run: dict[str, Any]) -> str:
     return f"https://github.com/{repo}/actions/runs/{run_id}"
 
 
+def _parse_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _load_drill_report_from_artifact(
+    *,
+    repo: str,
+    run_id: int,
+    artifact_name: str,
+) -> dict[str, Any]:
+    _expect(run_id > 0, "run_id must be > 0 for artifact download.")
+    _expect(str(artifact_name).strip(), "artifact_name must be non-empty.")
+    with tempfile.TemporaryDirectory(prefix="master-watchdog-rehearsal-slo-artifact-") as temp_root_text:
+        temp_root = Path(temp_root_text)
+        command = [
+            "gh",
+            "run",
+            "download",
+            str(run_id),
+            "-R",
+            repo,
+            "-n",
+            str(artifact_name),
+            "-D",
+            str(temp_root),
+        ]
+        completed = subprocess.run(command, capture_output=True, text=True)
+        _expect(
+            completed.returncode == 0,
+            f"gh run download failed ({completed.returncode}) for run #{run_id}: {completed.stderr.strip()}",
+        )
+        candidates = sorted(
+            item
+            for item in temp_root.rglob("*.json")
+            if item.is_file() and item.name.lower() == DEFAULT_DRILL_REPORT_FILENAME.lower()
+        )
+        _expect(
+            len(candidates) >= 1,
+            (
+                f"Downloaded artifact '{artifact_name}' for run #{run_id} but did not find "
+                f"'{DEFAULT_DRILL_REPORT_FILENAME}'."
+            ),
+        )
+        return _load_json_file(candidates[0])
+
+
 def run_watchdog_rehearsal_slo_guard(
     *,
     label: str,
@@ -129,14 +183,19 @@ def run_watchdog_rehearsal_slo_guard(
     branch: str,
     workflow_name: str,
     max_age_hours: float,
+    mttr_target_seconds: float,
     per_page: int,
     runs_file: Path | None,
+    drill_report_file: Path | None,
+    drill_artifact_name: str,
     now_utc: datetime,
     allow_breach: bool,
     output_file: Path,
 ) -> dict[str, Any]:
     _expect(float(max_age_hours) > 0.0, "max_age_hours must be > 0.")
+    _expect(float(mttr_target_seconds) > 0.0, "mttr_target_seconds must be > 0.")
     _expect(int(per_page) > 0, "per_page must be > 0.")
+    _expect(str(drill_artifact_name).strip(), "drill_artifact_name must be non-empty.")
 
     started = time.perf_counter()
     runs = (
@@ -173,8 +232,6 @@ def run_watchdog_rehearsal_slo_guard(
         and str(latest_run.get("conclusion") or "") == "success"
     )
     failed_breach = bool(latest_run is not None and not latest_run_success)
-    breach_reason = "stale" if stale_breach else ("failed" if failed_breach else "none")
-    breached = breach_reason in {"stale", "failed"}
 
     latest_run_snapshot = (
         {
@@ -188,6 +245,74 @@ def run_watchdog_rehearsal_slo_guard(
         if latest_run is not None
         else None
     )
+    latest_run_id = int((latest_run_snapshot or {}).get("run_id") or 0)
+
+    mttr_report_loaded = False
+    mttr_report_source = "none"
+    mttr_report_load_error: str | None = None
+    mttr_report: dict[str, Any] | None = None
+    mttr_seconds: float | None = None
+    mttr_target_effective_seconds: float = float(mttr_target_seconds)
+    mttr_evaluated = False
+    mttr_breach = False
+    mttr_report_unavailable = False
+
+    should_attempt_mttr = bool(
+        (not stale_breach)
+        and (not failed_breach)
+        and latest_run_id > 0
+        and (drill_report_file is not None or runs_file is None)
+    )
+    if not should_attempt_mttr and runs_file is not None and drill_report_file is None:
+        mttr_report_source = "skipped_fixture_mode"
+
+    if should_attempt_mttr:
+        mttr_evaluated = True
+        try:
+            if drill_report_file is not None:
+                mttr_report = _load_json_file(drill_report_file)
+                mttr_report_source = "file"
+            else:
+                mttr_report = _load_drill_report_from_artifact(
+                    repo=repo,
+                    run_id=latest_run_id,
+                    artifact_name=drill_artifact_name,
+                )
+                mttr_report_source = "artifact"
+            mttr_report_loaded = True
+        except Exception as exc:  # noqa: BLE001
+            mttr_report_load_error = str(exc)
+            mttr_report_loaded = False
+
+        if mttr_report_loaded and mttr_report is not None:
+            mttr_metrics = mttr_report.get("metrics") if isinstance(mttr_report.get("metrics"), dict) else {}
+            mttr_seconds = _parse_float(mttr_metrics.get("alert_chain_mttr_seconds"))
+            reported_target = _parse_float(mttr_metrics.get("mttr_target_seconds"))
+            if reported_target is not None and reported_target > 0:
+                mttr_target_effective_seconds = float(reported_target)
+            if mttr_seconds is None:
+                mttr_report_loaded = False
+                mttr_report_source = f"{mttr_report_source}-invalid"
+                mttr_report_load_error = (
+                    "Drill report missing numeric metrics.alert_chain_mttr_seconds."
+                )
+
+        if not mttr_report_loaded:
+            mttr_report_unavailable = True
+        elif mttr_seconds is not None:
+            mttr_breach = bool(float(mttr_seconds) > float(mttr_target_effective_seconds))
+
+    if stale_breach:
+        breach_reason = "stale"
+    elif failed_breach:
+        breach_reason = "failed"
+    elif mttr_report_unavailable:
+        breach_reason = "mttr_report_unavailable"
+    elif mttr_breach:
+        breach_reason = "mttr"
+    else:
+        breach_reason = "none"
+    breached = breach_reason != "none"
 
     criteria = [
         {
@@ -209,6 +334,26 @@ def run_watchdog_rehearsal_slo_guard(
                 f"allow_breach={allow_breach}"
             ),
         },
+        {
+            "name": "watchdog_rehearsal_mttr_within_target",
+            "passed": bool(
+                (
+                    (not mttr_report_unavailable)
+                    and (not mttr_breach)
+                )
+                or (not mttr_evaluated)
+                or allow_breach
+            ),
+            "details": (
+                f"mttr_evaluated={mttr_evaluated}, "
+                f"mttr_report_loaded={mttr_report_loaded}, "
+                f"mttr_report_unavailable={mttr_report_unavailable}, "
+                f"mttr_seconds={mttr_seconds}, "
+                f"mttr_target_effective_seconds={mttr_target_effective_seconds}, "
+                f"mttr_breach={mttr_breach}, "
+                f"allow_breach={allow_breach}"
+            ),
+        },
     ]
     failed_criteria = [item for item in criteria if not bool(item.get("passed"))]
     success = len(failed_criteria) == 0
@@ -221,8 +366,11 @@ def run_watchdog_rehearsal_slo_guard(
             "branch": branch,
             "workflow_name": workflow_name,
             "max_age_hours": float(max_age_hours),
+            "mttr_target_seconds": float(mttr_target_seconds),
             "per_page": int(per_page),
             "runs_file": str(runs_file) if runs_file is not None else None,
+            "drill_report_file": str(drill_report_file) if drill_report_file is not None else None,
+            "drill_artifact_name": str(drill_artifact_name),
             "allow_breach": bool(allow_breach),
             "now_utc": _format_utc(now_utc),
             "output_file": str(output_file),
@@ -231,11 +379,28 @@ def run_watchdog_rehearsal_slo_guard(
             "runs_total_fetched": int(len(runs)),
             "max_age_hours": float(max_age_hours),
             "latest_run_age_hours": float(latest_run_age_hours) if latest_run_age_hours is not None else None,
+            "mttr_evaluated": bool(mttr_evaluated),
+            "mttr_seconds": float(mttr_seconds) if mttr_seconds is not None else None,
+            "mttr_target_seconds": float(mttr_target_effective_seconds),
+            "mttr_breach": bool(mttr_breach),
+            "mttr_report_loaded": bool(mttr_report_loaded),
+            "mttr_report_unavailable": bool(mttr_report_unavailable),
+            "mttr_report_source": mttr_report_source,
+            "mttr_report_load_error": mttr_report_load_error,
             "criteria_failed": int(len(failed_criteria)),
         },
         "criteria": criteria,
         "failed_criteria": failed_criteria,
         "latest_run": latest_run_snapshot,
+        "drill_report": {
+            "loaded": bool(mttr_report_loaded),
+            "source": mttr_report_source,
+            "artifact_name": str(drill_artifact_name),
+            "report_file": str(drill_report_file) if drill_report_file is not None else None,
+            "load_error": mttr_report_load_error,
+            "mttr_seconds": float(mttr_seconds) if mttr_seconds is not None else None,
+            "mttr_target_seconds": float(mttr_target_effective_seconds),
+        },
         "decision": {
             "watchdog_rehearsal_slo_breached": bool(breached),
             "breach_reason": breach_reason,
@@ -267,8 +432,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--branch", default="master")
     parser.add_argument("--workflow-name", default="Master Watchdog Rehearsal Drill")
     parser.add_argument("--max-age-hours", type=float, default=192.0)
+    parser.add_argument("--mttr-target-seconds", type=float, default=DEFAULT_MTTR_TARGET_SECONDS)
     parser.add_argument("--per-page", type=int, default=20)
     parser.add_argument("--runs-file")
+    parser.add_argument("--drill-report-file")
+    parser.add_argument("--drill-artifact-name", default=DEFAULT_DRILL_ARTIFACT_NAME)
     parser.add_argument("--now-utc")
     parser.add_argument("--allow-breach", action="store_true")
     parser.add_argument("--output-file", default="artifacts/master-watchdog-rehearsal-slo-guard.json")
@@ -280,8 +448,15 @@ def main(argv: list[str] | None = None) -> int:
     if int(args.per_page) <= 0:
         print("[master-watchdog-rehearsal-slo-guard] ERROR: --per-page must be > 0.", file=sys.stderr)
         return 2
+    if float(args.mttr_target_seconds) <= 0:
+        print("[master-watchdog-rehearsal-slo-guard] ERROR: --mttr-target-seconds must be > 0.", file=sys.stderr)
+        return 2
+    if not str(args.drill_artifact_name or "").strip():
+        print("[master-watchdog-rehearsal-slo-guard] ERROR: --drill-artifact-name must be non-empty.", file=sys.stderr)
+        return 2
 
     runs_file = Path(str(args.runs_file)).expanduser() if args.runs_file else None
+    drill_report_file = Path(str(args.drill_report_file)).expanduser() if args.drill_report_file else None
     output_file = Path(str(args.output_file)).expanduser()
     try:
         report = run_watchdog_rehearsal_slo_guard(
@@ -290,8 +465,11 @@ def main(argv: list[str] | None = None) -> int:
             branch=str(args.branch),
             workflow_name=str(args.workflow_name),
             max_age_hours=float(args.max_age_hours),
+            mttr_target_seconds=float(args.mttr_target_seconds),
             per_page=int(args.per_page),
             runs_file=runs_file,
+            drill_report_file=drill_report_file,
+            drill_artifact_name=str(args.drill_artifact_name),
             now_utc=_resolve_now_utc(args.now_utc),
             allow_breach=bool(args.allow_breach),
             output_file=output_file,

--- a/scripts/run-master-production-readiness-gate.ps1
+++ b/scripts/run-master-production-readiness-gate.ps1
@@ -4,6 +4,7 @@ param(
     [string]$BranchProtectionReportFile = "artifacts\\master-branch-protection-drift-guard-readiness.json",
     [string]$GuardHealthReportFile = "artifacts\\master-guard-workflow-health-check-readiness.json",
     [string]$GuardBurninReportFile = "artifacts\\master-guard-burnin-check-readiness.json",
+    [string]$WatchdogRehearsalGuardReportFile = "artifacts\\master-watchdog-rehearsal-slo-guard-readiness.json",
     [string]$OutputFile = "artifacts\\master-production-readiness-gate.json",
     [switch]$AllowNotReady
 )
@@ -20,6 +21,7 @@ $args = @(
     "--branch-protection-report-file", $BranchProtectionReportFile,
     "--guard-health-report-file", $GuardHealthReportFile,
     "--guard-burnin-report-file", $GuardBurninReportFile,
+    "--watchdog-rehearsal-guard-report-file", $WatchdogRehearsalGuardReportFile,
     "--output-file", $OutputFile
 )
 if ($AllowNotReady) {

--- a/scripts/run-master-watchdog-rehearsal-slo-guard.ps1
+++ b/scripts/run-master-watchdog-rehearsal-slo-guard.ps1
@@ -4,8 +4,11 @@ param(
     [string]$Branch = "master",
     [string]$WorkflowName = "Master Watchdog Rehearsal Drill",
     [double]$MaxAgeHours = 192,
+    [double]$MttrTargetSeconds = 300,
     [int]$PerPage = 20,
     [string]$RunsFile = "",
+    [string]$DrillReportFile = "",
+    [string]$DrillArtifactName = "master-guard-workflow-health-rehearsal-drill",
     [string]$OutputFile = "artifacts\\master-watchdog-rehearsal-slo-guard.json",
     [switch]$AllowBreach
 )
@@ -22,11 +25,16 @@ $args = @(
     "--branch", $Branch,
     "--workflow-name", $WorkflowName,
     "--max-age-hours", [string]$MaxAgeHours,
+    "--mttr-target-seconds", [string]$MttrTargetSeconds,
     "--per-page", [string]$PerPage,
+    "--drill-artifact-name", $DrillArtifactName,
     "--output-file", $OutputFile
 )
 if ($RunsFile) {
     $args += @("--runs-file", $RunsFile)
+}
+if ($DrillReportFile) {
+    $args += @("--drill-report-file", $DrillReportFile)
 }
 if ($AllowBreach) {
     $args += "--allow-breach"

--- a/scripts/run-watchdog-rehearsal-mttr-calibrate.ps1
+++ b/scripts/run-watchdog-rehearsal-mttr-calibrate.ps1
@@ -1,0 +1,45 @@
+param(
+    [string]$Label = "watchdog-rehearsal-mttr-calibration",
+    [string]$ProjectRoot = "",
+    [string]$ReportFiles = "",
+    [string]$ReportsGlob = "artifacts\\master-guard-workflow-health-rehearsal-drill*.json",
+    [int]$MinSamples = 10,
+    [int]$MaxSamples = 14,
+    [double]$PercentileTarget = 95,
+    [double]$HeadroomPercent = 10,
+    [string]$OutputFile = "artifacts\\watchdog-rehearsal-mttr-calibration.json",
+    [string]$PolicyOutputFile = "docs\\watchdog-rehearsal-mttr-policy.json",
+    [switch]$WriteUpdates,
+    [switch]$AllowInsufficientSamples
+)
+
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptDir "..")
+$scriptPath = Join-Path $repoRoot "scripts\\watchdog-rehearsal-mttr-calibrate.py"
+
+$args = @(
+    $scriptPath,
+    "--label", $Label,
+    "--reports-glob", $ReportsGlob,
+    "--min-samples", [string]$MinSamples,
+    "--max-samples", [string]$MaxSamples,
+    "--percentile-target", [string]$PercentileTarget,
+    "--headroom-percent", [string]$HeadroomPercent,
+    "--output-file", $OutputFile,
+    "--policy-output-file", $PolicyOutputFile
+)
+if ($ProjectRoot) {
+    $args += @("--project-root", $ProjectRoot)
+}
+if ($ReportFiles) {
+    $args += @("--report-files", $ReportFiles)
+}
+if ($WriteUpdates) {
+    $args += "--write-updates"
+}
+if ($AllowInsufficientSamples) {
+    $args += "--allow-insufficient-samples"
+}
+
+& python @args

--- a/scripts/watchdog-rehearsal-mttr-calibrate.py
+++ b/scripts/watchdog-rehearsal-mttr-calibrate.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _resolve_path(project_root: Path, value: str) -> Path:
+    path = Path(str(value)).expanduser()
+    if not path.is_absolute():
+        path = project_root / path
+    return path.resolve()
+
+
+def _parse_csv_list(text: str) -> list[str]:
+    return [item.strip() for item in str(text).split(",") if item.strip()]
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    _expect(isinstance(payload, dict), f"Expected JSON object in {path}")
+    return payload
+
+
+def _parse_utc_timestamp(value: str) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _discover_report_files(project_root: Path, explicit_files: list[str], glob_pattern: str) -> list[Path]:
+    discovered: list[Path] = []
+    for value in explicit_files:
+        candidate = _resolve_path(project_root, value)
+        if candidate.exists() and candidate.is_file():
+            discovered.append(candidate)
+    if glob_pattern:
+        discovered.extend(
+            sorted(path.resolve() for path in project_root.glob(glob_pattern) if path.is_file())
+        )
+
+    deduped: list[Path] = []
+    seen: set[str] = set()
+    for path in discovered:
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(path)
+    return deduped
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    _expect(values, "Cannot compute percentile for empty sample list.")
+    sorted_values = sorted(float(item) for item in values)
+    if len(sorted_values) == 1:
+        return float(sorted_values[0])
+    p = max(0.0, min(100.0, float(percentile)))
+    rank = (len(sorted_values) - 1) * p / 100.0
+    lower = int(math.floor(rank))
+    upper = int(math.ceil(rank))
+    if lower == upper:
+        return float(sorted_values[lower])
+    weight = rank - lower
+    return float((sorted_values[lower] * (1.0 - weight)) + (sorted_values[upper] * weight))
+
+
+def run_watchdog_mttr_calibration(
+    *,
+    label: str,
+    project_root: Path,
+    report_files: list[Path],
+    min_samples: int,
+    max_samples: int,
+    percentile_target: float,
+    headroom_percent: float,
+    output_file: Path,
+    policy_output_file: Path,
+    write_updates: bool,
+    allow_insufficient_samples: bool,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    _expect(min_samples > 0, "min_samples must be > 0.")
+    _expect(max_samples >= min_samples, "max_samples must be >= min_samples.")
+    _expect(float(headroom_percent) >= 0.0, "headroom_percent must be >= 0.")
+
+    valid_samples: list[dict[str, Any]] = []
+    invalid_reports: list[dict[str, str]] = []
+    used_files: list[str] = []
+
+    for path in report_files:
+        try:
+            payload = _read_json_object(path)
+        except Exception as exc:  # noqa: BLE001
+            invalid_reports.append({"path": str(path), "error": str(exc)})
+            continue
+
+        metrics = payload.get("metrics") if isinstance(payload.get("metrics"), dict) else {}
+        mttr_value = metrics.get("alert_chain_mttr_seconds")
+        try:
+            mttr_seconds = float(mttr_value)
+        except (TypeError, ValueError):
+            invalid_reports.append(
+                {
+                    "path": str(path),
+                    "error": "metrics.alert_chain_mttr_seconds missing or non-numeric",
+                }
+            )
+            continue
+        if mttr_seconds < 0.0:
+            invalid_reports.append(
+                {
+                    "path": str(path),
+                    "error": "metrics.alert_chain_mttr_seconds must be >= 0",
+                }
+            )
+            continue
+
+        generated_at = _parse_utc_timestamp(str(payload.get("generated_at_utc") or ""))
+        valid_samples.append(
+            {
+                "path": str(path),
+                "generated_at_utc": (
+                    generated_at.strftime("%Y-%m-%dT%H:%M:%SZ") if generated_at is not None else ""
+                ),
+                "sort_generated_at": generated_at,
+                "mttr_seconds": float(mttr_seconds),
+                "reported_target_seconds": (
+                    float(metrics.get("mttr_target_seconds"))
+                    if metrics.get("mttr_target_seconds") is not None
+                    else None
+                ),
+            }
+        )
+        used_files.append(str(path))
+
+    valid_samples.sort(
+        key=lambda item: item.get("sort_generated_at") or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
+    selected_samples = valid_samples[: int(max_samples)]
+    sample_values = [float(item["mttr_seconds"]) for item in selected_samples]
+
+    recommended_target_seconds: float | None = None
+    sample_requirements_met = len(sample_values) >= int(min_samples)
+    if sample_values:
+        percentile_value = _percentile(sample_values, float(percentile_target))
+        recommended_target_seconds = float(percentile_value) * (1.0 + (float(headroom_percent) / 100.0))
+
+    success = bool(sample_requirements_met or allow_insufficient_samples)
+
+    policy_payload = {
+        "version": "1.0.0",
+        "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "samples_total": int(len(selected_samples)),
+        "calibration_window": {
+            "min_samples": int(min_samples),
+            "max_samples": int(max_samples),
+            "percentile_target": float(percentile_target),
+            "headroom_percent": float(headroom_percent),
+        },
+        "target_mttr_seconds": (
+            round(float(recommended_target_seconds), 3)
+            if recommended_target_seconds is not None
+            else None
+        ),
+    }
+
+    report = {
+        "label": label,
+        "success": bool(success),
+        "paths": {
+            "project_root": str(project_root),
+            "output_file": str(output_file),
+            "policy_output_file": str(policy_output_file),
+        },
+        "config": {
+            "min_samples": int(min_samples),
+            "max_samples": int(max_samples),
+            "percentile_target": float(percentile_target),
+            "headroom_percent": float(headroom_percent),
+            "write_updates": bool(write_updates),
+            "allow_insufficient_samples": bool(allow_insufficient_samples),
+        },
+        "metrics": {
+            "report_files_discovered": int(len(report_files)),
+            "report_files_used": int(len(used_files)),
+            "report_files_invalid": int(len(invalid_reports)),
+            "sample_values_total": int(len(sample_values)),
+            "sample_requirements_met": int(1 if sample_requirements_met else 0),
+            "recommended_target_seconds": (
+                round(float(recommended_target_seconds), 3)
+                if recommended_target_seconds is not None
+                else None
+            ),
+            "selected_samples_oldest_generated_at_utc": (
+                selected_samples[-1].get("generated_at_utc") if selected_samples else None
+            ),
+            "selected_samples_newest_generated_at_utc": (
+                selected_samples[0].get("generated_at_utc") if selected_samples else None
+            ),
+        },
+        "selected_samples": [
+            {
+                "path": str(item.get("path") or ""),
+                "generated_at_utc": str(item.get("generated_at_utc") or ""),
+                "mttr_seconds": float(item.get("mttr_seconds") or 0.0),
+                "reported_target_seconds": (
+                    float(item.get("reported_target_seconds"))
+                    if item.get("reported_target_seconds") is not None
+                    else None
+                ),
+            }
+            for item in selected_samples
+        ],
+        "invalid_reports": invalid_reports,
+        "recommended_policy": policy_payload,
+        "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "duration_ms": int((time.perf_counter() - started) * 1000),
+    }
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(json.dumps(report, ensure_ascii=True, sort_keys=True, indent=2), encoding="utf-8")
+
+    if write_updates:
+        policy_output_file.parent.mkdir(parents=True, exist_ok=True)
+        policy_output_file.write_text(
+            json.dumps(policy_payload, ensure_ascii=True, sort_keys=True, indent=2),
+            encoding="utf-8",
+        )
+
+    if not success:
+        raise RuntimeError(
+            "Watchdog rehearsal MTTR calibration failed due to insufficient samples: "
+            + json.dumps(report, sort_keys=True)
+        )
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Calibrate watchdog rehearsal MTTR target from historical drill reports."
+    )
+    parser.add_argument("--label", default="watchdog-rehearsal-mttr-calibration")
+    parser.add_argument("--project-root")
+    parser.add_argument("--report-files", default="")
+    parser.add_argument("--reports-glob", default="artifacts/master-guard-workflow-health-rehearsal-drill*.json")
+    parser.add_argument("--min-samples", type=int, default=10)
+    parser.add_argument("--max-samples", type=int, default=14)
+    parser.add_argument("--percentile-target", type=float, default=95.0)
+    parser.add_argument("--headroom-percent", type=float, default=10.0)
+    parser.add_argument("--output-file", default="artifacts/watchdog-rehearsal-mttr-calibration.json")
+    parser.add_argument("--policy-output-file", default="docs/watchdog-rehearsal-mttr-policy.json")
+    parser.add_argument("--write-updates", action="store_true")
+    parser.add_argument("--allow-insufficient-samples", action="store_true")
+    args = parser.parse_args(argv)
+
+    inferred_project_root = Path(__file__).resolve().parents[1]
+    project_root = _resolve_path(inferred_project_root, args.project_root) if args.project_root else inferred_project_root
+    explicit_files = _parse_csv_list(str(args.report_files))
+    report_files = _discover_report_files(project_root, explicit_files, str(args.reports_glob))
+
+    try:
+        report = run_watchdog_mttr_calibration(
+            label=str(args.label),
+            project_root=project_root,
+            report_files=report_files,
+            min_samples=int(args.min_samples),
+            max_samples=int(args.max_samples),
+            percentile_target=float(args.percentile_target),
+            headroom_percent=float(args.headroom_percent),
+            output_file=_resolve_path(project_root, str(args.output_file)),
+            policy_output_file=_resolve_path(project_root, str(args.policy_output_file)),
+            write_updates=bool(args.write_updates),
+            allow_insufficient_samples=bool(args.allow_insufficient_samples),
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"[watchdog-rehearsal-mttr-calibration] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -9,6 +9,7 @@ import shutil
 import sys
 import threading
 import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -11550,7 +11551,7 @@ def test_231_ci_alert_issue_upsert_workflow_wrapper_and_docs_wiring():
     assert "guard-workflow health watchdog" in readme
     assert "Immediate Actions" in readme
     assert "master-watchdog-rehearsal-slo-guard.yml" in readme
-    assert "stale`/`failed` reason" in readme
+    assert "stale`/`failed`/`mttr` reason" in readme
     assert "auto-close recovered issues after 2 healthy nightly runs" in readme
     assert "at most one open issue per signal" in readme
     assert "cooldown-throttled for unchanged failure states" in readme
@@ -12757,6 +12758,86 @@ def test_242b_ci_alert_issue_upsert_creates_issue_for_watchdog_rehearsal_slo():
     shutil.rmtree(workspace, ignore_errors=True)
 
 
+def test_242c_ci_alert_issue_upsert_includes_watchdog_mttr_details():
+    workspace = _local_test_dir("pytest-ci-alert-issue-upsert-watchdog-mttr").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    report_file = workspace / "master-watchdog-rehearsal-slo-guard.json"
+    issues_file = workspace / "issues.json"
+    issue_oplog_file = workspace / "issue-oplog.json"
+    output_file = workspace / "ci-alert-issue-upsert.json"
+
+    report_file.write_text(
+        json.dumps(
+            {
+                "label": "pytest-watchdog-rehearsal-mttr",
+                "config": {"branch": "master", "max_age_hours": 192.0},
+                "metrics": {
+                    "latest_run_age_hours": 0.25,
+                    "max_age_hours": 192.0,
+                    "mttr_seconds": 412.5,
+                    "mttr_target_seconds": 300.0,
+                    "mttr_report_loaded": True,
+                    "mttr_report_source": "file",
+                },
+                "latest_run": {
+                    "run_id": 778900,
+                    "status": "completed",
+                    "conclusion": "success",
+                    "url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/778900",
+                },
+                "decision": {
+                    "watchdog_rehearsal_slo_breached": True,
+                    "breach_reason": "mttr",
+                    "recommended_action": "watchdog_rehearsal_slo_mttr",
+                },
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    issues_file.write_text("[]", encoding="utf-8")
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "ci-alert-issue-upsert.py"),
+        "--label",
+        "pytest-watchdog-mttr-create",
+        "--signal-id",
+        "master-watchdog-rehearsal-drill-slo",
+        "--repo",
+        "donatomaurizio99-collab/GOC",
+        "--report-file",
+        str(report_file.resolve()),
+        "--issues-file",
+        str(issues_file.resolve()),
+        "--issue-oplog-file",
+        str(issue_oplog_file.resolve()),
+        "--dry-run",
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["decision"]["alert_triggered"] is True
+    assert payload["decision"]["issue_action"] == "created"
+
+    issue_oplog = json.loads(issue_oplog_file.read_text(encoding="utf-8"))
+    created_body = str(issue_oplog["actions"][0]["body"])
+    assert "Breach reason: mttr" in created_body
+    assert "Latest alert-chain MTTR: 412.500s (target=300.000s)" in created_body
+    assert "MTTR evidence loaded: yes (source=file)" in created_body
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
 def test_243_master_guard_workflow_health_contract_fails_on_uncovered_workflow_file():
     workspace = _local_test_dir("pytest-master-guard-workflow-health-contract-failure").resolve()
     project_root = Path(__file__).resolve().parents[1]
@@ -13053,17 +13134,24 @@ def test_246_master_watchdog_rehearsal_slo_guard_workflow_wrapper_and_docs_wirin
     assert "master-watchdog-rehearsal-slo-guard-selftest.json" in workflow
     assert ".\\scripts\\run-master-guard-chain-selftest.ps1" in workflow
     assert "master-watchdog-rehearsal-drill-slo" in workflow
+    assert "mttr_target_seconds" in workflow
+    assert "drill_artifact_name" in workflow
 
     assert "master-watchdog-rehearsal-slo-guard.py" in wrapper
     assert "--max-age-hours" in wrapper
+    assert "--mttr-target-seconds" in wrapper
+    assert "--drill-artifact-name" in wrapper
+    assert "--drill-report-file" in wrapper
     assert "--per-page" in wrapper
     assert "--allow-breach" in wrapper
     assert "MaxAgeHours" in wrapper
+    assert "MttrTargetSeconds" in wrapper
+    assert "DrillArtifactName" in wrapper
     assert "AllowBreach" in wrapper
 
     assert "master-watchdog-rehearsal-slo-guard.yml" in readme
     assert "master-reliability-digest.yml" in readme
-    assert "stale`/`failed` reason" in readme
+    assert "stale`/`failed`/`mttr` reason" in readme
 
 
 def test_247_master_watchdog_rehearsal_slo_guard_detects_stale_breach():
@@ -13239,6 +13327,92 @@ def test_248b_master_watchdog_rehearsal_slo_guard_accepts_bom_runs_fixture():
     assert parsed["success"] is True
     assert parsed["decision"]["watchdog_rehearsal_slo_breached"] is False
     assert parsed["latest_run"]["run_id"] == 771003
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_248c_master_watchdog_rehearsal_slo_guard_detects_mttr_breach_from_drill_report_file():
+    workspace = _local_test_dir("pytest-master-watchdog-rehearsal-slo-guard-mttr-breach").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    runs_file = workspace / "runs.json"
+    drill_report_file = workspace / "master-guard-workflow-health-rehearsal-drill.json"
+    output_file = workspace / "master-watchdog-rehearsal-slo-guard.json"
+
+    runs_file.write_text(
+        json.dumps(
+            {
+                "workflow_runs": [
+                    {
+                        "id": 771004,
+                        "status": "completed",
+                        "conclusion": "success",
+                        "updated_at": "2026-04-18T11:15:00Z",
+                        "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/771004",
+                    }
+                ]
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    drill_report_file.write_text(
+        json.dumps(
+            {
+                "label": "pytest-master-watchdog-rehearsal-drill",
+                "metrics": {
+                    "alert_chain_mttr_seconds": 412.5,
+                    "mttr_target_seconds": 300.0,
+                },
+                "generated_at_utc": "2026-04-18T11:16:00Z",
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "master-watchdog-rehearsal-slo-guard.py"),
+        "--label",
+        "pytest-master-watchdog-rehearsal-slo-guard-mttr-breach",
+        "--repo",
+        "donatomaurizio99-collab/GOC",
+        "--branch",
+        "master",
+        "--workflow-name",
+        "Master Watchdog Rehearsal Drill",
+        "--max-age-hours",
+        "192",
+        "--mttr-target-seconds",
+        "300",
+        "--runs-file",
+        str(runs_file.resolve()),
+        "--drill-report-file",
+        str(drill_report_file.resolve()),
+        "--now-utc",
+        "2026-04-18T12:00:00Z",
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "Master watchdog rehearsal SLO guard failed: "
+    assert marker in completed.stderr
+    payload = json.loads(completed.stderr.split(marker, 1)[1].strip())
+    assert payload["success"] is False
+    assert payload["decision"]["watchdog_rehearsal_slo_breached"] is True
+    assert payload["decision"]["breach_reason"] == "mttr"
+    assert payload["metrics"]["mttr_seconds"] == 412.5
+    assert payload["metrics"]["mttr_target_seconds"] == 300.0
+    assert payload["metrics"]["mttr_report_loaded"] is True
+    assert payload["drill_report"]["source"] == "file"
 
     shutil.rmtree(workspace, ignore_errors=True)
 
@@ -13992,8 +14166,11 @@ def test_258_master_production_readiness_gate_workflow_wrapper_and_docs_wiring()
     assert ".\\scripts\\run-master-branch-protection-drift-guard.ps1" in workflow
     assert ".\\scripts\\run-master-guard-workflow-health-check.ps1" in workflow
     assert ".\\scripts\\run-master-guard-burnin-check.ps1" in workflow
+    assert ".\\scripts\\run-master-watchdog-rehearsal-slo-guard.ps1" in workflow
     assert ".\\scripts\\run-master-production-readiness-gate.ps1" in workflow
     assert "master-production-readiness-gate.json" in workflow
+    assert "watchdog_mttr_target_seconds" in workflow
+    assert "master-watchdog-rehearsal-slo-guard-readiness.json" in workflow
     assert "allow_not_ready" in workflow
     assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" in workflow
 
@@ -14002,11 +14179,13 @@ def test_258_master_production_readiness_gate_workflow_wrapper_and_docs_wiring()
     assert "--branch-protection-report-file" in wrapper
     assert "--guard-health-report-file" in wrapper
     assert "--guard-burnin-report-file" in wrapper
+    assert "--watchdog-rehearsal-guard-report-file" in wrapper
     assert "--allow-not-ready" in wrapper
 
     assert "production_ready" in script
     assert "guard_burnin_integrity" in script
     assert "guard_workflow_health_integrity" in script
+    assert "watchdog_rehearsal_guard_integrity" in script
     assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" in ci_workflow
 
     assert "master-production-readiness-gate.yml" in readme
@@ -14021,6 +14200,7 @@ def test_259_master_production_readiness_gate_fails_when_guard_burnin_degraded()
     branch_protection_file = workspace / "branch-protection.json"
     guard_health_file = workspace / "guard-health.json"
     guard_burnin_file = workspace / "guard-burnin.json"
+    watchdog_rehearsal_guard_file = workspace / "watchdog-rehearsal-guard.json"
     output_file = workspace / "master-production-readiness-gate.json"
 
     required_checks_file.write_text(
@@ -14068,6 +14248,16 @@ def test_259_master_production_readiness_gate_fails_when_guard_burnin_degraded()
         ),
         encoding="utf-8",
     )
+    watchdog_rehearsal_guard_file.write_text(
+        json.dumps(
+            {
+                "decision": {"watchdog_rehearsal_slo_breached": False},
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
 
     command = [
         sys.executable,
@@ -14082,6 +14272,8 @@ def test_259_master_production_readiness_gate_fails_when_guard_burnin_degraded()
         str(guard_health_file.resolve()),
         "--guard-burnin-report-file",
         str(guard_burnin_file.resolve()),
+        "--watchdog-rehearsal-guard-report-file",
+        str(watchdog_rehearsal_guard_file.resolve()),
         "--output-file",
         str(output_file.resolve()),
     ]
@@ -14098,7 +14290,94 @@ def test_259_master_production_readiness_gate_fails_when_guard_burnin_degraded()
     assert payload["success"] is False
     assert payload["decision"]["production_ready"] is False
     assert payload["metrics"]["guard_burnin_degraded"] is True
+    assert payload["metrics"]["watchdog_rehearsal_slo_breached"] is False
     assert "guard_burnin_integrity" in [item["name"] for item in payload["failed_criteria"]]
+    assert output_file.exists()
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_259b_master_production_readiness_gate_fails_when_watchdog_rehearsal_guard_breached():
+    workspace = _local_test_dir("pytest-master-production-readiness-gate-watchdog-failure").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    required_checks_file = workspace / "required-checks.json"
+    branch_protection_file = workspace / "branch-protection.json"
+    guard_health_file = workspace / "guard-health.json"
+    guard_burnin_file = workspace / "guard-burnin.json"
+    watchdog_rehearsal_guard_file = workspace / "watchdog-rehearsal-guard.json"
+    output_file = workspace / "master-production-readiness-gate.json"
+
+    required_checks_file.write_text(
+        json.dumps(
+            {"metrics": {"non_green_runs_total": 0}, "decision": {"release_blocked": False}},
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    branch_protection_file.write_text(
+        json.dumps({"decision": {"branch_protection_drift_detected": False}}, ensure_ascii=True, sort_keys=True),
+        encoding="utf-8",
+    )
+    guard_health_file.write_text(
+        json.dumps(
+            {"decision": {"guard_workflow_health_degraded": False, "guard_workflow_coverage_contract_ok": True}},
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    guard_burnin_file.write_text(
+        json.dumps({"decision": {"guard_burnin_degraded": False}}, ensure_ascii=True, sort_keys=True),
+        encoding="utf-8",
+    )
+    watchdog_rehearsal_guard_file.write_text(
+        json.dumps(
+            {
+                "decision": {
+                    "watchdog_rehearsal_slo_breached": True,
+                    "breach_reason": "mttr",
+                }
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "master-production-readiness-gate.py"),
+        "--label",
+        "pytest-master-production-readiness-gate-watchdog-failure",
+        "--required-checks-report-file",
+        str(required_checks_file.resolve()),
+        "--branch-protection-report-file",
+        str(branch_protection_file.resolve()),
+        "--guard-health-report-file",
+        str(guard_health_file.resolve()),
+        "--guard-burnin-report-file",
+        str(guard_burnin_file.resolve()),
+        "--watchdog-rehearsal-guard-report-file",
+        str(watchdog_rehearsal_guard_file.resolve()),
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "Master production readiness gate failed: "
+    assert marker in completed.stderr
+    payload = json.loads(completed.stderr.split(marker, 1)[1].strip())
+    assert payload["success"] is False
+    assert payload["decision"]["production_ready"] is False
+    assert payload["metrics"]["guard_burnin_degraded"] is False
+    assert payload["metrics"]["watchdog_rehearsal_slo_breached"] is True
+    assert "watchdog_rehearsal_guard_integrity" in [item["name"] for item in payload["failed_criteria"]]
     assert output_file.exists()
 
     shutil.rmtree(workspace, ignore_errors=True)
@@ -14407,6 +14686,7 @@ def test_264_master_ci_drift_status_report_workflow_wrapper_and_docs_wiring():
     assert "BLOCKING_SIGNAL_IDS" in script
     assert "RESIDUAL_SIGNAL_IDS" in script
     assert "status_class" in script
+    assert "master-watchdog-rehearsal-drill-slo" in script
 
     assert "master-ci-drift-status-report.yml" in readme
     assert "run-master-ci-drift-status-report.ps1" in readme
@@ -14446,6 +14726,18 @@ def test_265_master_ci_drift_status_report_classifies_blocked_and_residual_from_
                         "donatomaurizio99-collab/GOC:master -->"
                     ),
                 },
+                {
+                    "number": 2003,
+                    "title": "[CI Drift] watchdog rehearsal drill SLO breached on master",
+                    "html_url": "https://github.com/donatomaurizio99-collab/GOC/issues/2003",
+                    "created_at": "2026-04-18T06:00:00Z",
+                    "updated_at": "2026-04-18T06:30:00Z",
+                    "labels": [{"name": "ci-drift"}, {"name": "watchdog-rehearsal"}],
+                    "body": (
+                        "<!-- ci-alert-key:master-watchdog-rehearsal-drill-slo:"
+                        "donatomaurizio99-collab/GOC:master -->"
+                    ),
+                },
             ],
             ensure_ascii=True,
             sort_keys=True,
@@ -14478,8 +14770,8 @@ def test_265_master_ci_drift_status_report_classifies_blocked_and_residual_from_
     assert completed.returncode == 0, completed.stderr
     payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
     assert payload["success"] is True
-    assert payload["metrics"]["open_ci_drift_issues_total"] == 2
-    assert payload["metrics"]["blocked_issues_total"] == 1
+    assert payload["metrics"]["open_ci_drift_issues_total"] == 3
+    assert payload["metrics"]["blocked_issues_total"] == 2
     assert payload["metrics"]["residual_issues_total"] == 1
     assert payload["decision"]["attention_required"] is True
     assert payload["decision"]["recommended_action"] == "ci_drift_blocked_incident_review_required"
@@ -14489,13 +14781,88 @@ def test_265_master_ci_drift_status_report_classifies_blocked_and_residual_from_
     issues = payload["issues"]
     assert issues[0]["signal_id"] == "master-branch-protection-drift"
     assert issues[0]["status_class"] == "blocked"
-    assert issues[1]["signal_id"] == "master-reliability-digest-warning"
-    assert issues[1]["status_class"] == "residual"
+    assert issues[1]["signal_id"] == "master-watchdog-rehearsal-drill-slo"
+    assert issues[1]["status_class"] == "blocked"
+    assert issues[2]["signal_id"] == "master-reliability-digest-warning"
+    assert issues[2]["status_class"] == "residual"
 
     markdown = markdown_output_file.read_text(encoding="utf-8")
     assert "Master CI Drift Status Report" in markdown
     assert "`blocked`" in markdown
     assert "`residual`" in markdown
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_265b_watchdog_rehearsal_mttr_calibration_wrapper_and_script_reports_recommended_target():
+    workspace = _local_test_dir("pytest-watchdog-rehearsal-mttr-calibration").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    report_paths: list[Path] = []
+    base_time = datetime(2026, 4, 1, 5, 0, tzinfo=timezone.utc)
+    for index in range(12):
+        report_path = workspace / f"master-guard-workflow-health-rehearsal-drill-{index:02d}.json"
+        report_path.write_text(
+            json.dumps(
+                {
+                    "label": "pytest-watchdog-rehearsal-drill",
+                    "metrics": {
+                        "alert_chain_mttr_seconds": float(210 + (index * 11)),
+                        "mttr_target_seconds": 300.0,
+                    },
+                    "generated_at_utc": (
+                        base_time + timedelta(days=index)
+                    ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                ensure_ascii=True,
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+        report_paths.append(report_path)
+
+    output_file = workspace / "watchdog-rehearsal-mttr-calibration.json"
+    policy_file = workspace / "watchdog-rehearsal-mttr-policy.json"
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "watchdog-rehearsal-mttr-calibrate.py"),
+        "--label",
+        "pytest-watchdog-rehearsal-mttr-calibration",
+        "--report-files",
+        ",".join(str(path.resolve()) for path in report_paths),
+        "--min-samples",
+        "10",
+        "--max-samples",
+        "14",
+        "--output-file",
+        str(output_file.resolve()),
+        "--policy-output-file",
+        str(policy_file.resolve()),
+        "--write-updates",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["metrics"]["sample_values_total"] == 12
+    assert payload["metrics"]["sample_requirements_met"] == 1
+    assert float(payload["metrics"]["recommended_target_seconds"]) > 300.0
+    assert output_file.exists()
+    assert policy_file.exists()
+
+    wrapper = (project_root / "scripts" / "run-watchdog-rehearsal-mttr-calibrate.ps1").read_text(encoding="utf-8")
+    readme = (project_root / "README.md").read_text(encoding="utf-8")
+    assert "watchdog-rehearsal-mttr-calibrate.py" in wrapper
+    assert "--min-samples" in wrapper
+    assert "--max-samples" in wrapper
+    assert "--write-updates" in wrapper
+    assert "run-watchdog-rehearsal-mttr-calibrate.ps1" in readme
+    assert "10-14 daily samples" in readme
 
     shutil.rmtree(workspace, ignore_errors=True)
 


### PR DESCRIPTION
﻿## Summary
- harden watchdog rehearsal SLO guard with MTTR evidence + breach classification
- wire watchdog guard output into master production readiness gate
- add MTTR calibration script/policy path and extend CI alert issue summary
- update workflow inputs/wrappers/docs/tests

## Validation
- python -m py_compile (updated scripts + tests/test_goal_ops.py)
- python -m pytest tests/test_goal_ops.py -k watchdog/production-readiness/ci-drift targeted set
- python .\\scripts\\p0-runbook-contract-check.py --label local-prepr-watchdog-mttr-hard-guard-readiness --project-root .
