### PR TITLE
Operationalize watchdog burn-in, weekly calibration, and breach handling

### DIFF
--- a/.github/workflows/master-guard-burnin-check.yml
+++ b/.github/workflows/master-guard-burnin-check.yml
@@ -21,6 +21,14 @@ on:
         description: "Required successful completed runs for weekly watchdog rehearsal drill workflow"
         required: false
         default: "1"
+      burnin_window_days:
+        description: "Rolling burn-in window in days used for MTTR/breach hard-exit criteria"
+        required: false
+        default: "14"
+      mttr_target_seconds:
+        description: "Optional MTTR target override for hard-exit criteria (defaults to policy target)"
+        required: false
+        default: ""
       allow_degraded:
         description: "Do not fail workflow when guard burn-in requirements are not met"
         required: false
@@ -57,25 +65,42 @@ jobs:
           REQUIRED_SUCCESSFUL_RUNS: ${{ github.event.inputs.required_successful_runs || '3' }}
           DIGEST_REQUIRED_SUCCESSFUL_RUNS: ${{ github.event.inputs.digest_required_successful_runs || '1' }}
           DRILL_REQUIRED_SUCCESSFUL_RUNS: ${{ github.event.inputs.drill_required_successful_runs || '1' }}
+          BURNIN_WINDOW_DAYS: ${{ github.event.inputs.burnin_window_days || '14' }}
+          MTTR_TARGET_SECONDS: ${{ github.event.inputs.mttr_target_seconds || '' }}
           ALLOW_DEGRADED: ${{ github.event.inputs.allow_degraded || 'false' }}
         run: |
+          $burninArgs = @(
+            "-Repo", "$env:REPO_FULL",
+            "-PerPage", "$env:PER_PAGE",
+            "-RequiredSuccessfulRuns", "$env:REQUIRED_SUCCESSFUL_RUNS",
+            "-DigestRequiredSuccessfulRuns", "$env:DIGEST_REQUIRED_SUCCESSFUL_RUNS",
+            "-DrillRequiredSuccessfulRuns", "$env:DRILL_REQUIRED_SUCCESSFUL_RUNS",
+            "-BurninWindowDays", "$env:BURNIN_WINDOW_DAYS",
+            "-OutputFile", "artifacts\master-guard-burnin-check.json"
+          )
+          if ($env:MTTR_TARGET_SECONDS) {
+            $burninArgs += @("-MttrTargetSeconds", "$env:MTTR_TARGET_SECONDS")
+          }
           if ($env:ALLOW_DEGRADED -eq "true") {
-            .\scripts\run-master-guard-burnin-check.ps1 `
-              -Repo "$env:REPO_FULL" `
-              -PerPage "$env:PER_PAGE" `
-              -RequiredSuccessfulRuns "$env:REQUIRED_SUCCESSFUL_RUNS" `
-              -DigestRequiredSuccessfulRuns "$env:DIGEST_REQUIRED_SUCCESSFUL_RUNS" `
-              -DrillRequiredSuccessfulRuns "$env:DRILL_REQUIRED_SUCCESSFUL_RUNS" `
-              -OutputFile "artifacts\master-guard-burnin-check.json" `
-              -AllowDegraded
+            .\scripts\run-master-guard-burnin-check.ps1 @burninArgs -AllowDegraded
           } else {
-            .\scripts\run-master-guard-burnin-check.ps1 `
-              -Repo "$env:REPO_FULL" `
-              -PerPage "$env:PER_PAGE" `
-              -RequiredSuccessfulRuns "$env:REQUIRED_SUCCESSFUL_RUNS" `
-              -DigestRequiredSuccessfulRuns "$env:DIGEST_REQUIRED_SUCCESSFUL_RUNS" `
-              -DrillRequiredSuccessfulRuns "$env:DRILL_REQUIRED_SUCCESSFUL_RUNS" `
-              -OutputFile "artifacts\master-guard-burnin-check.json"
+            .\scripts\run-master-guard-burnin-check.ps1 @burninArgs
+          }
+
+      - name: Publish burn-in summary
+        if: always()
+        shell: pwsh
+        run: |
+          if (Test-Path "artifacts\master-guard-burnin-check.json") {
+            $payload = Get-Content "artifacts\master-guard-burnin-check.json" -Raw | ConvertFrom-Json
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "## Master Guard Burn-in Check"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- burnin_status=$($payload.decision.burnin_status)"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- hard_exit_criteria_met=$($payload.decision.hard_exit_criteria_met)"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- missing_artifacts_total=$($payload.burnin_window.current_window.missing_artifacts.total)"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- unjustified_breaches=$($payload.burnin_window.current_window.unjustified_breaches)"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- p95_mttr_seconds=$($payload.burnin_window.current_window.mttr_percentiles_seconds.p95)"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- mttr_target_seconds=$($payload.burnin_window.mttr_target_seconds)"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- non_green_reasons=$([string]::Join(',', $payload.decision.non_green_reasons))"
           }
 
       - name: Upload guard burn-in report

--- a/.github/workflows/master-watchdog-mttr-weekly-calibration.yml
+++ b/.github/workflows/master-watchdog-mttr-weekly-calibration.yml
@@ -1,0 +1,165 @@
+name: Master Watchdog MTTR Weekly Calibration
+
+on:
+  schedule:
+    - cron: "15 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      per_page:
+        description: "Maximum completed rehearsal-drill runs fetched from GitHub history"
+        required: false
+        default: "28"
+      min_samples:
+        description: "Minimum samples required for calibration recommendation"
+        required: false
+        default: "10"
+      max_samples:
+        description: "Maximum latest samples considered for calibration"
+        required: false
+        default: "14"
+      recommendation_delta_threshold_percent:
+        description: "Create/update issue when recommended target differs by more than this percent"
+        required: false
+        default: "10"
+      recovery_threshold:
+        description: "Healthy calibration runs required before auto-closing open calibration issue"
+        required: false
+        default: "1"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
+jobs:
+  weekly-watchdog-mttr-calibration:
+    name: Weekly Watchdog MTTR Calibration
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Collect recent rehearsal drill reports
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_FULL: ${{ github.repository }}
+          PER_PAGE: ${{ github.event.inputs.per_page || '28' }}
+          WORKFLOW_NAME: Master Watchdog Rehearsal Drill
+          DRILL_ARTIFACT_NAME: master-guard-workflow-health-rehearsal-drill
+          REPORTS_DIR: artifacts\watchdog-mttr-calibration-samples
+        run: |
+          $ErrorActionPreference = "Stop"
+          New-Item -ItemType Directory -Force -Path $env:REPORTS_DIR | Out-Null
+          $workflowPayload = gh api "repos/$env:REPO_FULL/actions/workflows?per_page=100" | ConvertFrom-Json
+          $workflow = $workflowPayload.workflows | Where-Object { $_.name -eq $env:WORKFLOW_NAME } | Select-Object -First 1
+          if (-not $workflow) {
+            throw "Workflow '$env:WORKFLOW_NAME' not found in repository '$env:REPO_FULL'."
+          }
+
+          $runsPayload = gh api "repos/$env:REPO_FULL/actions/workflows/$($workflow.id)/runs?branch=master&status=completed&per_page=$env:PER_PAGE" | ConvertFrom-Json
+          $downloaded = 0
+          $downloadErrors = @()
+          foreach ($run in ($runsPayload.workflow_runs | Where-Object { $_ -ne $null })) {
+            $runId = [int]$run.id
+            if ($runId -le 0) {
+              continue
+            }
+            $runDir = Join-Path $env:REPORTS_DIR ("run-" + $runId)
+            New-Item -ItemType Directory -Force -Path $runDir | Out-Null
+            $downloadOutput = gh run download $runId -R $env:REPO_FULL -n $env:DRILL_ARTIFACT_NAME -D $runDir 2>&1
+            if ($LASTEXITCODE -eq 0) {
+              $downloaded += 1
+            } else {
+              $downloadErrors += "run_id=$runId error=$([string]::Join(' ', $downloadOutput))"
+            }
+          }
+
+          $manifest = @{
+            workflow_name = $env:WORKFLOW_NAME
+            workflow_id = [int]$workflow.id
+            runs_considered = [int](($runsPayload.workflow_runs | Measure-Object).Count)
+            reports_downloaded = [int]$downloaded
+            download_errors = $downloadErrors
+            generated_at_utc = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+          }
+          $manifest | ConvertTo-Json -Depth 8 | Set-Content -Path "artifacts/watchdog-rehearsal-mttr-calibration-samples-manifest.json" -Encoding utf8
+
+      - name: Run weekly MTTR calibration
+        shell: pwsh
+        env:
+          MIN_SAMPLES: ${{ github.event.inputs.min_samples || '10' }}
+          MAX_SAMPLES: ${{ github.event.inputs.max_samples || '14' }}
+          RECOMMENDATION_DELTA_THRESHOLD_PERCENT: ${{ github.event.inputs.recommendation_delta_threshold_percent || '10' }}
+        run: |
+          .\scripts\run-watchdog-rehearsal-mttr-calibrate.ps1 `
+            -MinSamples "$env:MIN_SAMPLES" `
+            -MaxSamples "$env:MAX_SAMPLES" `
+            -ReportsGlob "artifacts\watchdog-mttr-calibration-samples\**\master-guard-workflow-health-rehearsal-drill.json" `
+            -ActivePolicyFile "docs\watchdog-rehearsal-mttr-policy.json" `
+            -RecommendationDeltaThresholdPercent "$env:RECOMMENDATION_DELTA_THRESHOLD_PERCENT" `
+            -AllowInsufficientSamples `
+            -OutputFile "artifacts\watchdog-rehearsal-mttr-calibration-weekly.json" `
+            -PolicyOutputFile "docs\watchdog-rehearsal-mttr-policy.json"
+
+      - name: Upsert calibration drift issue
+        if: always()
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_FULL: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RECOVERY_THRESHOLD: ${{ github.event.inputs.recovery_threshold || '1' }}
+        run: |
+          if (-not (Test-Path "artifacts\watchdog-rehearsal-mttr-calibration-weekly.json")) {
+            throw "Calibration report not found: artifacts\\watchdog-rehearsal-mttr-calibration-weekly.json"
+          }
+          .\scripts\run-ci-alert-issue-upsert.ps1 `
+            -SignalId "watchdog-rehearsal-mttr-calibration" `
+            -Repo "$env:REPO_FULL" `
+            -ReportFile "artifacts\watchdog-rehearsal-mttr-calibration-weekly.json" `
+            -RunUrl "$env:RUN_URL" `
+            -RecoveryThreshold "$env:RECOVERY_THRESHOLD" `
+            -OutputFile "artifacts\watchdog-rehearsal-mttr-calibration-weekly-issue-upsert.json"
+
+      - name: Publish weekly calibration summary
+        if: always()
+        shell: pwsh
+        run: |
+          if (Test-Path "artifacts\watchdog-rehearsal-mttr-calibration-weekly.json") {
+            $payload = Get-Content "artifacts\watchdog-rehearsal-mttr-calibration-weekly.json" -Raw | ConvertFrom-Json
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "## Weekly Watchdog MTTR Calibration"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- sample_values_total=$($payload.metrics.sample_values_total)"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- active_target_seconds=$($payload.metrics.active_target_seconds)"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- recommended_target_seconds=$($payload.metrics.recommended_target_seconds)"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- recommendation_delta_percent=$($payload.metrics.recommendation_delta_percent)"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- action_required=$($payload.decision.action_required)"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- no_action_required=$($payload.decision.no_action_required)"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- recommended_action=$($payload.decision.recommended_action)"
+          }
+          if (Test-Path "artifacts\watchdog-rehearsal-mttr-calibration-weekly-issue-upsert.json") {
+            $issuePayload = Get-Content "artifacts\watchdog-rehearsal-mttr-calibration-weekly-issue-upsert.json" -Raw | ConvertFrom-Json
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- issue_action=$($issuePayload.decision.issue_action)"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- issue_number=$($issuePayload.issue.number)"
+          }
+
+      - name: Upload weekly calibration reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: watchdog-rehearsal-mttr-calibration-weekly
+          path: |
+            artifacts/watchdog-rehearsal-mttr-calibration-weekly.json
+            artifacts/watchdog-rehearsal-mttr-calibration-weekly-issue-upsert.json
+            artifacts/watchdog-rehearsal-mttr-calibration-samples-manifest.json
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -948,17 +948,18 @@ Nightly branch-protection drift guard now verifies that `master` keeps exactly t
 The drift guard reads required status checks from the branch API payload and still emits a drift report artifact even when branch-protection payload loading fails (for example token-scope/API-access errors), so issue upsert and artifact diagnostics stay intact.
 Nightly guard-workflow health watchdog now verifies that the guard workflows themselves run successfully on `master` and publish their expected artifacts.
 It also enforces a coverage contract so all relevant `master-*` guard/warning/required-checks workflow files are declared in the watchdog with expected artifact contracts.
-Guard-health issue summaries now include per-degraded-workflow diagnostics (reason(s), missing required artifacts, and latest run ID/URL) so on-call can triage directly from the issue.
+Guard-health issue summaries now include per-degraded-workflow diagnostics (reason(s), missing required artifacts, latest run ID/URL, and direct next action) so on-call can triage directly from the issue.
 Guard-health issue body/comments now include a dedicated `Immediate Actions` section with direct first-response steps and a local repro command.
 Nightly guard workflows now execute `run-master-guard-chain-selftest.ps1` to validate guard-report -> issue-upsert chain consistency and publish dedicated selftest artifacts.
 Weekly [master-watchdog-rehearsal-drill.yml](.github/workflows/master-watchdog-rehearsal-drill.yml) runs an injected-failure drill for the watchdog chain, verifies guard-health alert upsert behavior in dry-run mode, and publishes MTTR + run-link summary evidence for faster on-call triage.
-Nightly [master-watchdog-rehearsal-slo-guard.yml](.github/workflows/master-watchdog-rehearsal-slo-guard.yml) verifies the rehearsal drill SLO (>=1 successful run in 8 days), enforces latest drill MTTR target evidence, and raises a deduped `ci-drift` issue with explicit `stale`/`failed`/`mttr` reason plus latest run reference.
+Nightly [master-watchdog-rehearsal-slo-guard.yml](.github/workflows/master-watchdog-rehearsal-slo-guard.yml) verifies the rehearsal drill SLO (>=1 successful run in 8 days), enforces latest drill MTTR target evidence, and raises a deduped `ci-drift` issue with explicit `stale`/`failed`/`mttr` reason plus latest run reference, missing artifact context, and recommended next action.
 Nightly release-gate runtime early warning now flags sustained runtime slowdown (default: 3 consecutive runs >= 540s) before it escalates into flaky failures, and escalates when an active runtime warning issue stays open beyond the alert-age SLO (default: 72h).
 Nightly [master-release-gate-runtime-slo-guard.yml](.github/workflows/master-release-gate-runtime-slo-guard.yml) enforces a hard runtime guard (default: 3 consecutive runs >= 600s) and raises a deduped `ci-drift` blocking issue when breached.
 Nightly drift/warning workflows now upsert deduplicated GitHub issues (labels: `ci-drift` + signal label), enforce the invariant of at most one open issue per signal, reset recovery streak on active alerts, and auto-close recovered issues after 2 healthy nightly runs (configurable threshold). Active-alert comments are cooldown-throttled for unchanged failure states (default every 3 runs), while issue bodies continue to refresh each run. The runtime alert-age SLO escalation issue now carries a mandatory parent runtime-warning reference in its issue body and closes immediately when parent-coupled escalation criteria are no longer met.
 Weekly [master-reliability-digest.yml](.github/workflows/master-reliability-digest.yml) publishes a trend digest (Release Gate runtime, guard degradations, active-comment suppression totals) as artifact + workflow summary for proactive reliability tracking and feeds the deduped warning signal `master-reliability-digest-warning`.
 Reliability-digest guard degradation warnings are now based on consecutive head failures (default: 2) instead of any historical non-success sample in the trend window to reduce alert noise after successful recovery.
-Nightly [master-guard-burnin-check.yml](.github/workflows/master-guard-burnin-check.yml) enforces burn-in health for master guard/digest workflows by requiring recent successful runs with required artifacts (including weekly digest/rehearsal bootstrap windows).
+Nightly [master-guard-burnin-check.yml](.github/workflows/master-guard-burnin-check.yml) enforces burn-in health for master guard/digest workflows by requiring recent successful runs with required artifacts (including weekly digest/rehearsal bootstrap windows) and computes a 14-day hard-exit report (`missing_artifacts=0`, `unjustified_breaches=0`, `p95_mttr<=target`) with machine-readable non-green status.
+Weekly [master-watchdog-mttr-weekly-calibration.yml](.github/workflows/master-watchdog-mttr-weekly-calibration.yml) collects rehearsal-drill evidence, runs MTTR calibration, and opens/updates a deduped issue only when recommended target drift exceeds 10%; otherwise it records explicit machine-readable `no_action_required`.
 Daily [master-production-readiness-gate.yml](.github/workflows/master-production-readiness-gate.yml) aggregates required-check integrity, branch-protection drift, guard-workflow health, guard burn-in, and watchdog rehearsal SLO/MTTR integrity into one hard go/no-go production readiness gate.
 Daily [master-ci-drift-status-report.yml](.github/workflows/master-ci-drift-status-report.yml) publishes an operations report for open `ci-drift` issues with blocked/residual classification and issue-age context.
 Core CI and master guard/reliability workflows now set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` and standardize artifact uploads on `actions/upload-artifact@v7` to proactively avoid Node-20 action-runtime deprecation drift.
@@ -997,6 +998,9 @@ Weekly watchdog rehearsal drill workflow:
 
 Nightly watchdog rehearsal SLO guard workflow:
 [master-watchdog-rehearsal-slo-guard.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/master-watchdog-rehearsal-slo-guard.yml)
+
+Weekly watchdog MTTR calibration workflow:
+[master-watchdog-mttr-weekly-calibration.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/master-watchdog-mttr-weekly-calibration.yml)
 
 Weekly master reliability digest workflow:
 [master-reliability-digest.yml](/C:/Users/raffa/OneDrive/Documents/New%20project/.github/workflows/master-reliability-digest.yml)
@@ -1047,7 +1051,7 @@ Local guard burn-in check command:
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\run-master-guard-burnin-check.ps1 -PerPage 20 -RequiredSuccessfulRuns 3 -DigestRequiredSuccessfulRuns 1 -DrillRequiredSuccessfulRuns 1
+.\scripts\run-master-guard-burnin-check.ps1 -BurninWindowDays 14 -PerPage 20 -RequiredSuccessfulRuns 3 -DigestRequiredSuccessfulRuns 1 -DrillRequiredSuccessfulRuns 1
 ```
 
 Local production readiness gate command:
@@ -1082,7 +1086,7 @@ Watchdog MTTR calibration command (use after 10-14 daily samples):
 
 ```powershell
 Set-Location "C:\Users\raffa\OneDrive\Documents\New project"
-.\scripts\run-watchdog-rehearsal-mttr-calibrate.ps1 -MinSamples 10 -MaxSamples 14 -WriteUpdates
+.\scripts\run-watchdog-rehearsal-mttr-calibrate.ps1 -MinSamples 10 -MaxSamples 14 -RecommendationDeltaThresholdPercent 10 -OutputFile artifacts\watchdog-rehearsal-mttr-calibration-weekly.json
 ```
 
 Local release-gate runtime early warning command:

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -1679,6 +1679,99 @@ Actions:
    - `decision.recommended_action = production_ready_sustained`
 3. Treat AJ as the sustained production-ready certificate for long-running operations after cutover/hypercare/steady-state completion.
 
+### 3.53 Master watchdog burn-in hard exit criteria (14-day window)
+
+Symptoms:
+- master guard burn-in report is non-green and promotion readiness is unclear without opening multiple artifacts
+- on-call needs deterministic go/no-go conditions for release readiness over the rolling 14-day window
+
+Actions:
+1. Run burn-in check:
+   ```powershell
+   .\scripts\run-master-guard-burnin-check.ps1 -BurninWindowDays 14 -PerPage 20 -RequiredSuccessfulRuns 3 -DigestRequiredSuccessfulRuns 1 -DrillRequiredSuccessfulRuns 1 -OutputFile "artifacts\master-guard-burnin-check.json"
+   ```
+2. Validate hard exit criteria exactly:
+   - `missing_artifacts = 0`
+   - `unjustified_breaches = 0`
+   - `p95_mttr <= target`
+3. Confirm machine-readable decision fields:
+   - `decision.burnin_status = green`
+   - `decision.hard_exit_criteria_met = true`
+   - `decision.non_green = false`
+4. If any hard exit criterion fails, treat as release blocker and remediate before retrying readiness gate.
+
+### 3.54 Watchdog rehearsal breach handling (`stale` / `failed` / `mttr`)
+
+#### 3.54.1 `stale` breach
+
+Owner:
+- Primary: CI/Release on-call
+- Secondary: Platform reliability owner
+
+SLA / expected response time:
+- Triage start within 30 minutes
+- Fresh successful rehearsal drill run within 2 hours
+
+Diagnosis and recovery steps:
+1. Open latest guard issue summary and confirm stale context (`latest_run_age_hours > max_age_hours`).
+2. Trigger `master-watchdog-rehearsal-drill.yml` manually and monitor completion.
+3. Verify drill artifacts exist:
+   - `master-guard-workflow-health-rehearsal-check.json`
+   - `master-guard-workflow-health-rehearsal-issue-upsert.json`
+   - `master-guard-workflow-health-rehearsal-drill.json`
+4. Re-run `master-watchdog-rehearsal-slo-guard.yml` and confirm stale breach is cleared.
+
+Closure criteria:
+- latest rehearsal run is successful and within freshness SLO
+- guard report shows `decision.breach_reason = none`
+- alert issue transitions to recovery/closed per lifecycle policy
+
+#### 3.54.2 `failed` breach
+
+Owner:
+- Primary: workflow owner for failing rehearsal path
+- Secondary: CI/Release on-call
+
+SLA / expected response time:
+- Initial failure diagnosis within 30 minutes
+- validated green rerun within 4 hours
+
+Diagnosis and recovery steps:
+1. Open latest failing run (`run_id` + URL from issue summary) and inspect failing job logs.
+2. Fix root cause in workflow/script path, rerun rehearsal drill, and confirm success.
+3. Confirm required artifact set is present and non-expired in rerun output.
+4. Re-run `master-watchdog-rehearsal-slo-guard.yml` to verify failure breach is resolved.
+
+Closure criteria:
+- latest rehearsal run conclusion is `success`
+- `latest_run_missing_required_artifacts = []`
+- guard report returns `decision.watchdog_rehearsal_slo_breached = false`
+
+#### 3.54.3 `mttr` breach
+
+Owner:
+- Primary: Reliability engineering owner
+- Secondary: CI/Release on-call
+
+SLA / expected response time:
+- MTTR regression triage within 1 hour
+- mitigation plan and target action within same business day
+
+Diagnosis and recovery steps:
+1. Confirm MTTR evidence line in issue summary (`Latest alert-chain MTTR` vs target).
+2. Run weekly calibration evidence flow (no silent policy changes):
+   ```powershell
+   .\scripts\run-watchdog-rehearsal-mttr-calibrate.ps1 -MinSamples 10 -MaxSamples 14 -RecommendationDeltaThresholdPercent 10 -OutputFile "artifacts\watchdog-rehearsal-mttr-calibration-weekly.json"
+   ```
+3. If recommendation delta is >10%, open/update calibration issue with explicit recommendation and evidence.
+4. If calibration says no action required, keep policy target and optimize runtime path until MTTR falls below active target.
+5. Re-run rehearsal drill + SLO guard to confirm sustained MTTR recovery.
+
+Closure criteria:
+- guard report shows `metrics.mttr_seconds <= metrics.mttr_target_seconds`
+- burn-in report hard exit criteria remain green (`p95_mttr <= target`)
+- calibration output records `decision.no_action_required = true` or a tracked approved policy update
+
 ## 4. Operational Defaults
 
 - Keep single-instance protection enabled in production.

--- a/scripts/ci-alert-issue-upsert.py
+++ b/scripts/ci-alert-issue-upsert.py
@@ -38,6 +38,10 @@ SIGNAL_SPECS: dict[str, dict[str, Any]] = {
         "title": "[CI Drift] watchdog rehearsal drill SLO breached on master",
         "labels": ["ci-drift", "watchdog-rehearsal"],
     },
+    "watchdog-rehearsal-mttr-calibration": {
+        "title": "[CI Drift] watchdog rehearsal MTTR calibration drift on master",
+        "labels": ["ci-drift", "watchdog-rehearsal"],
+    },
     "master-reliability-digest-warning": {
         "title": "[CI Drift] master reliability digest warning detected",
         "labels": ["ci-drift", "reliability-digest"],
@@ -248,6 +252,56 @@ def _resolve_guard_workflow_run_url(*, repo: str, latest_run: dict[str, Any]) ->
     return f"https://github.com/{repo}/actions/runs/{run_id}"
 
 
+def _guard_workflow_next_action(
+    *,
+    workflow_name: str,
+    degraded_reasons: list[str],
+    missing_required_artifacts: list[str],
+) -> str:
+    normalized_reasons = {str(item).strip().lower() for item in degraded_reasons}
+    if "no_recent_completed_run_in_window" in normalized_reasons:
+        return (
+            f"Trigger `{workflow_name}` manually, confirm successful completion in-window, "
+            "then rerun guard-health watchdog."
+        )
+    if "latest_run_not_success" in normalized_reasons:
+        return (
+            f"Inspect failing logs for `{workflow_name}`, apply remediation, "
+            "rerun workflow, and confirm success."
+        )
+    if missing_required_artifacts:
+        return (
+            f"Restore artifact upload for `{workflow_name}` ({', '.join(missing_required_artifacts)}), "
+            "rerun workflow, and confirm artifact availability."
+        )
+    return f"Re-run `{workflow_name}` and validate green status with required artifacts."
+
+
+def _watchdog_breach_next_action(*, breach_reason: str) -> str:
+    reason = str(breach_reason or "").strip().lower()
+    if reason == "stale":
+        return (
+            "Trigger `master-watchdog-rehearsal-drill.yml` immediately and confirm a fresh successful run "
+            "within the 8-day SLO."
+        )
+    if reason == "failed":
+        return (
+            "Inspect the latest rehearsal drill failure, fix root cause, and rerun "
+            "`master-watchdog-rehearsal-drill.yml` until green."
+        )
+    if reason == "mttr":
+        return (
+            "Investigate alert-chain latency contributors, run weekly MTTR calibration evidence, "
+            "and restore MTTR <= target."
+        )
+    if reason == "mttr_report_unavailable":
+        return (
+            "Restore missing MTTR evidence artifact (`master-guard-workflow-health-rehearsal-drill`) "
+            "and rerun the rehearsal drill."
+        )
+    return "No immediate action required."
+
+
 def _format_guard_workflow_degraded_detail_lines(
     *,
     repo: str,
@@ -272,13 +326,19 @@ def _format_guard_workflow_degraded_detail_lines(
             latest_run_text = run_url
         else:
             latest_run_text = "none"
+        next_action = _guard_workflow_next_action(
+            workflow_name=workflow_name,
+            degraded_reasons=degraded_reasons,
+            missing_required_artifacts=missing_required_artifacts,
+        )
 
         detail_lines.append(
             (
                 f"- Degraded detail: {workflow_name} | "
                 f"reasons={reasons_text} | "
                 f"missing_required_artifacts={missing_text} | "
-                f"latest_run={latest_run_text}"
+                f"latest_run={latest_run_text} | "
+                f"next_action={next_action}"
             )
         )
     return detail_lines
@@ -439,6 +499,7 @@ def _signal_alert_state(
         decision = report.get("decision") if isinstance(report.get("decision"), dict) else {}
         metrics = report.get("metrics") if isinstance(report.get("metrics"), dict) else {}
         latest_run = report.get("latest_run") if isinstance(report.get("latest_run"), dict) else {}
+        drill_report = report.get("drill_report") if isinstance(report.get("drill_report"), dict) else {}
 
         latest_run_id = int(latest_run.get("run_id") or 0)
         latest_run_url = str(latest_run.get("url") or latest_run.get("html_url") or "").strip()
@@ -451,8 +512,12 @@ def _signal_alert_state(
         mttr_report_loaded = bool(metrics.get("mttr_report_loaded"))
         mttr_report_source = str(metrics.get("mttr_report_source") or "none")
         mttr_report_load_error = str(metrics.get("mttr_report_load_error") or "")
+        missing_required_artifacts = _coerce_string_list(latest_run.get("missing_required_artifacts"))
+        if not missing_required_artifacts:
+            missing_required_artifacts = _coerce_string_list(drill_report.get("missing_required_artifacts"))
         breach_reason = str(decision.get("breach_reason") or "none")
         alert_triggered = bool(decision.get("watchdog_rehearsal_slo_breached"))
+        next_action = _watchdog_breach_next_action(breach_reason=breach_reason)
 
         if latest_run_id > 0 and latest_run_url:
             latest_run_text = f"#{latest_run_id} ({latest_run_url})"
@@ -462,6 +527,7 @@ def _signal_alert_state(
             latest_run_text = latest_run_url
         else:
             latest_run_text = "none"
+        missing_artifacts_text = ", ".join(missing_required_artifacts) if missing_required_artifacts else "none"
         age_text = (
             f"{float(latest_run_age_hours):.2f}h"
             if latest_run_age_hours is not None
@@ -484,6 +550,7 @@ def _signal_alert_state(
             f"- Latest rehearsal run: {latest_run_text}",
             f"- Latest rehearsal run status: {latest_run_status or 'unknown'} / {latest_run_conclusion or 'unknown'}",
             f"- Latest rehearsal run age: {age_text} (threshold={max_age_hours}h)",
+            f"- Missing drill artifacts: {missing_artifacts_text}",
             f"- Latest alert-chain MTTR: {mttr_text} (target={mttr_target_text})",
             f"- MTTR evidence loaded: {'yes' if mttr_report_loaded else 'no'} (source={mttr_report_source})",
             (
@@ -491,9 +558,62 @@ def _signal_alert_state(
                 if mttr_report_load_error
                 else "- MTTR evidence load error: none"
             ),
+            f"- Recommended next action: {next_action}",
             f"- Recommended action: {decision.get('recommended_action') or 'watchdog_rehearsal_slo_healthy'}",
         ]
         return alert_triggered, summary, branch, {}
+
+    if signal_id == "watchdog-rehearsal-mttr-calibration":
+        decision = report.get("decision") if isinstance(report.get("decision"), dict) else {}
+        metrics = report.get("metrics") if isinstance(report.get("metrics"), dict) else {}
+        config = report.get("config") if isinstance(report.get("config"), dict) else {}
+        active_policy = report.get("active_policy") if isinstance(report.get("active_policy"), dict) else {}
+
+        action_required = bool(decision.get("action_required"))
+        no_action_required = bool(decision.get("no_action_required"))
+        sample_requirements_met = bool(decision.get("sample_requirements_met"))
+        recommended_action = str(decision.get("recommended_action") or "no_action_required")
+
+        sample_values_total = int(metrics.get("sample_values_total") or 0)
+        recommended_target_seconds = metrics.get("recommended_target_seconds")
+        active_target_seconds = metrics.get("active_target_seconds")
+        recommendation_delta_percent = metrics.get("recommendation_delta_percent")
+        recommendation_delta_threshold_percent = config.get("recommendation_delta_threshold_percent")
+        active_target_source = str(active_policy.get("source") or "unknown")
+        active_policy_load_error = str(active_policy.get("load_error") or "")
+
+        summary = [
+            f"- Action required: {'yes' if action_required else 'no'}",
+            f"- No action required: {'yes' if no_action_required else 'no'}",
+            f"- Sample requirements met: {'yes' if sample_requirements_met else 'no'} (samples={sample_values_total})",
+            (
+                f"- Active MTTR target: {float(active_target_seconds):.3f}s (source={active_target_source})"
+                if active_target_seconds is not None
+                else f"- Active MTTR target: unknown (source={active_target_source})"
+            ),
+            (
+                f"- Recommended MTTR target: {float(recommended_target_seconds):.3f}s"
+                if recommended_target_seconds is not None
+                else "- Recommended MTTR target: unavailable"
+            ),
+            (
+                "- Recommended-target delta: "
+                f"{float(recommendation_delta_percent):.3f}% "
+                f"(threshold={float(recommendation_delta_threshold_percent or 0):.3f}%)"
+                if recommendation_delta_percent is not None
+                else (
+                    "- Recommended-target delta: unavailable "
+                    f"(threshold={float(recommendation_delta_threshold_percent or 0):.3f}%)"
+                )
+            ),
+            (
+                f"- Active policy load error: {active_policy_load_error}"
+                if active_policy_load_error
+                else "- Active policy load error: none"
+            ),
+            f"- Recommended action: {recommended_action}",
+        ]
+        return bool(action_required), summary, branch, {}
 
     if signal_id in {"release-gate-runtime-early-warning", "release-gate-runtime-slo-guard"}:
         decision = report.get("decision") if isinstance(report.get("decision"), dict) else {}
@@ -848,6 +968,74 @@ def _signal_immediate_actions(
                 "`.\\scripts\\run-master-guard-workflow-health-check.ps1 "
                 "-LookbackHours 30 -PerPage 50 "
                 "-OutputFile artifacts\\master-guard-workflow-health-check.json`"
+            ),
+        ]
+
+    if signal_id == "master-watchdog-rehearsal-drill-slo":
+        decision = report.get("decision") if isinstance(report.get("decision"), dict) else {}
+        latest_run = report.get("latest_run") if isinstance(report.get("latest_run"), dict) else {}
+        drill_report = report.get("drill_report") if isinstance(report.get("drill_report"), dict) else {}
+
+        latest_run_id = int(latest_run.get("run_id") or 0)
+        latest_run_url = str(latest_run.get("url") or latest_run.get("html_url") or "").strip()
+        if latest_run_id > 0 and latest_run_url:
+            latest_reference = f"#{latest_run_id} ({latest_run_url})"
+        elif latest_run_id > 0:
+            latest_reference = f"#{latest_run_id}"
+        elif latest_run_url:
+            latest_reference = latest_run_url
+        else:
+            latest_reference = "none"
+
+        missing_required_artifacts = _coerce_string_list(latest_run.get("missing_required_artifacts"))
+        if not missing_required_artifacts:
+            missing_required_artifacts = _coerce_string_list(drill_report.get("missing_required_artifacts"))
+        missing_artifacts_text = ", ".join(missing_required_artifacts) if missing_required_artifacts else "none"
+        breach_reason = str(decision.get("breach_reason") or "none")
+
+        return [
+            f"- Open latest rehearsal run immediately: {latest_reference}",
+            f"- Restore missing drill artifacts if needed: {missing_artifacts_text}",
+            (
+                f"- Execute breach-specific playbook for reason `{breach_reason}` "
+                "(`stale`/`failed`/`mttr`) and rerun `master-watchdog-rehearsal-slo-guard.yml`."
+            ),
+            (
+                "- Re-run guard locally for confirmation: "
+                "`.\\scripts\\run-master-watchdog-rehearsal-slo-guard.ps1 "
+                "-MaxAgeHours 192 -MttrTargetSeconds 300 -PerPage 20 "
+                "-OutputFile artifacts\\master-watchdog-rehearsal-slo-guard.json`"
+            ),
+        ]
+
+    if signal_id == "watchdog-rehearsal-mttr-calibration":
+        decision = report.get("decision") if isinstance(report.get("decision"), dict) else {}
+        metrics = report.get("metrics") if isinstance(report.get("metrics"), dict) else {}
+        active_target_seconds = metrics.get("active_target_seconds")
+        recommended_target_seconds = metrics.get("recommended_target_seconds")
+        recommendation_delta_percent = metrics.get("recommendation_delta_percent")
+
+        return [
+            (
+                f"- Review MTTR target drift evidence: active={float(active_target_seconds):.3f}s, "
+                f"recommended={float(recommended_target_seconds):.3f}s, "
+                f"delta={float(recommendation_delta_percent):.3f}%"
+                if (
+                    active_target_seconds is not None
+                    and recommended_target_seconds is not None
+                    and recommendation_delta_percent is not None
+                )
+                else "- Review MTTR target drift evidence in the calibration report."
+            ),
+            (
+                f"- Apply recommendation decision: {decision.get('recommended_action') or 'no_action_required'} "
+                "(no silent policy changes)."
+            ),
+            (
+                "- Re-run weekly calibration manually if needed: "
+                "`.\\scripts\\run-watchdog-rehearsal-mttr-calibrate.ps1 "
+                "-MinSamples 10 -MaxSamples 14 "
+                "-OutputFile artifacts\\watchdog-rehearsal-mttr-calibration-weekly.json`"
             ),
         ]
 

--- a/scripts/master-guard-burnin-check.py
+++ b/scripts/master-guard-burnin-check.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import subprocess
 import sys
+import tempfile
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 
 DEFAULT_GUARD_BURNIN_WORKFLOW_SPECS = [
@@ -90,6 +92,14 @@ DEFAULT_GUARD_BURNIN_WORKFLOW_SPECS = [
     },
 ]
 
+DEFAULT_BURNIN_WINDOW_DAYS = 14
+DEFAULT_MTTR_TARGET_SECONDS = 300.0
+DEFAULT_MTTR_POLICY_FILE = "docs/watchdog-rehearsal-mttr-policy.json"
+DEFAULT_WATCHDOG_SLO_WORKFLOW_NAME = "Master Watchdog Rehearsal SLO Guard"
+DEFAULT_WATCHDOG_SLO_ARTIFACT_NAME = "master-watchdog-rehearsal-slo-guard"
+DEFAULT_WATCHDOG_SLO_REPORT_FILENAME = "master-watchdog-rehearsal-slo-guard.json"
+BURNIN_BREACH_REASONS = ("stale", "failed", "mttr")
+
 
 def _expect(condition: bool, message: str) -> None:
     if not condition:
@@ -143,6 +153,61 @@ def _resolve_now_utc(now_utc_text: str | None) -> datetime:
     return parsed
 
 
+def _parse_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    _expect(values, "Cannot compute percentile for empty values.")
+    sorted_values = sorted(float(item) for item in values)
+    if len(sorted_values) == 1:
+        return float(sorted_values[0])
+    p = max(0.0, min(100.0, float(percentile)))
+    rank = (len(sorted_values) - 1) * p / 100.0
+    lower = int(math.floor(rank))
+    upper = int(math.ceil(rank))
+    if lower == upper:
+        return float(sorted_values[lower])
+    weight = rank - lower
+    return float((sorted_values[lower] * (1.0 - weight)) + (sorted_values[upper] * weight))
+
+
+def _percentile_snapshot(values: list[float]) -> dict[str, float | None]:
+    if not values:
+        return {"p50": None, "p95": None, "p99": None}
+    return {
+        "p50": round(_percentile(values, 50.0), 3),
+        "p95": round(_percentile(values, 95.0), 3),
+        "p99": round(_percentile(values, 99.0), 3),
+    }
+
+
+def _delta(current: float | None, previous: float | None) -> float | None:
+    if current is None or previous is None:
+        return None
+    return round(float(current) - float(previous), 3)
+
+
+def _run_successful(run: dict[str, Any]) -> bool:
+    return bool(
+        str(run.get("status") or "") == "completed"
+        and str(run.get("conclusion") or "") == "success"
+    )
+
+
+def _resolve_run_url(*, repo: str, run: dict[str, Any]) -> str:
+    direct = str(run.get("html_url") or run.get("url") or "").strip()
+    if direct:
+        return direct
+    run_id = int(run.get("id") or 0)
+    if run_id <= 0:
+        return ""
+    return f"https://github.com/{repo}/actions/runs/{run_id}"
+
+
 def _fetch_workflow_id(*, repo: str, workflow_name: str) -> int:
     payload = _run_gh_api(f"repos/{repo}/actions/workflows?per_page=100")
     workflows = payload.get("workflows") or []
@@ -180,6 +245,50 @@ def _fetch_run_artifacts_from_github(*, repo: str, run_id: int) -> list[dict[str
     return [item for item in artifacts if isinstance(item, dict)]
 
 
+def _load_run_report_from_artifact(
+    *,
+    repo: str,
+    run_id: int,
+    artifact_name: str,
+    report_filename: str,
+) -> dict[str, Any]:
+    _expect(run_id > 0, "run_id must be > 0 for artifact download.")
+    _expect(str(artifact_name).strip(), "artifact_name must be non-empty.")
+    _expect(str(report_filename).strip(), "report_filename must be non-empty.")
+    with tempfile.TemporaryDirectory(prefix="master-guard-burnin-watchdog-report-") as temp_root_text:
+        temp_root = Path(temp_root_text)
+        command = [
+            "gh",
+            "run",
+            "download",
+            str(run_id),
+            "-R",
+            repo,
+            "-n",
+            str(artifact_name),
+            "-D",
+            str(temp_root),
+        ]
+        completed = subprocess.run(command, capture_output=True, text=True)
+        _expect(
+            completed.returncode == 0,
+            f"gh run download failed ({completed.returncode}) for run #{run_id}: {completed.stderr.strip()}",
+        )
+        candidates = sorted(
+            item
+            for item in temp_root.rglob("*.json")
+            if item.is_file() and item.name.lower() == str(report_filename).strip().lower()
+        )
+        _expect(
+            len(candidates) >= 1,
+            (
+                f"Downloaded artifact '{artifact_name}' for run #{run_id} but did not find "
+                f"'{report_filename}'."
+            ),
+        )
+        return _load_json_file(candidates[0])
+
+
 def _load_fixture_runs(*, payload: dict[str, Any], workflow_name: str) -> list[dict[str, Any]]:
     workflow_runs = payload.get("workflow_runs")
     if isinstance(workflow_runs, dict):
@@ -203,6 +312,33 @@ def _load_fixture_artifacts(*, payload: dict[str, Any], run_id: int) -> list[dic
         artifacts = entry
     _expect(isinstance(artifacts, list), f"fixtures.run_artifacts['{run_id}'] must resolve to a list.")
     return [item for item in artifacts if isinstance(item, dict)]
+
+
+def _load_fixture_run_report(
+    *,
+    payload: dict[str, Any],
+    run_id: int,
+    artifact_name: str,
+) -> dict[str, Any] | None:
+    run_reports = payload.get("run_reports")
+    if not isinstance(run_reports, dict):
+        return None
+    entry = run_reports.get(str(run_id))
+    if entry is None:
+        return None
+
+    if isinstance(entry, dict):
+        by_artifact = entry.get("artifacts")
+        if isinstance(by_artifact, dict):
+            artifact_report = by_artifact.get(str(artifact_name))
+            if isinstance(artifact_report, dict):
+                return artifact_report
+        report_payload = entry.get("report")
+        if isinstance(report_payload, dict):
+            return report_payload
+        if "label" in entry or "metrics" in entry or "decision" in entry:
+            return entry
+    return None
 
 
 def _extract_artifact_names(artifacts: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
@@ -295,7 +431,7 @@ def _evaluate_workflow_burnin(
     spec: dict[str, Any],
     runs: list[dict[str, Any]],
     required_successful_runs: int,
-    load_artifacts_for_run: Any,
+    load_artifacts_for_run: Callable[[int], list[dict[str, Any]]],
 ) -> tuple[dict[str, Any], dict[str, int]]:
     sorted_runs = sorted(
         runs,
@@ -319,7 +455,7 @@ def _evaluate_workflow_burnin(
         run_artifacts = load_artifacts_for_run(run_id) if run_id > 0 else []
         available_artifacts, expired_artifacts = _extract_artifact_names(run_artifacts)
         missing_required_artifacts = [item for item in required_artifacts if item not in available_artifacts]
-        run_success = run_status == "completed" and run_conclusion == "success"
+        run_success = bool(run_status == "completed" and run_conclusion == "success")
         run_healthy = bool(run_success and not missing_required_artifacts)
         if not run_success:
             non_success_runs_total += 1
@@ -376,6 +512,193 @@ def _evaluate_workflow_burnin(
     return evaluation, counters
 
 
+def _collect_burnin_window_stats(
+    *,
+    repo: str,
+    workflow_specs: list[dict[str, Any]],
+    runs_by_workflow: dict[str, list[dict[str, Any]]],
+    window_start_utc: datetime,
+    window_end_utc: datetime,
+    watchdog_slo_workflow_name: str,
+    load_artifacts_for_run: Callable[[int], list[dict[str, Any]]],
+    load_watchdog_report_for_run: Callable[[int], dict[str, Any] | None],
+) -> dict[str, Any]:
+    runs_in_window_total = 0
+    watchdog_report_runs_total = 0
+    mttr_samples: list[float] = []
+    breach_counts = {reason: 0 for reason in BURNIN_BREACH_REASONS}
+    missing_artifact_items: list[dict[str, Any]] = []
+    report_load_errors: list[dict[str, Any]] = []
+
+    for spec in workflow_specs:
+        workflow_name = str(spec.get("workflow_name") or "")
+        workflow_file = str(spec.get("workflow_file") or "")
+        required_artifacts = [str(item) for item in spec.get("required_artifacts") or []]
+        runs = runs_by_workflow.get(workflow_name) or []
+
+        for run in runs:
+            run_updated_at = _parse_utc_timestamp(str(run.get("updated_at") or ""))
+            if run_updated_at is None:
+                continue
+            if run_updated_at < window_start_utc or run_updated_at >= window_end_utc:
+                continue
+
+            runs_in_window_total += 1
+            run_id = int(run.get("id") or 0)
+            run_url = _resolve_run_url(repo=repo, run=run)
+            available_artifacts: list[str] = []
+            if run_id > 0:
+                run_artifacts = load_artifacts_for_run(run_id)
+                available_artifacts, _ = _extract_artifact_names(run_artifacts)
+
+            missing_required_artifacts = [
+                artifact_name
+                for artifact_name in required_artifacts
+                if artifact_name not in available_artifacts
+            ]
+            for artifact_name in missing_required_artifacts:
+                missing_artifact_items.append(
+                    {
+                        "workflow_name": workflow_name,
+                        "workflow_file": workflow_file,
+                        "run_id": run_id if run_id > 0 else None,
+                        "run_url": run_url or None,
+                        "artifact_name": artifact_name,
+                    }
+                )
+
+            if workflow_name != watchdog_slo_workflow_name or run_id <= 0:
+                continue
+            if missing_required_artifacts:
+                continue
+
+            try:
+                watchdog_report = load_watchdog_report_for_run(run_id)
+            except Exception as exc:  # noqa: BLE001
+                report_load_errors.append(
+                    {
+                        "run_id": run_id,
+                        "run_url": run_url or None,
+                        "error": str(exc),
+                    }
+                )
+                continue
+
+            if not isinstance(watchdog_report, dict):
+                report_load_errors.append(
+                    {
+                        "run_id": run_id,
+                        "run_url": run_url or None,
+                        "error": "watchdog report payload was not a JSON object",
+                    }
+                )
+                continue
+
+            watchdog_report_runs_total += 1
+            decision = watchdog_report.get("decision") if isinstance(watchdog_report.get("decision"), dict) else {}
+            metrics = watchdog_report.get("metrics") if isinstance(watchdog_report.get("metrics"), dict) else {}
+            breach_reason = str(decision.get("breach_reason") or "").strip().lower()
+            breached = bool(decision.get("watchdog_rehearsal_slo_breached")) or breach_reason in BURNIN_BREACH_REASONS
+            if breached and breach_reason in breach_counts:
+                breach_counts[breach_reason] += 1
+
+            mttr_seconds = _parse_float(metrics.get("mttr_seconds"))
+            if mttr_seconds is None:
+                mttr_seconds = _parse_float(metrics.get("alert_chain_mttr_seconds"))
+            if mttr_seconds is not None and mttr_seconds >= 0.0:
+                mttr_samples.append(float(mttr_seconds))
+
+    deduped_missing_items: list[dict[str, Any]] = []
+    seen_missing: set[tuple[str, int | None, str]] = set()
+    for item in sorted(
+        missing_artifact_items,
+        key=lambda entry: (
+            str(entry.get("workflow_name") or ""),
+            int(entry.get("run_id") or 0),
+            str(entry.get("artifact_name") or ""),
+        ),
+    ):
+        key = (
+            str(item.get("workflow_name") or ""),
+            int(item.get("run_id") or 0) if item.get("run_id") is not None else None,
+            str(item.get("artifact_name") or ""),
+        )
+        if key in seen_missing:
+            continue
+        seen_missing.add(key)
+        deduped_missing_items.append(item)
+
+    breach_total = int(sum(int(breach_counts[reason]) for reason in BURNIN_BREACH_REASONS))
+    percentiles = _percentile_snapshot(mttr_samples)
+    return {
+        "window_start_utc": _format_utc(window_start_utc),
+        "window_end_utc": _format_utc(window_end_utc),
+        "runs_in_window_total": int(runs_in_window_total),
+        "watchdog_report_runs_total": int(watchdog_report_runs_total),
+        "samples_total": int(len(mttr_samples)),
+        "mttr_samples_seconds": [round(float(item), 3) for item in sorted(mttr_samples)],
+        "mttr_percentiles_seconds": percentiles,
+        "breach_counts": {
+            "total": int(breach_total),
+            "by_reason": {reason: int(breach_counts[reason]) for reason in BURNIN_BREACH_REASONS},
+        },
+        "unjustified_breaches": int(breach_total),
+        "missing_artifacts": {
+            "total": int(len(deduped_missing_items)),
+            "items": deduped_missing_items,
+        },
+        "report_load_errors_total": int(len(report_load_errors)),
+        "report_load_errors": report_load_errors,
+    }
+
+
+def _resolve_mttr_target_seconds(
+    *,
+    mttr_target_seconds: float | None,
+    mttr_policy_file: Path | None,
+) -> dict[str, Any]:
+    if mttr_target_seconds is not None:
+        _expect(float(mttr_target_seconds) > 0.0, "mttr_target_seconds must be > 0 when provided.")
+        return {
+            "target_mttr_seconds": round(float(mttr_target_seconds), 3),
+            "source": "argument",
+            "policy_file": str(mttr_policy_file) if mttr_policy_file is not None else None,
+            "load_error": None,
+        }
+
+    if mttr_policy_file is not None and mttr_policy_file.exists():
+        try:
+            policy_payload = _load_json_file(mttr_policy_file)
+            policy_target = _parse_float(policy_payload.get("target_mttr_seconds"))
+            if policy_target is not None and policy_target > 0.0:
+                return {
+                    "target_mttr_seconds": round(float(policy_target), 3),
+                    "source": "policy_file",
+                    "policy_file": str(mttr_policy_file),
+                    "load_error": None,
+                }
+            return {
+                "target_mttr_seconds": round(float(DEFAULT_MTTR_TARGET_SECONDS), 3),
+                "source": "default",
+                "policy_file": str(mttr_policy_file),
+                "load_error": "Policy file missing numeric positive 'target_mttr_seconds'; using default.",
+            }
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "target_mttr_seconds": round(float(DEFAULT_MTTR_TARGET_SECONDS), 3),
+                "source": "default",
+                "policy_file": str(mttr_policy_file),
+                "load_error": f"Failed to load policy file: {exc}",
+            }
+
+    return {
+        "target_mttr_seconds": round(float(DEFAULT_MTTR_TARGET_SECONDS), 3),
+        "source": "default",
+        "policy_file": str(mttr_policy_file) if mttr_policy_file is not None else None,
+        "load_error": None,
+    }
+
+
 def run_guard_burnin_check(
     *,
     label: str,
@@ -385,6 +708,12 @@ def run_guard_burnin_check(
     required_successful_runs: int,
     digest_required_successful_runs: int,
     drill_required_successful_runs: int,
+    burnin_window_days: int,
+    mttr_target_seconds: float | None,
+    mttr_policy_file: Path | None,
+    watchdog_slo_workflow_name: str,
+    watchdog_slo_artifact_name: str,
+    watchdog_slo_report_filename: str,
     fixtures_file: Path | None,
     workflow_specs_file: Path | None,
     now_utc: datetime,
@@ -395,6 +724,10 @@ def run_guard_burnin_check(
     _expect(required_successful_runs > 0, "required_successful_runs must be > 0.")
     _expect(digest_required_successful_runs > 0, "digest_required_successful_runs must be > 0.")
     _expect(drill_required_successful_runs > 0, "drill_required_successful_runs must be > 0.")
+    _expect(burnin_window_days > 0, "burnin_window_days must be > 0.")
+    _expect(str(watchdog_slo_workflow_name).strip(), "watchdog_slo_workflow_name must be non-empty.")
+    _expect(str(watchdog_slo_artifact_name).strip(), "watchdog_slo_artifact_name must be non-empty.")
+    _expect(str(watchdog_slo_report_filename).strip(), "watchdog_slo_report_filename must be non-empty.")
 
     started = time.perf_counter()
     fixtures_payload = _load_json_file(fixtures_file) if fixtures_file is not None else None
@@ -403,6 +736,10 @@ def run_guard_burnin_check(
         if workflow_specs_file is not None
         else _normalize_workflow_specs(DEFAULT_GUARD_BURNIN_WORKFLOW_SPECS)
     )
+
+    artifacts_cache: dict[int, list[dict[str, Any]]] = {}
+    watchdog_report_cache: dict[int, dict[str, Any] | None] = {}
+    runs_by_workflow: dict[str, list[dict[str, Any]]] = {}
 
     def load_runs_for_workflow(workflow_name: str) -> list[dict[str, Any]]:
         if fixtures_payload is not None:
@@ -415,9 +752,39 @@ def run_guard_burnin_check(
         )
 
     def load_artifacts_for_run(run_id: int) -> list[dict[str, Any]]:
+        if run_id <= 0:
+            return []
+        cached = artifacts_cache.get(int(run_id))
+        if cached is not None:
+            return cached
         if fixtures_payload is not None:
-            return _load_fixture_artifacts(payload=fixtures_payload, run_id=run_id)
-        return _fetch_run_artifacts_from_github(repo=repo, run_id=run_id)
+            loaded = _load_fixture_artifacts(payload=fixtures_payload, run_id=run_id)
+        else:
+            loaded = _fetch_run_artifacts_from_github(repo=repo, run_id=run_id)
+        artifacts_cache[int(run_id)] = loaded
+        return loaded
+
+    def load_watchdog_report_for_run(run_id: int) -> dict[str, Any] | None:
+        if run_id <= 0:
+            return None
+        if int(run_id) in watchdog_report_cache:
+            return watchdog_report_cache[int(run_id)]
+        loaded_report: dict[str, Any] | None
+        if fixtures_payload is not None:
+            loaded_report = _load_fixture_run_report(
+                payload=fixtures_payload,
+                run_id=run_id,
+                artifact_name=watchdog_slo_artifact_name,
+            )
+        else:
+            loaded_report = _load_run_report_from_artifact(
+                repo=repo,
+                run_id=run_id,
+                artifact_name=watchdog_slo_artifact_name,
+                report_filename=watchdog_slo_report_filename,
+            )
+        watchdog_report_cache[int(run_id)] = loaded_report
+        return loaded_report
 
     evaluations: list[dict[str, Any]] = []
     aggregate_non_success_runs_total = 0
@@ -431,6 +798,7 @@ def run_guard_burnin_check(
             drill_required_successful_runs=drill_required_successful_runs,
         )
         runs = load_runs_for_workflow(workflow_name)
+        runs_by_workflow[workflow_name] = runs
         evaluation, counters = _evaluate_workflow_burnin(
             spec=spec,
             runs=runs,
@@ -446,6 +814,114 @@ def run_guard_burnin_check(
     degraded_workflow_names = [str(item.get("workflow_name") or "") for item in degraded_workflows]
     runs_evaluated_total = sum(int(item.get("burnin_runs_observed") or 0) for item in evaluations)
 
+    current_window_end = now_utc
+    current_window_start = now_utc - timedelta(days=burnin_window_days)
+    previous_window_start = current_window_start - timedelta(days=burnin_window_days)
+
+    current_window = _collect_burnin_window_stats(
+        repo=repo,
+        workflow_specs=workflow_specs,
+        runs_by_workflow=runs_by_workflow,
+        window_start_utc=current_window_start,
+        window_end_utc=current_window_end,
+        watchdog_slo_workflow_name=watchdog_slo_workflow_name,
+        load_artifacts_for_run=load_artifacts_for_run,
+        load_watchdog_report_for_run=load_watchdog_report_for_run,
+    )
+    previous_window = _collect_burnin_window_stats(
+        repo=repo,
+        workflow_specs=workflow_specs,
+        runs_by_workflow=runs_by_workflow,
+        window_start_utc=previous_window_start,
+        window_end_utc=current_window_start,
+        watchdog_slo_workflow_name=watchdog_slo_workflow_name,
+        load_artifacts_for_run=load_artifacts_for_run,
+        load_watchdog_report_for_run=load_watchdog_report_for_run,
+    )
+
+    mttr_target_resolution = _resolve_mttr_target_seconds(
+        mttr_target_seconds=mttr_target_seconds,
+        mttr_policy_file=mttr_policy_file,
+    )
+    mttr_target_effective_seconds = float(mttr_target_resolution["target_mttr_seconds"])
+
+    current_percentiles = current_window.get("mttr_percentiles_seconds") if isinstance(
+        current_window.get("mttr_percentiles_seconds"), dict
+    ) else {}
+    previous_percentiles = previous_window.get("mttr_percentiles_seconds") if isinstance(
+        previous_window.get("mttr_percentiles_seconds"), dict
+    ) else {}
+    current_p95 = _parse_float(current_percentiles.get("p95"))
+    current_unjustified_breaches = int(current_window.get("unjustified_breaches") or 0)
+    current_missing_artifacts_total = int(
+        ((current_window.get("missing_artifacts") or {}) if isinstance(current_window.get("missing_artifacts"), dict) else {}).get(
+            "total"
+        )
+        or 0
+    )
+
+    exit_criteria = [
+        {
+            "name": "missing_artifacts_zero",
+            "passed": bool(current_missing_artifacts_total == 0),
+            "details": f"missing_artifacts_total={current_missing_artifacts_total}",
+        },
+        {
+            "name": "unjustified_breaches_zero",
+            "passed": bool(current_unjustified_breaches == 0),
+            "details": f"unjustified_breaches={current_unjustified_breaches}",
+        },
+        {
+            "name": "p95_mttr_within_target",
+            "passed": bool(current_p95 is not None and float(current_p95) <= float(mttr_target_effective_seconds)),
+            "details": (
+                f"p95_mttr_seconds={current_p95}, "
+                f"mttr_target_seconds={mttr_target_effective_seconds}"
+            ),
+        },
+    ]
+    failed_exit_criteria = [item for item in exit_criteria if not bool(item.get("passed"))]
+    exit_criteria_met = len(failed_exit_criteria) == 0
+
+    trend_available = bool(
+        int(previous_window.get("samples_total") or 0) > 0
+        or int((previous_window.get("breach_counts") or {}).get("total") or 0) > 0
+        or int(((previous_window.get("missing_artifacts") or {}).get("total") or 0)) > 0
+    )
+    trend = {
+        "available": bool(trend_available),
+        "sample_count_delta": int(int(current_window.get("samples_total") or 0) - int(previous_window.get("samples_total") or 0)),
+        "breach_total_delta": int(
+            int((current_window.get("breach_counts") or {}).get("total") or 0)
+            - int((previous_window.get("breach_counts") or {}).get("total") or 0)
+        ),
+        "missing_artifacts_total_delta": int(
+            int(((current_window.get("missing_artifacts") or {}).get("total") or 0))
+            - int(((previous_window.get("missing_artifacts") or {}).get("total") or 0))
+        ),
+        "mttr_percentile_delta_seconds": {
+            "p50": _delta(
+                _parse_float(current_percentiles.get("p50")),
+                _parse_float(previous_percentiles.get("p50")),
+            ),
+            "p95": _delta(
+                _parse_float(current_percentiles.get("p95")),
+                _parse_float(previous_percentiles.get("p95")),
+            ),
+            "p99": _delta(
+                _parse_float(current_percentiles.get("p99")),
+                _parse_float(previous_percentiles.get("p99")),
+            ),
+        },
+    }
+
+    guard_burnin_degraded = bool(len(degraded_workflows) > 0 or not exit_criteria_met)
+    non_green_reasons: list[str] = []
+    if len(degraded_workflows) > 0:
+        non_green_reasons.append("workflow_window_degraded")
+    for failed in failed_exit_criteria:
+        non_green_reasons.append(f"hard_exit_{str(failed.get('name') or 'unknown')}")
+
     criteria = [
         {
             "name": "workflows_configured_for_guard_burnin",
@@ -457,6 +933,14 @@ def run_guard_burnin_check(
             "passed": bool((len(degraded_workflows) == 0) or allow_degraded),
             "details": (
                 f"degraded_workflows_total={len(degraded_workflows)}, "
+                f"allow_degraded={allow_degraded}"
+            ),
+        },
+        {
+            "name": "guard_burnin_hard_exit_criteria",
+            "passed": bool(exit_criteria_met or allow_degraded),
+            "details": (
+                f"hard_exit_criteria_failed_total={len(failed_exit_criteria)}, "
                 f"allow_degraded={allow_degraded}"
             ),
         },
@@ -474,6 +958,14 @@ def run_guard_burnin_check(
             "required_successful_runs": int(required_successful_runs),
             "digest_required_successful_runs": int(digest_required_successful_runs),
             "drill_required_successful_runs": int(drill_required_successful_runs),
+            "burnin_window_days": int(burnin_window_days),
+            "mttr_target_seconds_override": (
+                round(float(mttr_target_seconds), 3) if mttr_target_seconds is not None else None
+            ),
+            "mttr_policy_file": str(mttr_policy_file) if mttr_policy_file is not None else None,
+            "watchdog_slo_workflow_name": watchdog_slo_workflow_name,
+            "watchdog_slo_artifact_name": watchdog_slo_artifact_name,
+            "watchdog_slo_report_filename": watchdog_slo_report_filename,
             "allow_degraded": bool(allow_degraded),
             "now_utc": _format_utc(now_utc),
             "fixtures_file": str(fixtures_file) if fixtures_file is not None else None,
@@ -489,18 +981,53 @@ def run_guard_burnin_check(
             "runs_evaluated_total": int(runs_evaluated_total),
             "non_success_runs_total": int(aggregate_non_success_runs_total),
             "missing_required_artifacts_total": int(aggregate_missing_required_artifacts_total),
+            "burnin_window_days": int(burnin_window_days),
+            "burnin_window_samples_total": int(current_window.get("samples_total") or 0),
+            "burnin_unjustified_breaches_total": int(current_unjustified_breaches),
+            "burnin_missing_artifacts_total": int(current_missing_artifacts_total),
+            "burnin_mttr_p95_seconds": float(current_p95) if current_p95 is not None else None,
+            "burnin_mttr_target_seconds": round(float(mttr_target_effective_seconds), 3),
+            "hard_exit_criteria_failed": int(len(failed_exit_criteria)),
             "criteria_failed": int(len(failed_criteria)),
         },
         "criteria": criteria,
         "failed_criteria": failed_criteria,
         "evaluations": evaluations,
         "degraded_workflow_names": degraded_workflow_names,
+        "burnin_window": {
+            "window_days": int(burnin_window_days),
+            "current_window": current_window,
+            "previous_window": previous_window,
+            "trend": trend,
+            "mttr_target_seconds": round(float(mttr_target_effective_seconds), 3),
+            "mttr_target_source": str(mttr_target_resolution.get("source") or "default"),
+            "mttr_target_policy_file": mttr_target_resolution.get("policy_file"),
+            "mttr_target_load_error": mttr_target_resolution.get("load_error"),
+            "exit_criteria": {
+                "criteria": exit_criteria,
+                "failed": failed_exit_criteria,
+                "met": bool(exit_criteria_met),
+            },
+        },
         "decision": {
-            "guard_burnin_degraded": bool(len(degraded_workflows) > 0),
+            "guard_burnin_degraded": bool(guard_burnin_degraded),
+            "burnin_status": "green" if not guard_burnin_degraded else "non_green",
+            "non_green": bool(guard_burnin_degraded),
+            "non_green_reasons": non_green_reasons,
+            "hard_exit_criteria_met": bool(exit_criteria_met),
+            "hard_exit_criteria_failed": [str(item.get("name") or "") for item in failed_exit_criteria],
             "recommended_action": (
                 "guard_burnin_healthy"
-                if len(degraded_workflows) == 0
-                else "guard_burnin_rehearsal_required"
+                if not guard_burnin_degraded
+                else (
+                    "guard_burnin_rehearsal_required_and_exit_criteria_failed"
+                    if len(degraded_workflows) > 0 and not exit_criteria_met
+                    else (
+                        "guard_burnin_rehearsal_required"
+                        if len(degraded_workflows) > 0
+                        else "guard_burnin_exit_criteria_failed"
+                    )
+                )
             ),
         },
         "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
@@ -519,7 +1046,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
             "Validate burn-in health for master guard/digest workflows by requiring N recent "
-            "successful runs with required artifacts."
+            "successful runs with required artifacts, plus a 14-day watchdog MTTR/breach hard-exit window."
         )
     )
     parser.add_argument("--label", default="master-guard-burnin-check")
@@ -529,6 +1056,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--required-successful-runs", type=int, default=3)
     parser.add_argument("--digest-required-successful-runs", type=int, default=1)
     parser.add_argument("--drill-required-successful-runs", type=int, default=1)
+    parser.add_argument("--burnin-window-days", type=int, default=DEFAULT_BURNIN_WINDOW_DAYS)
+    parser.add_argument("--mttr-target-seconds", type=float)
+    parser.add_argument("--mttr-policy-file", default=DEFAULT_MTTR_POLICY_FILE)
+    parser.add_argument("--watchdog-slo-workflow-name", default=DEFAULT_WATCHDOG_SLO_WORKFLOW_NAME)
+    parser.add_argument("--watchdog-slo-artifact-name", default=DEFAULT_WATCHDOG_SLO_ARTIFACT_NAME)
+    parser.add_argument("--watchdog-slo-report-filename", default=DEFAULT_WATCHDOG_SLO_REPORT_FILENAME)
     parser.add_argument("--fixtures-file")
     parser.add_argument("--workflow-specs-file")
     parser.add_argument("--now-utc")
@@ -554,9 +1087,25 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 2
+    if int(args.burnin_window_days) <= 0:
+        print("[master-guard-burnin-check] ERROR: --burnin-window-days must be > 0.", file=sys.stderr)
+        return 2
+    if args.mttr_target_seconds is not None and float(args.mttr_target_seconds) <= 0.0:
+        print("[master-guard-burnin-check] ERROR: --mttr-target-seconds must be > 0 when provided.", file=sys.stderr)
+        return 2
+    if not str(args.watchdog_slo_workflow_name or "").strip():
+        print("[master-guard-burnin-check] ERROR: --watchdog-slo-workflow-name must be non-empty.", file=sys.stderr)
+        return 2
+    if not str(args.watchdog_slo_artifact_name or "").strip():
+        print("[master-guard-burnin-check] ERROR: --watchdog-slo-artifact-name must be non-empty.", file=sys.stderr)
+        return 2
+    if not str(args.watchdog_slo_report_filename or "").strip():
+        print("[master-guard-burnin-check] ERROR: --watchdog-slo-report-filename must be non-empty.", file=sys.stderr)
+        return 2
 
     fixtures_file = Path(str(args.fixtures_file)).expanduser() if args.fixtures_file else None
     workflow_specs_file = Path(str(args.workflow_specs_file)).expanduser() if args.workflow_specs_file else None
+    mttr_policy_file = Path(str(args.mttr_policy_file)).expanduser() if args.mttr_policy_file else None
     output_file = Path(str(args.output_file)).expanduser()
     try:
         report = run_guard_burnin_check(
@@ -567,6 +1116,12 @@ def main(argv: list[str] | None = None) -> int:
             required_successful_runs=int(args.required_successful_runs),
             digest_required_successful_runs=int(args.digest_required_successful_runs),
             drill_required_successful_runs=int(args.drill_required_successful_runs),
+            burnin_window_days=int(args.burnin_window_days),
+            mttr_target_seconds=float(args.mttr_target_seconds) if args.mttr_target_seconds is not None else None,
+            mttr_policy_file=mttr_policy_file,
+            watchdog_slo_workflow_name=str(args.watchdog_slo_workflow_name),
+            watchdog_slo_artifact_name=str(args.watchdog_slo_artifact_name),
+            watchdog_slo_report_filename=str(args.watchdog_slo_report_filename),
             fixtures_file=fixtures_file,
             workflow_specs_file=workflow_specs_file,
             now_utc=_resolve_now_utc(args.now_utc),

--- a/scripts/master-watchdog-rehearsal-slo-guard.py
+++ b/scripts/master-watchdog-rehearsal-slo-guard.py
@@ -97,16 +97,49 @@ def _fetch_runs_from_github(
     return [item for item in runs if isinstance(item, dict)]
 
 
-def _load_fixture_runs(*, runs_file: Path, workflow_name: str) -> list[dict[str, Any]]:
-    payload = _load_json_file(runs_file)
+def _fetch_run_artifacts_from_github(*, repo: str, run_id: int) -> list[dict[str, Any]]:
+    payload = _run_gh_api(f"repos/{repo}/actions/runs/{run_id}/artifacts?per_page=100")
+    artifacts = payload.get("artifacts") or []
+    _expect(isinstance(artifacts, list), f"Invalid artifacts payload for run {run_id}.")
+    return [item for item in artifacts if isinstance(item, dict)]
+
+
+def _load_fixture_runs(*, payload: dict[str, Any], workflow_name: str) -> list[dict[str, Any]]:
     if isinstance(payload.get("workflow_runs"), list):
         runs = payload.get("workflow_runs") or []
     elif isinstance(payload.get("workflow_runs"), dict):
         runs = (payload.get("workflow_runs") or {}).get(workflow_name) or []
     else:
         runs = payload.get("runs") or []
-    _expect(isinstance(runs, list), f"Invalid runs fixture payload in {runs_file}")
+    _expect(isinstance(runs, list), "Invalid runs fixture payload.")
     return [item for item in runs if isinstance(item, dict)]
+
+
+def _load_fixture_artifacts(*, payload: dict[str, Any], run_id: int) -> list[dict[str, Any]]:
+    run_artifacts = payload.get("run_artifacts") if isinstance(payload.get("run_artifacts"), dict) else {}
+    value = run_artifacts.get(str(run_id)) if isinstance(run_artifacts, dict) else None
+    if value is None:
+        return []
+    if isinstance(value, dict):
+        artifacts = value.get("artifacts") or []
+    else:
+        artifacts = value
+    _expect(isinstance(artifacts, list), f"fixtures.run_artifacts['{run_id}'] must resolve to a list.")
+    return [item for item in artifacts if isinstance(item, dict)]
+
+
+def _extract_artifact_names(artifacts: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
+    available: list[str] = []
+    expired: list[str] = []
+    for artifact in artifacts:
+        name = str(artifact.get("name") or "").strip()
+        if not name:
+            continue
+        if bool(artifact.get("expired")):
+            expired.append(name)
+        else:
+            available.append(name)
+    return sorted(available), sorted(expired)
 
 
 def _run_timestamp_for_sort(run: dict[str, Any]) -> datetime:
@@ -198,9 +231,13 @@ def run_watchdog_rehearsal_slo_guard(
     _expect(str(drill_artifact_name).strip(), "drill_artifact_name must be non-empty.")
 
     started = time.perf_counter()
+    fixtures_payload = _load_json_file(runs_file) if runs_file is not None else None
+    fixture_artifacts_available = bool(
+        fixtures_payload is not None and isinstance(fixtures_payload.get("run_artifacts"), dict)
+    )
     runs = (
-        _load_fixture_runs(runs_file=runs_file, workflow_name=workflow_name)
-        if runs_file is not None
+        _load_fixture_runs(payload=fixtures_payload or {}, workflow_name=workflow_name)
+        if fixtures_payload is not None
         else _fetch_runs_from_github(
             repo=repo,
             branch=branch,
@@ -208,6 +245,21 @@ def run_watchdog_rehearsal_slo_guard(
             per_page=per_page,
         )
     )
+
+    artifacts_cache: dict[int, list[dict[str, Any]]] = {}
+
+    def load_artifacts_for_run(run_id: int) -> list[dict[str, Any]]:
+        if run_id <= 0:
+            return []
+        if int(run_id) in artifacts_cache:
+            return artifacts_cache[int(run_id)]
+        if fixtures_payload is not None:
+            loaded = _load_fixture_artifacts(payload=fixtures_payload, run_id=run_id)
+        else:
+            loaded = _fetch_run_artifacts_from_github(repo=repo, run_id=run_id)
+        artifacts_cache[int(run_id)] = loaded
+        return loaded
+
     sorted_runs = sorted(runs, key=_run_timestamp_for_sort, reverse=True)
     latest_run = sorted_runs[0] if sorted_runs else None
 
@@ -233,19 +285,34 @@ def run_watchdog_rehearsal_slo_guard(
     )
     failed_breach = bool(latest_run is not None and not latest_run_success)
 
+    latest_run_id = int(latest_run.get("id") or 0) if latest_run is not None else 0
+    latest_run_artifacts = load_artifacts_for_run(latest_run_id) if latest_run_id > 0 else []
+    latest_run_available_artifacts, latest_run_expired_artifacts = _extract_artifact_names(latest_run_artifacts)
+    required_artifacts = [str(drill_artifact_name)]
+    artifact_inventory_known = bool(fixtures_payload is None or fixture_artifacts_available)
+    latest_run_missing_required_artifacts = (
+        [artifact_name for artifact_name in required_artifacts if artifact_name not in latest_run_available_artifacts]
+        if artifact_inventory_known
+        else []
+    )
+
     latest_run_snapshot = (
         {
-            "run_id": int(latest_run.get("id") or 0),
+            "run_id": latest_run_id,
             "status": str(latest_run.get("status") or ""),
             "conclusion": str(latest_run.get("conclusion") or ""),
             "updated_at": str(latest_run.get("updated_at") or ""),
             "updated_at_parsed_utc": _format_utc(latest_run_updated_at),
             "url": _resolve_latest_run_url(repo=repo, run=latest_run),
+            "required_artifacts": required_artifacts,
+            "artifact_inventory_known": bool(artifact_inventory_known),
+            "available_artifacts": latest_run_available_artifacts,
+            "expired_artifacts": latest_run_expired_artifacts,
+            "missing_required_artifacts": latest_run_missing_required_artifacts,
         }
         if latest_run is not None
         else None
     )
-    latest_run_id = int((latest_run_snapshot or {}).get("run_id") or 0)
 
     mttr_report_loaded = False
     mttr_report_source = "none"
@@ -262,9 +329,28 @@ def run_watchdog_rehearsal_slo_guard(
         and (not failed_breach)
         and latest_run_id > 0
         and (drill_report_file is not None or runs_file is None)
+        and (not artifact_inventory_known or len(latest_run_missing_required_artifacts) == 0)
     )
-    if not should_attempt_mttr and runs_file is not None and drill_report_file is None:
+    if (
+        not should_attempt_mttr
+        and runs_file is not None
+        and drill_report_file is None
+        and not artifact_inventory_known
+    ):
         mttr_report_source = "skipped_fixture_mode"
+    elif (
+        not should_attempt_mttr
+        and artifact_inventory_known
+        and len(latest_run_missing_required_artifacts) > 0
+        and not stale_breach
+        and not failed_breach
+    ):
+        mttr_report_source = "missing_required_artifact"
+        mttr_report_load_error = (
+            "Latest rehearsal run missing required artifact(s): "
+            + ", ".join(latest_run_missing_required_artifacts)
+        )
+        mttr_report_unavailable = True
 
     if should_attempt_mttr:
         mttr_evaluated = True
@@ -379,6 +465,11 @@ def run_watchdog_rehearsal_slo_guard(
             "runs_total_fetched": int(len(runs)),
             "max_age_hours": float(max_age_hours),
             "latest_run_age_hours": float(latest_run_age_hours) if latest_run_age_hours is not None else None,
+            "latest_run_artifact_inventory_known": bool(artifact_inventory_known),
+            "latest_run_available_artifacts_total": int(len(latest_run_available_artifacts)),
+            "latest_run_expired_artifacts_total": int(len(latest_run_expired_artifacts)),
+            "required_artifacts_missing_total": int(len(latest_run_missing_required_artifacts)),
+            "latest_run_missing_required_artifacts": latest_run_missing_required_artifacts,
             "mttr_evaluated": bool(mttr_evaluated),
             "mttr_seconds": float(mttr_seconds) if mttr_seconds is not None else None,
             "mttr_target_seconds": float(mttr_target_effective_seconds),
@@ -396,6 +487,9 @@ def run_watchdog_rehearsal_slo_guard(
             "loaded": bool(mttr_report_loaded),
             "source": mttr_report_source,
             "artifact_name": str(drill_artifact_name),
+            "required_artifacts": required_artifacts,
+            "artifact_inventory_known": bool(artifact_inventory_known),
+            "missing_required_artifacts": latest_run_missing_required_artifacts,
             "report_file": str(drill_report_file) if drill_report_file is not None else None,
             "load_error": mttr_report_load_error,
             "mttr_seconds": float(mttr_seconds) if mttr_seconds is not None else None,

--- a/scripts/run-ci-alert-issue-upsert.ps1
+++ b/scripts/run-ci-alert-issue-upsert.ps1
@@ -1,6 +1,6 @@
 ﻿param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("master-branch-protection-drift", "master-guard-workflow-health", "release-gate-runtime-early-warning", "release-gate-runtime-slo-guard", "release-gate-runtime-alert-age-slo", "master-watchdog-rehearsal-drill-slo", "master-reliability-digest-warning", "master-reliability-digest-guard")]
+    [ValidateSet("master-branch-protection-drift", "master-guard-workflow-health", "release-gate-runtime-early-warning", "release-gate-runtime-slo-guard", "release-gate-runtime-alert-age-slo", "master-watchdog-rehearsal-drill-slo", "watchdog-rehearsal-mttr-calibration", "master-reliability-digest-warning", "master-reliability-digest-guard")]
     [string]$SignalId,
     [Parameter(Mandatory = $true)]
     [string]$ReportFile,

--- a/scripts/run-master-guard-burnin-check.ps1
+++ b/scripts/run-master-guard-burnin-check.ps1
@@ -6,6 +6,12 @@ param(
     [int]$RequiredSuccessfulRuns = 3,
     [int]$DigestRequiredSuccessfulRuns = 1,
     [int]$DrillRequiredSuccessfulRuns = 1,
+    [int]$BurninWindowDays = 14,
+    [double]$MttrTargetSeconds = 0,
+    [string]$MttrPolicyFile = "docs\\watchdog-rehearsal-mttr-policy.json",
+    [string]$WatchdogSloWorkflowName = "Master Watchdog Rehearsal SLO Guard",
+    [string]$WatchdogSloArtifactName = "master-watchdog-rehearsal-slo-guard",
+    [string]$WatchdogSloReportFilename = "master-watchdog-rehearsal-slo-guard.json",
     [string]$FixturesFile = "",
     [string]$WorkflowSpecsFile = "",
     [string]$OutputFile = "artifacts\\master-guard-burnin-check.json",
@@ -26,8 +32,16 @@ $args = @(
     "--required-successful-runs", [string]$RequiredSuccessfulRuns,
     "--digest-required-successful-runs", [string]$DigestRequiredSuccessfulRuns,
     "--drill-required-successful-runs", [string]$DrillRequiredSuccessfulRuns,
+    "--burnin-window-days", [string]$BurninWindowDays,
+    "--mttr-policy-file", $MttrPolicyFile,
+    "--watchdog-slo-workflow-name", $WatchdogSloWorkflowName,
+    "--watchdog-slo-artifact-name", $WatchdogSloArtifactName,
+    "--watchdog-slo-report-filename", $WatchdogSloReportFilename,
     "--output-file", $OutputFile
 )
+if ($MttrTargetSeconds -gt 0) {
+    $args += @("--mttr-target-seconds", [string]$MttrTargetSeconds)
+}
 if ($FixturesFile) {
     $args += @("--fixtures-file", $FixturesFile)
 }

--- a/scripts/run-watchdog-rehearsal-mttr-calibrate.ps1
+++ b/scripts/run-watchdog-rehearsal-mttr-calibrate.ps1
@@ -7,6 +7,8 @@ param(
     [int]$MaxSamples = 14,
     [double]$PercentileTarget = 95,
     [double]$HeadroomPercent = 10,
+    [string]$ActivePolicyFile = "docs\\watchdog-rehearsal-mttr-policy.json",
+    [double]$RecommendationDeltaThresholdPercent = 10,
     [string]$OutputFile = "artifacts\\watchdog-rehearsal-mttr-calibration.json",
     [string]$PolicyOutputFile = "docs\\watchdog-rehearsal-mttr-policy.json",
     [switch]$WriteUpdates,
@@ -26,6 +28,8 @@ $args = @(
     "--max-samples", [string]$MaxSamples,
     "--percentile-target", [string]$PercentileTarget,
     "--headroom-percent", [string]$HeadroomPercent,
+    "--active-policy-file", $ActivePolicyFile,
+    "--recommendation-delta-threshold-percent", [string]$RecommendationDeltaThresholdPercent,
     "--output-file", $OutputFile,
     "--policy-output-file", $PolicyOutputFile
 )

--- a/scripts/watchdog-rehearsal-mttr-calibrate.py
+++ b/scripts/watchdog-rehearsal-mttr-calibrate.py
@@ -11,6 +11,7 @@ from typing import Any
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ACTIVE_MTTR_TARGET_SECONDS = 300.0
 
 
 def _expect(condition: bool, message: str) -> None:
@@ -33,6 +34,46 @@ def _read_json_object(path: Path) -> dict[str, Any]:
     payload = json.loads(path.read_text(encoding="utf-8-sig"))
     _expect(isinstance(payload, dict), f"Expected JSON object in {path}")
     return payload
+
+
+def _resolve_active_target_seconds(
+    *,
+    active_policy_file: Path | None,
+) -> tuple[float, str, str | None]:
+    if active_policy_file is None:
+        return float(DEFAULT_ACTIVE_MTTR_TARGET_SECONDS), "default", None
+    if not active_policy_file.exists():
+        return (
+            float(DEFAULT_ACTIVE_MTTR_TARGET_SECONDS),
+            "default",
+            f"Active policy file not found: {active_policy_file}",
+        )
+
+    try:
+        payload = _read_json_object(active_policy_file)
+    except Exception as exc:  # noqa: BLE001
+        return (
+            float(DEFAULT_ACTIVE_MTTR_TARGET_SECONDS),
+            "default",
+            f"Failed to read active policy file: {exc}",
+        )
+
+    target_raw = payload.get("target_mttr_seconds")
+    try:
+        target_seconds = float(target_raw)
+    except (TypeError, ValueError):
+        return (
+            float(DEFAULT_ACTIVE_MTTR_TARGET_SECONDS),
+            "default",
+            "Active policy target_mttr_seconds missing or non-numeric.",
+        )
+    if target_seconds <= 0.0:
+        return (
+            float(DEFAULT_ACTIVE_MTTR_TARGET_SECONDS),
+            "default",
+            "Active policy target_mttr_seconds must be > 0.",
+        )
+    return float(target_seconds), "policy_file", None
 
 
 def _parse_utc_timestamp(value: str) -> datetime | None:
@@ -95,6 +136,8 @@ def run_watchdog_mttr_calibration(
     max_samples: int,
     percentile_target: float,
     headroom_percent: float,
+    active_policy_file: Path | None,
+    recommendation_delta_threshold_percent: float,
     output_file: Path,
     policy_output_file: Path,
     write_updates: bool,
@@ -104,6 +147,10 @@ def run_watchdog_mttr_calibration(
     _expect(min_samples > 0, "min_samples must be > 0.")
     _expect(max_samples >= min_samples, "max_samples must be >= min_samples.")
     _expect(float(headroom_percent) >= 0.0, "headroom_percent must be >= 0.")
+    _expect(
+        float(recommendation_delta_threshold_percent) >= 0.0,
+        "recommendation_delta_threshold_percent must be >= 0.",
+    )
 
     valid_samples: list[dict[str, Any]] = []
     invalid_reports: list[dict[str, str]] = []
@@ -168,6 +215,28 @@ def run_watchdog_mttr_calibration(
         percentile_value = _percentile(sample_values, float(percentile_target))
         recommended_target_seconds = float(percentile_value) * (1.0 + (float(headroom_percent) / 100.0))
 
+    active_target_seconds, active_target_source, active_target_load_error = _resolve_active_target_seconds(
+        active_policy_file=active_policy_file
+    )
+    recommendation_delta_percent: float | None = None
+    if recommended_target_seconds is not None and float(active_target_seconds) > 0.0:
+        recommendation_delta_percent = abs(float(recommended_target_seconds) - float(active_target_seconds)) / float(
+            active_target_seconds
+        ) * 100.0
+    action_required = bool(
+        sample_requirements_met
+        and recommendation_delta_percent is not None
+        and float(recommendation_delta_percent) > float(recommendation_delta_threshold_percent)
+    )
+    no_action_required = bool(not action_required)
+
+    if not sample_requirements_met:
+        recommended_action = "insufficient_samples_no_action_required"
+    elif action_required:
+        recommended_action = "watchdog_mttr_target_update_recommended"
+    else:
+        recommended_action = "no_action_required"
+
     success = bool(sample_requirements_met or allow_insufficient_samples)
 
     policy_payload = {
@@ -200,6 +269,8 @@ def run_watchdog_mttr_calibration(
             "max_samples": int(max_samples),
             "percentile_target": float(percentile_target),
             "headroom_percent": float(headroom_percent),
+            "active_policy_file": str(active_policy_file) if active_policy_file is not None else None,
+            "recommendation_delta_threshold_percent": float(recommendation_delta_threshold_percent),
             "write_updates": bool(write_updates),
             "allow_insufficient_samples": bool(allow_insufficient_samples),
         },
@@ -214,6 +285,14 @@ def run_watchdog_mttr_calibration(
                 if recommended_target_seconds is not None
                 else None
             ),
+            "active_target_seconds": round(float(active_target_seconds), 3),
+            "recommendation_delta_percent": (
+                round(float(recommendation_delta_percent), 3)
+                if recommendation_delta_percent is not None
+                else None
+            ),
+            "action_required": bool(action_required),
+            "no_action_required": bool(no_action_required),
             "selected_samples_oldest_generated_at_utc": (
                 selected_samples[-1].get("generated_at_utc") if selected_samples else None
             ),
@@ -234,8 +313,23 @@ def run_watchdog_mttr_calibration(
             }
             for item in selected_samples
         ],
+        "active_policy": {
+            "path": str(active_policy_file) if active_policy_file is not None else None,
+            "target_mttr_seconds": round(float(active_target_seconds), 3),
+            "source": active_target_source,
+            "load_error": active_target_load_error,
+        },
         "invalid_reports": invalid_reports,
         "recommended_policy": policy_payload,
+        "decision": {
+            "sample_requirements_met": bool(sample_requirements_met),
+            "action_required": bool(action_required),
+            "no_action_required": bool(no_action_required),
+            "recommended_action": recommended_action,
+            "recommendation_delta_threshold_percent": float(recommendation_delta_threshold_percent),
+            "policy_update_applied": bool(write_updates and recommended_target_seconds is not None),
+            "policy_update_allowed": bool(write_updates),
+        },
         "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "duration_ms": int((time.perf_counter() - started) * 1000),
     }
@@ -270,6 +364,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--max-samples", type=int, default=14)
     parser.add_argument("--percentile-target", type=float, default=95.0)
     parser.add_argument("--headroom-percent", type=float, default=10.0)
+    parser.add_argument("--active-policy-file", default="docs/watchdog-rehearsal-mttr-policy.json")
+    parser.add_argument("--recommendation-delta-threshold-percent", type=float, default=10.0)
     parser.add_argument("--output-file", default="artifacts/watchdog-rehearsal-mttr-calibration.json")
     parser.add_argument("--policy-output-file", default="docs/watchdog-rehearsal-mttr-policy.json")
     parser.add_argument("--write-updates", action="store_true")
@@ -290,6 +386,12 @@ def main(argv: list[str] | None = None) -> int:
             max_samples=int(args.max_samples),
             percentile_target=float(args.percentile_target),
             headroom_percent=float(args.headroom_percent),
+            active_policy_file=(
+                _resolve_path(project_root, str(args.active_policy_file))
+                if str(args.active_policy_file or "").strip()
+                else None
+            ),
+            recommendation_delta_threshold_percent=float(args.recommendation_delta_threshold_percent),
             output_file=_resolve_path(project_root, str(args.output_file)),
             policy_output_file=_resolve_path(project_root, str(args.policy_output_file)),
             write_updates=bool(args.write_updates),

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -11499,6 +11499,7 @@ def test_231_ci_alert_issue_upsert_workflow_wrapper_and_docs_wiring():
     assert "release-gate-runtime-slo-guard" in wrapper
     assert "release-gate-runtime-alert-age-slo" in wrapper
     assert "master-watchdog-rehearsal-drill-slo" in wrapper
+    assert "watchdog-rehearsal-mttr-calibration" in wrapper
     assert "master-reliability-digest-warning" in wrapper
     assert "master-reliability-digest-guard" in wrapper
 
@@ -12754,6 +12755,8 @@ def test_242b_ci_alert_issue_upsert_creates_issue_for_watchdog_rehearsal_slo():
     created_body = str(issue_oplog["actions"][0]["body"])
     assert "Breach reason: stale" in created_body
     assert "Latest rehearsal run: #778899 (https://github.com/donatomaurizio99-collab/GOC/actions/runs/778899)" in created_body
+    assert "Missing drill artifacts: none" in created_body
+    assert "Recommended next action: Trigger `master-watchdog-rehearsal-drill.yml` immediately" in created_body
 
     shutil.rmtree(workspace, ignore_errors=True)
 
@@ -12834,6 +12837,7 @@ def test_242c_ci_alert_issue_upsert_includes_watchdog_mttr_details():
     assert "Breach reason: mttr" in created_body
     assert "Latest alert-chain MTTR: 412.500s (target=300.000s)" in created_body
     assert "MTTR evidence loaded: yes (source=file)" in created_body
+    assert "Recommended next action: Investigate alert-chain latency contributors" in created_body
 
     shutil.rmtree(workspace, ignore_errors=True)
 
@@ -14039,6 +14043,8 @@ def test_256_master_guard_burnin_workflow_wrapper_and_docs_wiring():
     assert "required_successful_runs" in workflow
     assert "digest_required_successful_runs" in workflow
     assert "drill_required_successful_runs" in workflow
+    assert "burnin_window_days" in workflow
+    assert "mttr_target_seconds" in workflow
     assert "allow_degraded" in workflow
     assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" in workflow
 
@@ -14046,12 +14052,17 @@ def test_256_master_guard_burnin_workflow_wrapper_and_docs_wiring():
     assert "--required-successful-runs" in wrapper
     assert "--digest-required-successful-runs" in wrapper
     assert "--drill-required-successful-runs" in wrapper
+    assert "--burnin-window-days" in wrapper
+    assert "--mttr-policy-file" in wrapper
+    assert "--watchdog-slo-workflow-name" in wrapper
     assert "--workflow-specs-file" in wrapper
     assert "--allow-degraded" in wrapper
 
     assert "master-guard-burnin-check.yml" in readme
     assert "run-master-guard-burnin-check.ps1" in readme
     assert "burn-in health for master guard/digest workflows" in readme
+    assert "missing_artifacts=0" in readme
+    assert "unjustified_breaches=0" in readme
 
 
 def test_257_master_guard_burnin_check_detects_insufficient_runs():
@@ -14146,6 +14157,173 @@ def test_257_master_guard_burnin_check_detects_insufficient_runs():
     assert payload["decision"]["guard_burnin_degraded"] is True
     assert payload["degraded_workflow_names"] == ["Master Guard Burn-in Probe"]
     assert payload["evaluations"][0]["has_sufficient_runs"] is False
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_257b_master_guard_burnin_check_reports_hard_exit_criteria_and_window_trend():
+    workspace = _local_test_dir("pytest-master-guard-burnin-check-hard-exit-window").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    fixtures_file = workspace / "fixtures.json"
+    workflow_specs_file = workspace / "workflow-specs.json"
+
+    workflow_specs_file.write_text(
+        json.dumps(
+            [
+                {
+                    "workflow_name": "Master Watchdog Rehearsal SLO Guard",
+                    "workflow_file": "master-watchdog-rehearsal-slo-guard.yml",
+                    "required_artifacts": ["master-watchdog-rehearsal-slo-guard"],
+                    "required_successful_runs": 1,
+                }
+            ],
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    fixtures_file.write_text(
+        json.dumps(
+            {
+                "workflow_runs": {
+                    "Master Watchdog Rehearsal SLO Guard": [
+                        {
+                            "id": 991001,
+                            "status": "completed",
+                            "conclusion": "success",
+                            "updated_at": "2026-04-28T05:00:00Z",
+                            "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/991001",
+                        },
+                        {
+                            "id": 991002,
+                            "status": "completed",
+                            "conclusion": "success",
+                            "updated_at": "2026-04-27T05:00:00Z",
+                            "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/991002",
+                        },
+                        {
+                            "id": 991003,
+                            "status": "completed",
+                            "conclusion": "success",
+                            "updated_at": "2026-04-26T05:00:00Z",
+                            "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/991003",
+                        },
+                        {
+                            "id": 991004,
+                            "status": "completed",
+                            "conclusion": "success",
+                            "updated_at": "2026-04-25T05:00:00Z",
+                            "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/991004",
+                        },
+                        {
+                            "id": 991005,
+                            "status": "completed",
+                            "conclusion": "success",
+                            "updated_at": "2026-04-10T05:00:00Z",
+                            "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/991005",
+                        },
+                        {
+                            "id": 991006,
+                            "status": "completed",
+                            "conclusion": "success",
+                            "updated_at": "2026-04-09T05:00:00Z",
+                            "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/991006",
+                        },
+                    ]
+                },
+                "run_artifacts": {
+                    "991001": {"artifacts": [{"name": "master-watchdog-rehearsal-slo-guard", "expired": False}]},
+                    "991002": {"artifacts": [{"name": "master-watchdog-rehearsal-slo-guard", "expired": False}]},
+                    "991003": {"artifacts": []},
+                    "991004": {"artifacts": [{"name": "master-watchdog-rehearsal-slo-guard", "expired": False}]},
+                    "991005": {"artifacts": [{"name": "master-watchdog-rehearsal-slo-guard", "expired": False}]},
+                    "991006": {"artifacts": [{"name": "master-watchdog-rehearsal-slo-guard", "expired": False}]},
+                },
+                "run_reports": {
+                    "991001": {
+                        "label": "pytest-watchdog-slo-run-991001",
+                        "metrics": {"mttr_seconds": 360.0, "mttr_target_seconds": 300.0},
+                        "decision": {"watchdog_rehearsal_slo_breached": True, "breach_reason": "mttr"},
+                    },
+                    "991002": {
+                        "label": "pytest-watchdog-slo-run-991002",
+                        "metrics": {"mttr_seconds": 280.0, "mttr_target_seconds": 300.0},
+                        "decision": {"watchdog_rehearsal_slo_breached": True, "breach_reason": "stale"},
+                    },
+                    "991004": {
+                        "label": "pytest-watchdog-slo-run-991004",
+                        "metrics": {"mttr_seconds": 320.0, "mttr_target_seconds": 300.0},
+                        "decision": {"watchdog_rehearsal_slo_breached": True, "breach_reason": "failed"},
+                    },
+                    "991005": {
+                        "label": "pytest-watchdog-slo-run-991005",
+                        "metrics": {"mttr_seconds": 250.0, "mttr_target_seconds": 300.0},
+                        "decision": {"watchdog_rehearsal_slo_breached": False, "breach_reason": "none"},
+                    },
+                    "991006": {
+                        "label": "pytest-watchdog-slo-run-991006",
+                        "metrics": {"mttr_seconds": 330.0, "mttr_target_seconds": 300.0},
+                        "decision": {"watchdog_rehearsal_slo_breached": True, "breach_reason": "mttr"},
+                    },
+                },
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "master-guard-burnin-check.py"),
+        "--label",
+        "pytest-master-guard-burnin-hard-exit-window",
+        "--repo",
+        "donatomaurizio99-collab/GOC",
+        "--branch",
+        "master",
+        "--fixtures-file",
+        str(fixtures_file.resolve()),
+        "--workflow-specs-file",
+        str(workflow_specs_file.resolve()),
+        "--required-successful-runs",
+        "1",
+        "--burnin-window-days",
+        "14",
+        "--mttr-target-seconds",
+        "300",
+        "--watchdog-slo-workflow-name",
+        "Master Watchdog Rehearsal SLO Guard",
+        "--watchdog-slo-artifact-name",
+        "master-watchdog-rehearsal-slo-guard",
+        "--watchdog-slo-report-filename",
+        "master-watchdog-rehearsal-slo-guard.json",
+        "--now-utc",
+        "2026-04-29T00:00:00Z",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "Master guard burn-in check failed: "
+    assert marker in completed.stderr
+    payload = json.loads(completed.stderr.split(marker, 1)[1].strip())
+    assert payload["success"] is False
+    assert payload["decision"]["guard_burnin_degraded"] is True
+    assert payload["decision"]["burnin_status"] == "non_green"
+    assert payload["decision"]["hard_exit_criteria_met"] is False
+    assert payload["burnin_window"]["current_window"]["samples_total"] == 3
+    assert payload["burnin_window"]["current_window"]["breach_counts"]["total"] == 3
+    assert payload["burnin_window"]["current_window"]["breach_counts"]["by_reason"]["stale"] == 1
+    assert payload["burnin_window"]["current_window"]["breach_counts"]["by_reason"]["failed"] == 1
+    assert payload["burnin_window"]["current_window"]["breach_counts"]["by_reason"]["mttr"] == 1
+    assert payload["burnin_window"]["current_window"]["missing_artifacts"]["total"] == 1
+    assert payload["burnin_window"]["trend"]["available"] is True
+    assert payload["burnin_window"]["trend"]["breach_total_delta"] == 2
+    assert float(payload["burnin_window"]["current_window"]["mttr_percentiles_seconds"]["p95"]) > 300.0
 
     shutil.rmtree(workspace, ignore_errors=True)
 
@@ -14822,6 +15000,19 @@ def test_265b_watchdog_rehearsal_mttr_calibration_wrapper_and_script_reports_rec
 
     output_file = workspace / "watchdog-rehearsal-mttr-calibration.json"
     policy_file = workspace / "watchdog-rehearsal-mttr-policy.json"
+    active_policy_file = workspace / "watchdog-rehearsal-active-policy.json"
+    active_policy_file.write_text(
+        json.dumps(
+            {
+                "target_mttr_seconds": 300.0,
+                "generated_at_utc": "2026-04-19T00:00:00Z",
+                "version": "1.0.0",
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
 
     command = [
         sys.executable,
@@ -14834,6 +15025,10 @@ def test_265b_watchdog_rehearsal_mttr_calibration_wrapper_and_script_reports_rec
         "10",
         "--max-samples",
         "14",
+        "--active-policy-file",
+        str(active_policy_file.resolve()),
+        "--recommendation-delta-threshold-percent",
+        "10",
         "--output-file",
         str(output_file.resolve()),
         "--policy-output-file",
@@ -14852,6 +15047,9 @@ def test_265b_watchdog_rehearsal_mttr_calibration_wrapper_and_script_reports_rec
     assert payload["metrics"]["sample_values_total"] == 12
     assert payload["metrics"]["sample_requirements_met"] == 1
     assert float(payload["metrics"]["recommended_target_seconds"]) > 300.0
+    assert payload["decision"]["action_required"] is True
+    assert payload["decision"]["no_action_required"] is False
+    assert payload["decision"]["recommended_action"] == "watchdog_mttr_target_update_recommended"
     assert output_file.exists()
     assert policy_file.exists()
 
@@ -14860,9 +15058,190 @@ def test_265b_watchdog_rehearsal_mttr_calibration_wrapper_and_script_reports_rec
     assert "watchdog-rehearsal-mttr-calibrate.py" in wrapper
     assert "--min-samples" in wrapper
     assert "--max-samples" in wrapper
+    assert "--active-policy-file" in wrapper
+    assert "--recommendation-delta-threshold-percent" in wrapper
     assert "--write-updates" in wrapper
     assert "run-watchdog-rehearsal-mttr-calibrate.ps1" in readme
     assert "10-14 daily samples" in readme
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_265c_watchdog_rehearsal_mttr_calibration_sets_no_action_required_with_small_delta():
+    workspace = _local_test_dir("pytest-watchdog-rehearsal-mttr-calibration-no-action").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    report_paths: list[Path] = []
+    base_time = datetime(2026, 4, 1, 6, 0, tzinfo=timezone.utc)
+    for index in range(10):
+        report_path = workspace / f"master-guard-workflow-health-rehearsal-drill-no-action-{index:02d}.json"
+        report_path.write_text(
+            json.dumps(
+                {
+                    "label": "pytest-watchdog-rehearsal-drill-no-action",
+                    "metrics": {
+                        "alert_chain_mttr_seconds": float(250 + (index * 4)),
+                        "mttr_target_seconds": 330.0,
+                    },
+                    "generated_at_utc": (
+                        base_time + timedelta(days=index)
+                    ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                ensure_ascii=True,
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+        report_paths.append(report_path)
+
+    active_policy_file = workspace / "watchdog-rehearsal-active-policy-no-action.json"
+    active_policy_file.write_text(
+        json.dumps(
+            {
+                "target_mttr_seconds": 330.0,
+                "generated_at_utc": "2026-04-19T00:00:00Z",
+                "version": "1.0.0",
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    output_file = workspace / "watchdog-rehearsal-mttr-calibration-no-action.json"
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "watchdog-rehearsal-mttr-calibrate.py"),
+        "--label",
+        "pytest-watchdog-rehearsal-mttr-calibration-no-action",
+        "--report-files",
+        ",".join(str(path.resolve()) for path in report_paths),
+        "--min-samples",
+        "10",
+        "--max-samples",
+        "10",
+        "--active-policy-file",
+        str(active_policy_file.resolve()),
+        "--recommendation-delta-threshold-percent",
+        "10",
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["decision"]["sample_requirements_met"] is True
+    assert payload["decision"]["action_required"] is False
+    assert payload["decision"]["no_action_required"] is True
+    assert payload["decision"]["recommended_action"] == "no_action_required"
+    assert output_file.exists()
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_265d_master_watchdog_mttr_weekly_calibration_workflow_wiring():
+    project_root = Path(__file__).resolve().parents[1]
+    workflow = (
+        project_root / ".github" / "workflows" / "master-watchdog-mttr-weekly-calibration.yml"
+    ).read_text(encoding="utf-8")
+    readme = (project_root / "README.md").read_text(encoding="utf-8")
+
+    assert "name: Master Watchdog MTTR Weekly Calibration" in workflow
+    assert 'cron: "15 6 * * 1"' in workflow
+    assert ".\\scripts\\run-watchdog-rehearsal-mttr-calibrate.ps1" in workflow
+    assert ".\\scripts\\run-ci-alert-issue-upsert.ps1" in workflow
+    assert "watchdog-rehearsal-mttr-calibration" in workflow
+    assert "watchdog-rehearsal-mttr-calibration-weekly.json" in workflow
+    assert "no_action_required" in workflow
+    assert "actions/upload-artifact@v7" in workflow
+    assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" in workflow
+
+    assert "master-watchdog-mttr-weekly-calibration.yml" in readme
+    assert "watchdog-rehearsal-mttr-calibration-weekly.json" in readme
+
+
+def test_265e_ci_alert_issue_upsert_creates_watchdog_mttr_calibration_issue_when_action_required():
+    workspace = _local_test_dir("pytest-ci-alert-issue-upsert-watchdog-mttr-calibration").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    report_file = workspace / "watchdog-rehearsal-mttr-calibration-weekly.json"
+    issues_file = workspace / "issues.json"
+    issue_oplog_file = workspace / "issue-oplog.json"
+    output_file = workspace / "ci-alert-issue-upsert-watchdog-mttr-calibration.json"
+
+    report_file.write_text(
+        json.dumps(
+            {
+                "label": "pytest-watchdog-mttr-calibration",
+                "config": {
+                    "branch": "master",
+                    "recommendation_delta_threshold_percent": 10.0,
+                },
+                "metrics": {
+                    "sample_values_total": 12,
+                    "active_target_seconds": 300.0,
+                    "recommended_target_seconds": 342.0,
+                    "recommendation_delta_percent": 14.0,
+                },
+                "decision": {
+                    "sample_requirements_met": True,
+                    "action_required": True,
+                    "no_action_required": False,
+                    "recommended_action": "watchdog_mttr_target_update_recommended",
+                },
+                "active_policy": {"source": "policy_file", "load_error": None},
+                "generated_at_utc": "2026-04-19T06:30:00Z",
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    issues_file.write_text("[]", encoding="utf-8")
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "ci-alert-issue-upsert.py"),
+        "--label",
+        "pytest-watchdog-mttr-calibration-upsert",
+        "--signal-id",
+        "watchdog-rehearsal-mttr-calibration",
+        "--repo",
+        "donatomaurizio99-collab/GOC",
+        "--report-file",
+        str(report_file.resolve()),
+        "--issues-file",
+        str(issues_file.resolve()),
+        "--issue-oplog-file",
+        str(issue_oplog_file.resolve()),
+        "--dry-run",
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["decision"]["alert_triggered"] is True
+    assert payload["decision"]["issue_action"] == "created"
+    assert payload["issue"]["title"] == "[CI Drift] watchdog rehearsal MTTR calibration drift on master"
+    assert "ci-alert-key:watchdog-rehearsal-mttr-calibration:donatomaurizio99-collab/GOC:master" in payload["issue"]["marker"]
+
+    issue_oplog = json.loads(issue_oplog_file.read_text(encoding="utf-8"))
+    created_body = str(issue_oplog["actions"][0]["body"])
+    assert "Action required: yes" in created_body
+    assert "Recommended MTTR target: 342.000s" in created_body
+    assert "Active MTTR target: 300.000s" in created_body
+    assert "Recommended-target delta: 14.000% (threshold=10.000%)" in created_body
 
     shutil.rmtree(workspace, ignore_errors=True)
 


### PR DESCRIPTION
﻿## Ziel/Scope
- Operationalisiert den 14-Tage-Burn-in-Report auf `master` inkl. p50/p95/p99-MTTR, Breach-Reason-Breakdown (`stale`/`failed`/`mttr`), Missing-Artifact-Inventar, Fenster-Delta sowie harte Exit-Kriterien mit maschinenlesbarem Non-Green-Status.
- Führt einen geplanten Weekly-Workflow zur MTTR-Kalibrierung ein (Artifact + Summary + Alert/Issue-Entscheidung bei >10% Delta, sonst explizites `no_action_required`).
- Operationalisiert Breach-Handling in Runbook und Alert-Summary (Owner, SLA, Diagnose/Recovery, Abschlusskriterien, letzte Run-ID/URL, direkte Next Action).
- Ergänzt/aktualisiert zugehörige Tests für Script-Logik, Workflow-Wiring und Summary/Decision-Felder.

## Validierung (lokal)
- `python -m py_compile scripts/master-guard-burnin-check.py scripts/watchdog-rehearsal-mttr-calibrate.py scripts/master-watchdog-rehearsal-slo-guard.py scripts/ci-alert-issue-upsert.py tests/test_goal_ops.py`
- `python -m pytest -q tests/test_goal_ops.py::test_231_ci_alert_issue_upsert_workflow_wrapper_and_docs_wiring tests/test_goal_ops.py::test_242b_ci_alert_issue_upsert_creates_issue_for_watchdog_rehearsal_slo tests/test_goal_ops.py::test_242c_ci_alert_issue_upsert_includes_watchdog_mttr_details tests/test_goal_ops.py::test_256_master_guard_burnin_workflow_wrapper_and_docs_wiring tests/test_goal_ops.py::test_257_master_guard_burnin_check_detects_insufficient_runs tests/test_goal_ops.py::test_257b_master_guard_burnin_check_reports_hard_exit_criteria_and_window_trend tests/test_goal_ops.py::test_265b_watchdog_rehearsal_mttr_calibration_wrapper_and_script_reports_recommended_target tests/test_goal_ops.py::test_265c_watchdog_rehearsal_mttr_calibration_sets_no_action_required_with_small_delta tests/test_goal_ops.py::test_265d_master_watchdog_mttr_weekly_calibration_workflow_wiring tests/test_goal_ops.py::test_265e_ci_alert_issue_upsert_creates_watchdog_mttr_calibration_issue_when_action_required`
- `python -m pytest -q tests/test_goal_ops.py -k "master_guard or watchdog_rehearsal or ci_alert_issue_upsert"`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-p0-runbook-contract-check.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-p0-report-schema-contract-check.ps1 -ArtifactsDir artifacts\validation-empty -AllowEmpty`

## Risiko/Rollback
- Risiko: mittel (Workflow-/Alert-Wiring + erweiterte Decision-Contracts); durch gezielte Regressionstests und Contract-Checks abgesichert.
- Rollback: Revert des PR-Commits auf `master`; keine stillen Policy-Änderungen, alle Empfehlungen/Abweichungen sind explizit im Output dokumentiert.
