### PR TITLE
Fix watchdog dispatch workflow runtime failures

### DIFF
--- a/.github/workflows/master-guard-burnin-check.yml
+++ b/.github/workflows/master-guard-burnin-check.yml
@@ -69,22 +69,22 @@ jobs:
           MTTR_TARGET_SECONDS: ${{ github.event.inputs.mttr_target_seconds || '' }}
           ALLOW_DEGRADED: ${{ github.event.inputs.allow_degraded || 'false' }}
         run: |
-          $burninArgs = @(
-            "-Repo", "$env:REPO_FULL",
-            "-PerPage", "$env:PER_PAGE",
-            "-RequiredSuccessfulRuns", "$env:REQUIRED_SUCCESSFUL_RUNS",
-            "-DigestRequiredSuccessfulRuns", "$env:DIGEST_REQUIRED_SUCCESSFUL_RUNS",
-            "-DrillRequiredSuccessfulRuns", "$env:DRILL_REQUIRED_SUCCESSFUL_RUNS",
-            "-BurninWindowDays", "$env:BURNIN_WINDOW_DAYS",
-            "-OutputFile", "artifacts\master-guard-burnin-check.json"
-          )
+          $burninParams = @{
+            Repo = "$env:REPO_FULL"
+            PerPage = [int]$env:PER_PAGE
+            RequiredSuccessfulRuns = [int]$env:REQUIRED_SUCCESSFUL_RUNS
+            DigestRequiredSuccessfulRuns = [int]$env:DIGEST_REQUIRED_SUCCESSFUL_RUNS
+            DrillRequiredSuccessfulRuns = [int]$env:DRILL_REQUIRED_SUCCESSFUL_RUNS
+            BurninWindowDays = [int]$env:BURNIN_WINDOW_DAYS
+            OutputFile = "artifacts\master-guard-burnin-check.json"
+          }
           if ($env:MTTR_TARGET_SECONDS) {
-            $burninArgs += @("-MttrTargetSeconds", "$env:MTTR_TARGET_SECONDS")
+            $burninParams.MttrTargetSeconds = [double]$env:MTTR_TARGET_SECONDS
           }
           if ($env:ALLOW_DEGRADED -eq "true") {
-            .\scripts\run-master-guard-burnin-check.ps1 @burninArgs -AllowDegraded
+            .\scripts\run-master-guard-burnin-check.ps1 @burninParams -AllowDegraded
           } else {
-            .\scripts\run-master-guard-burnin-check.ps1 @burninArgs
+            .\scripts\run-master-guard-burnin-check.ps1 @burninParams
           }
 
       - name: Publish burn-in summary

--- a/.github/workflows/master-watchdog-mttr-weekly-calibration.yml
+++ b/.github/workflows/master-watchdog-mttr-weekly-calibration.yml
@@ -71,8 +71,8 @@ jobs:
           $downloaded = 0
           $downloadErrors = @()
           foreach ($run in ($runsPayload.workflow_runs | Where-Object { $_ -ne $null })) {
-            $runId = [int]$run.id
-            if ($runId -le 0) {
+            $runId = [string]$run.id
+            if ([string]::IsNullOrWhiteSpace($runId)) {
               continue
             }
             $runDir = Join-Path $env:REPORTS_DIR ("run-" + $runId)
@@ -87,7 +87,7 @@ jobs:
 
           $manifest = @{
             workflow_name = $env:WORKFLOW_NAME
-            workflow_id = [int]$workflow.id
+            workflow_id = [long]$workflow.id
             runs_considered = [int](($runsPayload.workflow_runs | Measure-Object).Count)
             reports_downloaded = [int]$downloaded
             download_errors = $downloadErrors

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -14046,6 +14046,9 @@ def test_256_master_guard_burnin_workflow_wrapper_and_docs_wiring():
     assert "burnin_window_days" in workflow
     assert "mttr_target_seconds" in workflow
     assert "allow_degraded" in workflow
+    assert "$burninParams = @{" in workflow
+    assert "RequiredSuccessfulRuns = [int]$env:REQUIRED_SUCCESSFUL_RUNS" in workflow
+    assert ".\\scripts\\run-master-guard-burnin-check.ps1 @burninParams" in workflow
     assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" in workflow
 
     assert "master-guard-burnin-check.py" in wrapper
@@ -15158,6 +15161,9 @@ def test_265d_master_watchdog_mttr_weekly_calibration_workflow_wiring():
     assert "watchdog-rehearsal-mttr-calibration" in workflow
     assert "watchdog-rehearsal-mttr-calibration-weekly.json" in workflow
     assert "no_action_required" in workflow
+    assert "$runId = [string]$run.id" in workflow
+    assert "[string]::IsNullOrWhiteSpace($runId)" in workflow
+    assert "workflow_id = [long]$workflow.id" in workflow
     assert "actions/upload-artifact@v7" in workflow
     assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" in workflow
 


### PR DESCRIPTION
﻿## Summary
- fix PowerShell splatting in master burn-in dispatch to pass typed named parameters reliably
- fix weekly calibration workflow to handle large GitHub run IDs without Int32 overflow
- add wiring assertions to prevent regression in both workflows

## Validation
- python -m py_compile tests/test_goal_ops.py
- python -m pytest -q tests/test_goal_ops.py::test_256_master_guard_burnin_workflow_wrapper_and_docs_wiring tests/test_goal_ops.py::test_265d_master_watchdog_mttr_weekly_calibration_workflow_wiring
- python -m pytest -q tests/test_goal_ops.py -k "master_guard_burnin or watchdog_mttr_weekly_calibration"

## Risk
- low; workflow-dispatch runtime typing fix only, no policy/threshold behavior changes
