### PR TITLE
Harden watchdog MTTR evidence and burn-in missing artifact accounting

### DIFF
--- a/scripts/master-guard-burnin-check.py
+++ b/scripts/master-guard-burnin-check.py
@@ -528,6 +528,7 @@ def _collect_burnin_window_stats(
     mttr_samples: list[float] = []
     breach_counts = {reason: 0 for reason in BURNIN_BREACH_REASONS}
     missing_artifact_items: list[dict[str, Any]] = []
+    missing_artifact_items_non_success_runs: list[dict[str, Any]] = []
     report_load_errors: list[dict[str, Any]] = []
 
     for spec in workflow_specs:
@@ -546,6 +547,9 @@ def _collect_burnin_window_stats(
             runs_in_window_total += 1
             run_id = int(run.get("id") or 0)
             run_url = _resolve_run_url(repo=repo, run=run)
+            run_status = str(run.get("status") or "")
+            run_conclusion = str(run.get("conclusion") or "")
+            run_success = bool(run_status == "completed" and run_conclusion == "success")
             available_artifacts: list[str] = []
             if run_id > 0:
                 run_artifacts = load_artifacts_for_run(run_id)
@@ -557,15 +561,19 @@ def _collect_burnin_window_stats(
                 if artifact_name not in available_artifacts
             ]
             for artifact_name in missing_required_artifacts:
-                missing_artifact_items.append(
-                    {
-                        "workflow_name": workflow_name,
-                        "workflow_file": workflow_file,
-                        "run_id": run_id if run_id > 0 else None,
-                        "run_url": run_url or None,
-                        "artifact_name": artifact_name,
-                    }
-                )
+                missing_item = {
+                    "workflow_name": workflow_name,
+                    "workflow_file": workflow_file,
+                    "run_id": run_id if run_id > 0 else None,
+                    "run_url": run_url or None,
+                    "run_status": run_status,
+                    "run_conclusion": run_conclusion,
+                    "artifact_name": artifact_name,
+                }
+                if run_success:
+                    missing_artifact_items.append(missing_item)
+                else:
+                    missing_artifact_items_non_success_runs.append(missing_item)
 
             if workflow_name != watchdog_slo_workflow_name or run_id <= 0:
                 continue
@@ -608,25 +616,30 @@ def _collect_burnin_window_stats(
             if mttr_seconds is not None and mttr_seconds >= 0.0:
                 mttr_samples.append(float(mttr_seconds))
 
-    deduped_missing_items: list[dict[str, Any]] = []
-    seen_missing: set[tuple[str, int | None, str]] = set()
-    for item in sorted(
-        missing_artifact_items,
-        key=lambda entry: (
-            str(entry.get("workflow_name") or ""),
-            int(entry.get("run_id") or 0),
-            str(entry.get("artifact_name") or ""),
-        ),
-    ):
-        key = (
-            str(item.get("workflow_name") or ""),
-            int(item.get("run_id") or 0) if item.get("run_id") is not None else None,
-            str(item.get("artifact_name") or ""),
-        )
-        if key in seen_missing:
-            continue
-        seen_missing.add(key)
-        deduped_missing_items.append(item)
+    def dedupe_missing_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        deduped_items: list[dict[str, Any]] = []
+        seen_missing: set[tuple[str, int | None, str]] = set()
+        for item in sorted(
+            items,
+            key=lambda entry: (
+                str(entry.get("workflow_name") or ""),
+                int(entry.get("run_id") or 0),
+                str(entry.get("artifact_name") or ""),
+            ),
+        ):
+            key = (
+                str(item.get("workflow_name") or ""),
+                int(item.get("run_id") or 0) if item.get("run_id") is not None else None,
+                str(item.get("artifact_name") or ""),
+            )
+            if key in seen_missing:
+                continue
+            seen_missing.add(key)
+            deduped_items.append(item)
+        return deduped_items
+
+    deduped_missing_items = dedupe_missing_items(missing_artifact_items)
+    deduped_missing_items_non_success_runs = dedupe_missing_items(missing_artifact_items_non_success_runs)
 
     breach_total = int(sum(int(breach_counts[reason]) for reason in BURNIN_BREACH_REASONS))
     percentiles = _percentile_snapshot(mttr_samples)
@@ -646,6 +659,10 @@ def _collect_burnin_window_stats(
         "missing_artifacts": {
             "total": int(len(deduped_missing_items)),
             "items": deduped_missing_items,
+            "non_success_runs": {
+                "total": int(len(deduped_missing_items_non_success_runs)),
+                "items": deduped_missing_items_non_success_runs,
+            },
         },
         "report_load_errors_total": int(len(report_load_errors)),
         "report_load_errors": report_load_errors,

--- a/scripts/master-watchdog-rehearsal-slo-guard.py
+++ b/scripts/master-watchdog-rehearsal-slo-guard.py
@@ -167,6 +167,26 @@ def _parse_float(value: Any) -> float | None:
         return None
 
 
+def _resolve_mttr_from_drill_report(report: dict[str, Any]) -> tuple[float | None, float | None, str | None]:
+    metrics = report.get("metrics") if isinstance(report.get("metrics"), dict) else {}
+    mttr_seconds = _parse_float(metrics.get("alert_chain_mttr_seconds"))
+    mttr_value_source: str | None = None
+    if mttr_seconds is not None and mttr_seconds >= 0.0:
+        mttr_value_source = "metrics.alert_chain_mttr_seconds"
+    else:
+        mttr_seconds = None
+
+    # Backward-compatibility for older rehearsal drill artifacts.
+    if mttr_seconds is None:
+        duration_ms = _parse_float(report.get("duration_ms"))
+        if duration_ms is not None and duration_ms >= 0.0:
+            mttr_seconds = float(duration_ms) / 1000.0
+            mttr_value_source = "duration_ms_fallback"
+
+    reported_target = _parse_float(metrics.get("mttr_target_seconds"))
+    return mttr_seconds, reported_target, mttr_value_source
+
+
 def _load_drill_report_from_artifact(
     *,
     repo: str,
@@ -319,6 +339,7 @@ def run_watchdog_rehearsal_slo_guard(
     mttr_report_load_error: str | None = None
     mttr_report: dict[str, Any] | None = None
     mttr_seconds: float | None = None
+    mttr_value_source: str | None = None
     mttr_target_effective_seconds: float = float(mttr_target_seconds)
     mttr_evaluated = False
     mttr_breach = False
@@ -371,16 +392,14 @@ def run_watchdog_rehearsal_slo_guard(
             mttr_report_loaded = False
 
         if mttr_report_loaded and mttr_report is not None:
-            mttr_metrics = mttr_report.get("metrics") if isinstance(mttr_report.get("metrics"), dict) else {}
-            mttr_seconds = _parse_float(mttr_metrics.get("alert_chain_mttr_seconds"))
-            reported_target = _parse_float(mttr_metrics.get("mttr_target_seconds"))
+            mttr_seconds, reported_target, mttr_value_source = _resolve_mttr_from_drill_report(mttr_report)
             if reported_target is not None and reported_target > 0:
                 mttr_target_effective_seconds = float(reported_target)
             if mttr_seconds is None:
                 mttr_report_loaded = False
                 mttr_report_source = f"{mttr_report_source}-invalid"
                 mttr_report_load_error = (
-                    "Drill report missing numeric metrics.alert_chain_mttr_seconds."
+                    "Drill report missing numeric metrics.alert_chain_mttr_seconds and duration_ms fallback."
                 )
 
         if not mttr_report_loaded:
@@ -476,6 +495,7 @@ def run_watchdog_rehearsal_slo_guard(
             "mttr_breach": bool(mttr_breach),
             "mttr_report_loaded": bool(mttr_report_loaded),
             "mttr_report_unavailable": bool(mttr_report_unavailable),
+            "mttr_value_source": mttr_value_source,
             "mttr_report_source": mttr_report_source,
             "mttr_report_load_error": mttr_report_load_error,
             "criteria_failed": int(len(failed_criteria)),
@@ -493,6 +513,7 @@ def run_watchdog_rehearsal_slo_guard(
             "report_file": str(drill_report_file) if drill_report_file is not None else None,
             "load_error": mttr_report_load_error,
             "mttr_seconds": float(mttr_seconds) if mttr_seconds is not None else None,
+            "mttr_value_source": mttr_value_source,
             "mttr_target_seconds": float(mttr_target_effective_seconds),
         },
         "decision": {

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -13421,6 +13421,89 @@ def test_248c_master_watchdog_rehearsal_slo_guard_detects_mttr_breach_from_drill
     shutil.rmtree(workspace, ignore_errors=True)
 
 
+def test_248d_master_watchdog_rehearsal_slo_guard_uses_duration_ms_fallback_for_legacy_drill_report():
+    workspace = _local_test_dir("pytest-master-watchdog-rehearsal-slo-guard-duration-ms-fallback").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    runs_file = workspace / "runs.json"
+    drill_report_file = workspace / "master-guard-workflow-health-rehearsal-drill.json"
+
+    runs_file.write_text(
+        json.dumps(
+            {
+                "workflow_runs": [
+                    {
+                        "id": 771005,
+                        "status": "completed",
+                        "conclusion": "success",
+                        "updated_at": "2026-04-18T11:20:00Z",
+                        "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/771005",
+                    }
+                ]
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    drill_report_file.write_text(
+        json.dumps(
+            {
+                "label": "pytest-master-watchdog-rehearsal-drill-legacy",
+                "duration_ms": 412500,
+                "metrics": {
+                    "mttr_target_seconds": 300.0,
+                },
+                "generated_at_utc": "2026-04-18T11:21:00Z",
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "master-watchdog-rehearsal-slo-guard.py"),
+        "--label",
+        "pytest-master-watchdog-rehearsal-slo-guard-duration-ms-fallback",
+        "--repo",
+        "donatomaurizio99-collab/GOC",
+        "--branch",
+        "master",
+        "--workflow-name",
+        "Master Watchdog Rehearsal Drill",
+        "--max-age-hours",
+        "192",
+        "--mttr-target-seconds",
+        "300",
+        "--runs-file",
+        str(runs_file.resolve()),
+        "--drill-report-file",
+        str(drill_report_file.resolve()),
+        "--now-utc",
+        "2026-04-18T12:00:00Z",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    marker = "Master watchdog rehearsal SLO guard failed: "
+    assert marker in completed.stderr
+    payload = json.loads(completed.stderr.split(marker, 1)[1].strip())
+    assert payload["success"] is False
+    assert payload["decision"]["watchdog_rehearsal_slo_breached"] is True
+    assert payload["decision"]["breach_reason"] == "mttr"
+    assert payload["metrics"]["mttr_seconds"] == 412.5
+    assert payload["metrics"]["mttr_report_unavailable"] is False
+    assert payload["metrics"]["mttr_value_source"] == "duration_ms_fallback"
+    assert payload["drill_report"]["source"] == "file"
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
 def test_249_master_guard_chain_selftest_verifies_signal_chain():
     workspace = _local_test_dir("pytest-master-guard-chain-selftest").resolve()
     project_root = Path(__file__).resolve().parents[1]
@@ -14327,6 +14410,113 @@ def test_257b_master_guard_burnin_check_reports_hard_exit_criteria_and_window_tr
     assert payload["burnin_window"]["trend"]["available"] is True
     assert payload["burnin_window"]["trend"]["breach_total_delta"] == 2
     assert float(payload["burnin_window"]["current_window"]["mttr_percentiles_seconds"]["p95"]) > 300.0
+
+    shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_257c_master_guard_burnin_check_ignores_non_success_missing_artifacts_in_hard_exit_count():
+    workspace = _local_test_dir("pytest-master-guard-burnin-check-ignore-failed-missing").resolve()
+    project_root = Path(__file__).resolve().parents[1]
+    fixtures_file = workspace / "fixtures.json"
+    workflow_specs_file = workspace / "workflow-specs.json"
+    output_file = workspace / "master-guard-burnin-check.json"
+
+    workflow_specs_file.write_text(
+        json.dumps(
+            [
+                {
+                    "workflow_name": "Master Watchdog Rehearsal SLO Guard",
+                    "workflow_file": "master-watchdog-rehearsal-slo-guard.yml",
+                    "required_artifacts": ["master-watchdog-rehearsal-slo-guard"],
+                    "required_successful_runs": 1,
+                }
+            ],
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    fixtures_file.write_text(
+        json.dumps(
+            {
+                "workflow_runs": {
+                    "Master Watchdog Rehearsal SLO Guard": [
+                        {
+                            "id": 992001,
+                            "status": "completed",
+                            "conclusion": "success",
+                            "updated_at": "2026-04-28T08:00:00Z",
+                            "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/992001",
+                        },
+                        {
+                            "id": 992000,
+                            "status": "completed",
+                            "conclusion": "failure",
+                            "updated_at": "2026-04-27T08:00:00Z",
+                            "html_url": "https://github.com/donatomaurizio99-collab/GOC/actions/runs/992000",
+                        },
+                    ]
+                },
+                "run_artifacts": {
+                    "992001": {"artifacts": [{"name": "master-watchdog-rehearsal-slo-guard", "expired": False}]},
+                    "992000": {"artifacts": []},
+                },
+                "run_reports": {
+                    "992001": {
+                        "label": "pytest-watchdog-slo-run-992001",
+                        "metrics": {"mttr_seconds": 120.0, "mttr_target_seconds": 300.0},
+                        "decision": {"watchdog_rehearsal_slo_breached": False, "breach_reason": "none"},
+                    }
+                },
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(project_root / "scripts" / "master-guard-burnin-check.py"),
+        "--label",
+        "pytest-master-guard-burnin-ignore-failed-missing",
+        "--repo",
+        "donatomaurizio99-collab/GOC",
+        "--branch",
+        "master",
+        "--fixtures-file",
+        str(fixtures_file.resolve()),
+        "--workflow-specs-file",
+        str(workflow_specs_file.resolve()),
+        "--required-successful-runs",
+        "1",
+        "--burnin-window-days",
+        "14",
+        "--mttr-target-seconds",
+        "300",
+        "--watchdog-slo-workflow-name",
+        "Master Watchdog Rehearsal SLO Guard",
+        "--watchdog-slo-artifact-name",
+        "master-watchdog-rehearsal-slo-guard",
+        "--watchdog-slo-report-filename",
+        "master-watchdog-rehearsal-slo-guard.json",
+        "--now-utc",
+        "2026-04-29T00:00:00Z",
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads([line.strip() for line in completed.stdout.splitlines() if line.strip()][-1])
+    assert payload["success"] is True
+    assert payload["decision"]["hard_exit_criteria_met"] is True
+    assert payload["burnin_window"]["current_window"]["missing_artifacts"]["total"] == 0
+    assert payload["burnin_window"]["current_window"]["missing_artifacts"]["non_success_runs"]["total"] == 1
 
     shutil.rmtree(workspace, ignore_errors=True)
 


### PR DESCRIPTION
﻿## Summary
- add legacy MTTR evidence fallback in watchdog SLO guard: when `metrics.alert_chain_mttr_seconds` is absent, use `duration_ms` fallback (`duration_ms_fallback`) instead of hard-failing with `mttr_report_unavailable`
- keep MTTR source machine-readable via `metrics.mttr_value_source` and `drill_report.mttr_value_source`
- make burn-in missing-artifact hard-exit accounting stability-first: count missing artifacts from successful runs for the hard criterion, and report non-success-run missing artifacts separately in `missing_artifacts.non_success_runs`
- add regression tests for both paths

## Validation
- `python -m py_compile scripts/master-watchdog-rehearsal-slo-guard.py scripts/master-guard-burnin-check.py tests/test_goal_ops.py`
- `python -m pytest -q tests/test_goal_ops.py::test_248c_master_watchdog_rehearsal_slo_guard_detects_mttr_breach_from_drill_report_file tests/test_goal_ops.py::test_248d_master_watchdog_rehearsal_slo_guard_uses_duration_ms_fallback_for_legacy_drill_report tests/test_goal_ops.py::test_257b_master_guard_burnin_check_reports_hard_exit_criteria_and_window_trend tests/test_goal_ops.py::test_257c_master_guard_burnin_check_ignores_non_success_missing_artifacts_in_hard_exit_count`
- `python -m pytest -q tests/test_goal_ops.py::test_248_master_watchdog_rehearsal_slo_guard_detects_failed_breach`
- `python -m pytest -q tests/test_goal_ops.py::test_248b_master_watchdog_rehearsal_slo_guard_accepts_bom_runs_fixture`

## Risk
- low to medium: affects watchdog/burn-in evidence interpretation only; no silent policy target changes.
