### PR TITLE
[codex] Add supervised planner preview

### DIFF
--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -70,6 +70,20 @@ class GoalCreateRequest(BaseModel):
     deadline_score: float = Field(default=0.0, ge=0.0, le=1.0)
 
 
+class PlannerTaskSuggestion(BaseModel):
+    title: str
+    description: str
+    priority_hint: str
+    source: str
+
+
+class PlannerPreviewResponse(BaseModel):
+    goal_id: str
+    goal_title: str
+    source: str
+    suggestions: list[PlannerTaskSuggestion]
+
+
 class TaskCreateRequest(BaseModel):
     goal_id: str
     title: str = Field(min_length=1, max_length=200)

--- a/goal_ops_console/planner.py
+++ b/goal_ops_console/planner.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+class Planner:
+    source = "deterministic_planner"
+
+    def create_plan(self, goal: Mapping[str, Any]) -> dict[str, Any]:
+        title = _clean_text(goal.get("title"), fallback="Untitled goal")
+        description = _clean_text(goal.get("description"), fallback="")
+        urgency = _score(goal.get("urgency"))
+        value = _score(goal.get("value"))
+        deadline_score = _score(goal.get("deadline_score"))
+        priority_hint = _priority_hint(max(urgency, value, deadline_score))
+        context = description or f"Goal context is currently limited to the title: {title}."
+
+        suggestions = [
+            _suggestion(
+                title=f"Clarify success criteria for {title}",
+                description=(
+                    "Define the smallest observable outcome, owner expectation, and stop condition "
+                    f"before execution starts. Context: {context}"
+                ),
+                priority_hint=priority_hint,
+            ),
+            _suggestion(
+                title="Identify risks and dependencies",
+                description=(
+                    "List blockers, required inputs, and any approval points so the operator can keep "
+                    "the plan supervised and reversible."
+                ),
+                priority_hint=_priority_hint(max(urgency, deadline_score)),
+            ),
+            _suggestion(
+                title="Execute the first reversible task",
+                description=(
+                    "Choose the smallest implementation step that produces evidence without committing "
+                    "the whole goal to an irreversible path."
+                ),
+                priority_hint=_priority_hint(max(value, urgency)),
+            ),
+            _suggestion(
+                title="Validate impact and capture evidence",
+                description=(
+                    "Check the result against the success criteria, record evidence, and decide whether "
+                    "the goal should continue, pause, or escalate."
+                ),
+                priority_hint=_priority_hint(max(value, deadline_score)),
+            ),
+        ]
+        if urgency >= 0.75 or deadline_score >= 0.75:
+            suggestions.insert(
+                2,
+                _suggestion(
+                    title="Resolve time-critical constraints",
+                    description=(
+                        "Handle deadline-sensitive blockers first and confirm whether scope must be "
+                        "reduced to protect the goal outcome."
+                    ),
+                    priority_hint="high",
+                ),
+            )
+
+        return {
+            "goal_id": _clean_text(goal.get("goal_id"), fallback=""),
+            "goal_title": title,
+            "source": self.source,
+            "suggestions": suggestions[:5],
+        }
+
+
+def _suggestion(*, title: str, description: str, priority_hint: str) -> dict[str, str]:
+    return {
+        "title": title,
+        "description": description,
+        "priority_hint": priority_hint,
+        "source": Planner.source,
+    }
+
+
+def _clean_text(value: object, *, fallback: str) -> str:
+    cleaned = str(value or "").strip()
+    return cleaned or fallback
+
+
+def _score(value: object) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return min(1.0, max(0.0, parsed))
+
+
+def _priority_hint(score: float) -> str:
+    if score >= 0.75:
+        return "high"
+    if score >= 0.4:
+        return "medium"
+    return "low"

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends
 
-from goal_ops_console.models import GoalCreateRequest
+from goal_ops_console.models import GoalCreateRequest, PlannerPreviewResponse
 from goal_ops_console.services import AppServices, get_services
 
 router = APIRouter(prefix="/goals", tags=["goals"])
@@ -28,6 +28,12 @@ def create_goal(
 @router.get("/{goal_id}")
 def get_goal(goal_id: str, services: AppServices = Depends(get_services)) -> dict:
     return services.state_manager.get_goal(goal_id)
+
+
+@router.post("/{goal_id}/plan", response_model=PlannerPreviewResponse)
+def preview_goal_plan(goal_id: str, services: AppServices = Depends(get_services)) -> dict:
+    goal = services.state_manager.get_goal(goal_id)
+    return services.planner.create_plan(goal)
 
 
 @router.post("/{goal_id}/activate")

--- a/goal_ops_console/services.py
+++ b/goal_ops_console/services.py
@@ -9,10 +9,11 @@ from goal_ops_console.execution_layer import ExecutionLayer
 from goal_ops_console.failure_intelligence import FailureIntelligence
 from goal_ops_console.invariant_monitor import InvariantMonitor
 from goal_ops_console.observability import ObservabilityService
+from goal_ops_console.planner import Planner
 from goal_ops_console.runtime_guard import RuntimeGuard
 from goal_ops_console.scheduler import SchedulerService
 from goal_ops_console.state_manager import StateManager
-from goal_ops_console.stubs import PermissionManager, Planner, QdrantClientStub
+from goal_ops_console.stubs import PermissionManager, QdrantClientStub
 from goal_ops_console.workflow_catalog import WorkflowCatalog
 
 

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -33,6 +33,7 @@ const VISUAL_PRESETS = [
 ];
 
 let selectedGoalId = "";
+let plannerPreview = null;
 let defaultConsumerId = "goal_ops_console";
 let autoRefreshEnabled = true;
 let autoRefreshHandle = null;
@@ -491,7 +492,7 @@ function renderGoalButtons(goal) {
     archived: [["trace", "Trace"]],
   };
   const actions = actionsByState[goal.state] || [["trace", "Trace"]];
-  return actions.map(([action, label]) => {
+  const actionButtons = actions.map(([action, label]) => {
     if (action === "trace") {
       return `<button class="secondary" data-correlation="${goal.goal_id}">${label}</button>`;
     }
@@ -499,7 +500,43 @@ function renderGoalButtons(goal) {
       `<button class="secondary" data-mutation-control="true" data-goal-action="${action}" `
       + `data-goal-id="${goal.goal_id}">${label}</button>`
     );
-  }).join("");
+  });
+  actionButtons.push(
+    `<button class="secondary" data-plan-goal="${goal.goal_id}">Plan Preview</button>`,
+  );
+  return actionButtons.join("");
+}
+
+function renderPlannerPreview(preview) {
+  const container = document.getElementById("planner-preview");
+  if (!container) return;
+  if (!preview) {
+    container.innerHTML = `
+      <span class="meta">Planner Preview</span>
+      <p class="meta">Select a goal and use Plan Preview to generate deterministic task suggestions. Suggestions are read-only until you create tasks explicitly.</p>
+    `;
+    return;
+  }
+  const suggestions = preview.suggestions || [];
+  container.innerHTML = `
+    <span class="meta">Planner Preview · ${escapeHtml(preview.source)}</span>
+    <h3>${escapeHtml(preview.goal_title)}</h3>
+    <div class="meta">${escapeHtml(preview.goal_id)} · ${suggestions.length} suggested tasks · no tasks created automatically</div>
+    <div class="stack-list" style="margin-top:0.75rem;">
+      ${suggestions.map((item) => `
+        <article class="entity-card">
+          <div class="entity-header">
+            <div>
+              <div class="entity-title">${escapeHtml(item.title)}</div>
+              <div class="meta">${escapeHtml(item.source)}</div>
+            </div>
+            <span class="pill state-${escapeHtml(item.priority_hint)}">${escapeHtml(item.priority_hint)}</span>
+          </div>
+          <p class="meta">${escapeHtml(item.description)}</p>
+        </article>
+      `).join("")}
+    </div>
+  `;
 }
 
 function renderTaskButtons(task) {
@@ -561,6 +598,7 @@ function renderGoals(goals) {
       </div>`
     : `<div class="meta">${filteredEmptyMessage("No goals yet.")}</div>`;
   document.getElementById("goals-table").innerHTML = content;
+  renderPlannerPreview(plannerPreview);
   applyMutationControlState();
 }
 
@@ -1316,6 +1354,21 @@ async function runOperatorAction(action) {
   await refreshAll();
 }
 
+async function runPlannerPreview(goalId) {
+  if (!goalId) {
+    throw new Error("Select a goal before requesting a plan preview.");
+  }
+  const preview = await api(`/goals/${encodeURIComponent(goalId)}/plan`, { method: "POST" });
+  plannerPreview = preview;
+  selectedGoalId = goalId;
+  document.getElementById("task-goal-id").value = goalId;
+  document.getElementById("event-correlation-id").value = goalId;
+  document.getElementById("trace-goal-id").value = goalId;
+  document.getElementById("fault-goal-id").value = goalId;
+  renderPlannerPreview(plannerPreview);
+  updateSelectedGoalLabel();
+}
+
 function parseWorkflowPayload(text) {
   if (!text.trim()) {
     return {};
@@ -1676,6 +1729,7 @@ document.addEventListener("click", async (event) => {
   const workflowCancel = event.target.dataset.workflowCancel;
   const correlation = event.target.dataset.correlation;
   const selectGoal = event.target.dataset.selectGoal;
+  const planGoal = event.target.dataset.planGoal;
   const operatorAction = event.target.dataset.operatorAction;
   const jumpTarget = event.target.dataset.jumpTarget;
 
@@ -1711,6 +1765,11 @@ document.addEventListener("click", async (event) => {
       document.getElementById("trace-goal-id").value = goalId;
       document.getElementById("fault-goal-id").value = goalId;
       await refreshAll();
+    }
+
+    if (planGoal) {
+      await runPlannerPreview(planGoal);
+      setActiveJump("goals-section");
     }
 
     if (taskAction && taskId) {
@@ -1759,7 +1818,7 @@ document.addEventListener("click", async (event) => {
       ? "system-feedback"
       : workflowStart || workflowCancel
         ? "workflow-error"
-        : goalAction
+        : goalAction || planGoal
           ? "goal-error"
           : "task-error";
     showError(target, error);

--- a/goal_ops_console/stubs.py
+++ b/goal_ops_console/stubs.py
@@ -3,11 +3,6 @@ class QdrantClientStub:
         return []
 
 
-class Planner:
-    def create_plan(self, goal):
-        return {"steps": [], "stub": True, "goal_id": goal["goal_id"]}
-
-
 class PermissionManager:
     def check(self, category, key):
         return True

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -838,6 +838,10 @@
         <div class="error" id="goal-error" role="status" aria-live="polite"></div>
       </form>
       <div class="meta" id="selected-goal-label">No goal selected.</div>
+      <div id="planner-preview" class="card" aria-live="polite">
+        <span class="meta">Planner Preview</span>
+        <p class="meta">Select a goal and use Plan Preview to generate deterministic task suggestions. Suggestions are read-only until you create tasks explicitly.</p>
+      </div>
       <div id="goals-table"></div>
     </section>
 

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -15564,3 +15564,65 @@ def test_267_master_release_gate_runtime_slo_guard_workflow_wrapper_and_docs_wir
 
     assert "master-release-gate-runtime-slo-guard.yml" in readme
     assert "run-master-release-gate-runtime-slo-guard.ps1" in readme
+
+
+def test_268_goal_plan_preview_returns_deterministic_suggestions(client):
+    goal = client.post(
+        "/goals",
+        json={
+            "title": "Launch supervised planner",
+            "description": "Help operators preview safe next steps.",
+            "urgency": 0.8,
+            "value": 0.7,
+            "deadline_score": 0.6,
+        },
+    ).json()
+
+    first = client.post(f"/goals/{goal['goal_id']}/plan")
+    second = client.post(f"/goals/{goal['goal_id']}/plan")
+
+    assert first.status_code == 200
+    assert first.json() == second.json()
+    payload = first.json()
+    assert payload["goal_id"] == goal["goal_id"]
+    assert payload["goal_title"] == "Launch supervised planner"
+    assert payload["source"] == "deterministic_planner"
+    assert 3 <= len(payload["suggestions"]) <= 5
+
+
+def test_269_goal_plan_preview_suggestions_have_expected_fields(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Review release readiness", "urgency": 0.3, "value": 0.5, "deadline_score": 0.2},
+    ).json()
+
+    payload = client.post(f"/goals/{goal['goal_id']}/plan").json()
+
+    for suggestion in payload["suggestions"]:
+        assert set(suggestion) == {"title", "description", "priority_hint", "source"}
+        assert suggestion["title"]
+        assert suggestion["description"]
+        assert suggestion["priority_hint"] in {"low", "medium", "high"}
+        assert suggestion["source"] == "deterministic_planner"
+
+
+def test_270_goal_plan_preview_unknown_goal_returns_404(client):
+    response = client.post("/goals/missing-goal/plan")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Goal missing-goal not found"
+
+
+def test_271_goal_plan_preview_does_not_create_tasks(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Keep preview read only", "urgency": 0.6, "value": 0.4, "deadline_score": 0.1},
+    ).json()
+    before = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    response = client.post(f"/goals/{goal['goal_id']}/plan")
+    after = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    assert response.status_code == 200
+    assert before == []
+    assert after == []


### PR DESCRIPTION
﻿## Summary
- Add a deterministic `Planner` implementation that returns supervised task suggestions for an existing goal.
- Add `POST /goals/{goal_id}/plan` as a read-only planner preview endpoint.
- Add a dashboard Plan Preview action/panel without automatic task creation.
- Cover the preview behavior with API regression tests.

## Validation
- `python -m pytest tests/test_goal_ops.py -k "goal_plan_preview"` -> 4 passed
- `python -m pytest tests/test_goal_ops.py::test_82_workflow_soak_drill_reports_success` -> 1 passed after an initial full-suite timeout on that existing soak drill
- `python -m pytest` -> 308 passed

## Notes
- No external AI/Qdrant dependency is introduced.
- `artifacts/` remains untracked and out of scope.
