### PR TITLE
[codex] Add planner suggestion task API

### DIFF
--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -84,6 +84,17 @@ class PlannerPreviewResponse(BaseModel):
     suggestions: list[PlannerTaskSuggestion]
 
 
+class PlannerTaskCreateRequest(BaseModel):
+    suggestion_index: int = Field(ge=0)
+
+
+class PlannerTaskCreateResponse(BaseModel):
+    goal_id: str
+    suggestion_index: int
+    suggestion: PlannerTaskSuggestion
+    task: dict[str, Any]
+
+
 class TaskCreateRequest(BaseModel):
     goal_id: str
     title: str = Field(min_length=1, max_length=200)

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -1,6 +1,12 @@
 from fastapi import APIRouter, Depends
 
-from goal_ops_console.models import GoalCreateRequest, PlannerPreviewResponse
+from goal_ops_console.models import (
+    DomainError,
+    GoalCreateRequest,
+    PlannerPreviewResponse,
+    PlannerTaskCreateRequest,
+    PlannerTaskCreateResponse,
+)
 from goal_ops_console.services import AppServices, get_services
 
 router = APIRouter(prefix="/goals", tags=["goals"])
@@ -34,6 +40,29 @@ def get_goal(goal_id: str, services: AppServices = Depends(get_services)) -> dic
 def preview_goal_plan(goal_id: str, services: AppServices = Depends(get_services)) -> dict:
     goal = services.state_manager.get_goal(goal_id)
     return services.planner.create_plan(goal)
+
+
+@router.post("/{goal_id}/plan/tasks", status_code=201, response_model=PlannerTaskCreateResponse)
+def create_task_from_plan_suggestion(
+    goal_id: str,
+    request: PlannerTaskCreateRequest,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    goal = services.state_manager.get_goal(goal_id)
+    plan = services.planner.create_plan(goal)
+    suggestions = plan["suggestions"]
+    if request.suggestion_index >= len(suggestions):
+        raise DomainError(
+            f"Planner suggestion index {request.suggestion_index} not found for goal {goal_id}"
+        )
+    suggestion = suggestions[request.suggestion_index]
+    task = services.execution_layer.create_task(goal_id=goal_id, title=suggestion["title"])
+    return {
+        "goal_id": goal_id,
+        "suggestion_index": request.suggestion_index,
+        "suggestion": suggestion,
+        "task": task,
+    }
 
 
 @router.post("/{goal_id}/activate")

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -1373,26 +1373,25 @@ async function runPlannerPreview(goalId) {
   updateSelectedGoalLabel();
 }
 
-function getPlannerSuggestion(indexValue) {
-  const suggestions = Array.isArray(plannerPreview?.suggestions) ? plannerPreview.suggestions : [];
+function parsePlannerSuggestionIndex(indexValue) {
   const index = Number.parseInt(indexValue, 10);
+  const suggestions = Array.isArray(plannerPreview?.suggestions) ? plannerPreview.suggestions : [];
   if (!Number.isInteger(index) || index < 0 || index >= suggestions.length) {
     throw new Error("Planner suggestion is no longer available. Run Plan Preview again.");
   }
-  return suggestions[index];
+  return index;
 }
 
 async function createTaskFromPlannerSuggestion(indexValue) {
   if (!plannerPreview?.goal_id) {
     throw new Error("Run Plan Preview before creating a suggested task.");
   }
-  const suggestion = getPlannerSuggestion(indexValue);
+  const suggestionIndex = parsePlannerSuggestionIndex(indexValue);
   ensureMutationAllowed("Planner task creation");
-  await api("/tasks", {
+  await api(`/goals/${encodeURIComponent(plannerPreview.goal_id)}/plan/tasks`, {
     method: "POST",
     body: JSON.stringify({
-      goal_id: plannerPreview.goal_id,
-      title: suggestion.title,
+      suggestion_index: suggestionIndex,
     }),
   });
   selectedGoalId = plannerPreview.goal_id;

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -15628,7 +15628,7 @@ def test_271_goal_plan_preview_does_not_create_tasks(client):
     assert after == []
 
 
-def test_272_goal_plan_preview_suggestion_can_be_created_as_one_task(client):
+def test_272_goal_plan_preview_suggestion_endpoint_creates_one_task(client):
     goal = client.post(
         "/goals",
         json={"title": "Create one supervised task", "urgency": 0.7, "value": 0.7, "deadline_score": 0.3},
@@ -15637,15 +15637,37 @@ def test_272_goal_plan_preview_suggestion_can_be_created_as_one_task(client):
     selected = preview["suggestions"][0]
     other_titles = {suggestion["title"] for suggestion in preview["suggestions"][1:]}
 
-    response = client.post(
-        "/tasks",
-        json={"goal_id": goal["goal_id"], "title": selected["title"]},
-    )
+    response = client.post(f"/goals/{goal['goal_id']}/plan/tasks", json={"suggestion_index": 0})
     tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+    payload = response.json()
 
     assert response.status_code == 201
-    assert response.json()["title"] == selected["title"]
+    assert payload["goal_id"] == goal["goal_id"]
+    assert payload["suggestion_index"] == 0
+    assert payload["suggestion"] == selected
+    assert payload["task"]["title"] == selected["title"]
     assert len(tasks) == 1
     assert tasks[0]["goal_id"] == goal["goal_id"]
     assert tasks[0]["title"] == selected["title"]
     assert tasks[0]["title"] not in other_titles
+
+
+def test_273_goal_plan_task_create_unknown_goal_returns_404(client):
+    response = client.post("/goals/missing-goal/plan/tasks", json={"suggestion_index": 0})
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Goal missing-goal not found"
+
+
+def test_274_goal_plan_task_create_invalid_suggestion_index_returns_400(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Reject missing planner suggestion", "urgency": 0.2, "value": 0.2, "deadline_score": 0.2},
+    ).json()
+
+    response = client.post(f"/goals/{goal['goal_id']}/plan/tasks", json={"suggestion_index": 99})
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == f"Planner suggestion index 99 not found for goal {goal['goal_id']}"
+    assert tasks == []


### PR DESCRIPTION
﻿## Summary
- Add a dedicated `POST /goals/{goal_id}/plan/tasks` endpoint for supervised Planner Preview task creation.
- Recompute the deterministic plan server-side and create exactly the selected suggestion by index.
- Update the UI to use the Planner-specific endpoint instead of posting directly to generic task creation.
- Add API coverage for success, unknown goals, and invalid suggestion indexes.

## Validation
- `python -m pytest tests/test_goal_ops.py -q -k "goal_plan"`
- `python -m pytest`

## Notes
- Scope stays product-only and stability-first; no CI/guard workflow changes.
- `artifacts/` remains untracked and untouched.
