### PR TITLE
[codex] Prevent duplicate planner task creation

### DIFF
--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends
 
 from goal_ops_console.models import (
+    ConflictError,
     DomainError,
     GoalCreateRequest,
     PlannerPreviewResponse,
@@ -56,6 +57,18 @@ def create_task_from_plan_suggestion(
             f"Planner suggestion index {request.suggestion_index} not found for goal {goal_id}"
         )
     suggestion = suggestions[request.suggestion_index]
+    duplicate = next(
+        (
+            task
+            for task in services.execution_layer.list_tasks(goal_id=goal_id)
+            if task["title"] == suggestion["title"]
+        ),
+        None,
+    )
+    if duplicate is not None:
+        raise ConflictError(
+            f"Planner suggestion already exists as task {duplicate['task_id']} for goal {goal_id}"
+        )
     task = services.execution_layer.create_task(goal_id=goal_id, title=suggestion["title"])
     return {
         "goal_id": goal_id,

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -15671,3 +15671,40 @@ def test_274_goal_plan_task_create_invalid_suggestion_index_returns_400(client):
     assert response.status_code == 400
     assert response.json()["detail"] == f"Planner suggestion index 99 not found for goal {goal['goal_id']}"
     assert tasks == []
+
+
+def test_275_goal_plan_task_create_rejects_duplicate_suggestion(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Prevent duplicate planner task", "urgency": 0.7, "value": 0.6, "deadline_score": 0.2},
+    ).json()
+
+    first = client.post(f"/goals/{goal['goal_id']}/plan/tasks", json={"suggestion_index": 0})
+    second = client.post(f"/goals/{goal['goal_id']}/plan/tasks", json={"suggestion_index": 0})
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    assert first.status_code == 201
+    assert second.status_code == 409
+    assert "Planner suggestion already exists as task" in second.json()["detail"]
+    assert len(tasks) == 1
+    assert tasks[0]["title"] == first.json()["suggestion"]["title"]
+
+
+def test_276_goal_plan_task_create_allows_different_suggestion(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Allow separate planner tasks", "urgency": 0.7, "value": 0.6, "deadline_score": 0.2},
+    ).json()
+    preview = client.post(f"/goals/{goal['goal_id']}/plan").json()
+
+    first = client.post(f"/goals/{goal['goal_id']}/plan/tasks", json={"suggestion_index": 0})
+    second = client.post(f"/goals/{goal['goal_id']}/plan/tasks", json={"suggestion_index": 1})
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    assert len(tasks) == 2
+    assert {task["title"] for task in tasks} == {
+        preview["suggestions"][0]["title"],
+        preview["suggestions"][1]["title"],
+    }


### PR DESCRIPTION
﻿## Summary
- Prevent duplicate task creation from the same deterministic Planner Preview suggestion for a goal.
- Return `409 Conflict` when the selected suggestion title already exists as a task on that goal.
- Keep other Planner suggestions creatable so operators can still build the supervised task set intentionally.

## Validation
- `python -m pytest tests/test_goal_ops.py -q -k "goal_plan"`
- `python -m pytest`

## Notes
- Scope stays product-only and stability-first; no CI/guard workflow changes.
- `artifacts/` remains untracked and untouched.
