### PR TITLE
[codex] Add planner task provenance

### DIFF
--- a/goal_ops_console/database.py
+++ b/goal_ops_console/database.py
@@ -329,6 +329,19 @@ COMMIT;
 PRAGMA foreign_keys = ON;
 """,
     ),
+    (
+        2,
+        """
+BEGIN IMMEDIATE;
+ALTER TABLE tasks ADD COLUMN planner_source TEXT;
+ALTER TABLE tasks ADD COLUMN planner_suggestion_index INTEGER;
+ALTER TABLE tasks ADD COLUMN planner_priority_hint TEXT;
+ALTER TABLE tasks ADD COLUMN planner_suggestion_description TEXT;
+INSERT INTO schema_migrations (version, name, applied_at)
+VALUES (2, 'task_planner_provenance', datetime('now'));
+COMMIT;
+""",
+    ),
 )
 T = TypeVar("T")
 

--- a/goal_ops_console/execution_layer.py
+++ b/goal_ops_console/execution_layer.py
@@ -28,7 +28,16 @@ class ExecutionLayer:
         self.failure_intelligence = failure_intelligence
         self.observability = observability
 
-    def create_task(self, *, goal_id: str, title: str) -> dict[str, Any]:
+    def create_task(
+        self,
+        *,
+        goal_id: str,
+        title: str,
+        planner_source: str | None = None,
+        planner_suggestion_index: int | None = None,
+        planner_priority_hint: str | None = None,
+        planner_suggestion_description: str | None = None,
+    ) -> dict[str, Any]:
         goal = self.state_manager.get_goal(goal_id)
         if goal["state"] in {"archived", "cancelled"}:
             raise ConflictError(f"Goal {goal_id} cannot accept new tasks in state {goal['state']}")
@@ -36,12 +45,26 @@ class ExecutionLayer:
         task_id = new_id()
         timestamp = now_utc()
         correlation_id = f"{goal_id}:{task_id}:0"
+        event_payload: dict[str, Any] = {"goal_id": goal_id, "title": title}
+        if planner_source is not None:
+            event_payload["planner"] = {
+                "source": planner_source,
+                "suggestion_index": planner_suggestion_index,
+                "priority_hint": planner_priority_hint,
+            }
         with self.db.transaction() as tx:
             tx.execute(
-                "INSERT INTO tasks (task_id, goal_id, title, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+                "INSERT INTO tasks "
+                "(task_id, goal_id, title, planner_source, planner_suggestion_index, "
+                "planner_priority_hint, planner_suggestion_description, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 task_id,
                 goal_id,
                 title,
+                planner_source,
+                planner_suggestion_index,
+                planner_priority_hint,
+                planner_suggestion_description,
                 timestamp,
                 timestamp,
             )
@@ -59,7 +82,7 @@ class ExecutionLayer:
                 "task.created",
                 task_id,
                 correlation_id,
-                {"goal_id": goal_id, "title": title},
+                event_payload,
                 tx=tx,
             )
             self._metric("tasks.created", tx=tx)
@@ -75,6 +98,10 @@ class ExecutionLayer:
             f"""SELECT ts.task_id,
                        ts.goal_id,
                        t.title,
+                       t.planner_source,
+                       t.planner_suggestion_index,
+                       t.planner_priority_hint,
+                       t.planner_suggestion_description,
                        ts.correlation_id,
                        ts.status,
                        ts.retry_count,
@@ -96,6 +123,10 @@ class ExecutionLayer:
             """SELECT ts.task_id,
                       ts.goal_id,
                       t.title,
+                      t.planner_source,
+                      t.planner_suggestion_index,
+                      t.planner_priority_hint,
+                      t.planner_suggestion_description,
                       ts.correlation_id,
                       ts.status,
                       ts.retry_count,

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -69,7 +69,14 @@ def create_task_from_plan_suggestion(
         raise ConflictError(
             f"Planner suggestion already exists as task {duplicate['task_id']} for goal {goal_id}"
         )
-    task = services.execution_layer.create_task(goal_id=goal_id, title=suggestion["title"])
+    task = services.execution_layer.create_task(
+        goal_id=goal_id,
+        title=suggestion["title"],
+        planner_source=suggestion["source"],
+        planner_suggestion_index=request.suggestion_index,
+        planner_priority_hint=suggestion["priority_hint"],
+        planner_suggestion_description=suggestion["description"],
+    )
     return {
         "goal_id": goal_id,
         "suggestion_index": request.suggestion_index,

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -564,6 +564,23 @@ function renderTaskButtons(task) {
   return buttons.join("");
 }
 
+function renderTaskPlannerProvenance(task) {
+  if (!task.planner_source) {
+    return "";
+  }
+  const parts = [`Planner: ${escapeHtml(task.planner_source)}`];
+  if (task.planner_suggestion_index !== null && task.planner_suggestion_index !== undefined) {
+    const suggestionIndex = Number(task.planner_suggestion_index);
+    if (Number.isFinite(suggestionIndex)) {
+      parts.push(`suggestion #${suggestionIndex + 1}`);
+    }
+  }
+  if (task.planner_priority_hint) {
+    parts.push(`priority: ${escapeHtml(task.planner_priority_hint)}`);
+  }
+  return `<div class="meta">${parts.join(" &middot; ")}</div>`;
+}
+
 function renderGoals(goals) {
   const filteredGoals = filterRows(goals, (goal) => [
     goal.goal_id,
@@ -616,6 +633,10 @@ function renderTasks(tasks) {
     task.failure_type,
     task.error_hash,
     task.correlation_id,
+    task.planner_source,
+    task.planner_suggestion_index,
+    task.planner_priority_hint,
+    task.planner_suggestion_description,
   ]);
   if (!filteredTasks.length) {
     container.innerHTML = `<div class="meta">${filteredEmptyMessage("No tasks for the current selection.")}</div>`;
@@ -629,6 +650,7 @@ function renderTasks(tasks) {
           <div>
             <div class="entity-title">${task.title}</div>
             <div class="meta">${task.task_id}</div>
+            ${renderTaskPlannerProvenance(task)}
           </div>
           <span class="pill ${stateClass(task.status)}">${task.status}</span>
         </div>

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1175,6 +1175,22 @@ def test_53_schema_migrations_record_workflow_hardening(services):
     assert row["name"] == "workflow_runs_hardening"
 
 
+def test_53_task_planner_provenance_schema_migration(services):
+    row = services.db.fetch_one(
+        "SELECT version, name FROM schema_migrations WHERE version = 2"
+    )
+    columns = {column["name"] for column in services.db.fetch_all("PRAGMA table_info(tasks)")}
+
+    assert row is not None
+    assert row["name"] == "task_planner_provenance"
+    assert {
+        "planner_source",
+        "planner_suggestion_index",
+        "planner_priority_hint",
+        "planner_suggestion_description",
+    }.issubset(columns)
+
+
 def test_54_workflow_start_is_idempotent_with_idempotency_key(client):
     first = client.post(
         "/workflows/maintenance.retention_cleanup/start",
@@ -15646,10 +15662,18 @@ def test_272_goal_plan_preview_suggestion_endpoint_creates_one_task(client):
     assert payload["suggestion_index"] == 0
     assert payload["suggestion"] == selected
     assert payload["task"]["title"] == selected["title"]
+    assert payload["task"]["planner_source"] == selected["source"]
+    assert payload["task"]["planner_suggestion_index"] == 0
+    assert payload["task"]["planner_priority_hint"] == selected["priority_hint"]
+    assert payload["task"]["planner_suggestion_description"] == selected["description"]
     assert len(tasks) == 1
     assert tasks[0]["goal_id"] == goal["goal_id"]
     assert tasks[0]["title"] == selected["title"]
     assert tasks[0]["title"] not in other_titles
+    assert tasks[0]["planner_source"] == selected["source"]
+    assert tasks[0]["planner_suggestion_index"] == 0
+    assert tasks[0]["planner_priority_hint"] == selected["priority_hint"]
+    assert tasks[0]["planner_suggestion_description"] == selected["description"]
 
 
 def test_273_goal_plan_task_create_unknown_goal_returns_404(client):
@@ -15708,3 +15732,22 @@ def test_276_goal_plan_task_create_allows_different_suggestion(client):
         preview["suggestions"][0]["title"],
         preview["suggestions"][1]["title"],
     }
+
+
+def test_277_manual_task_create_has_no_planner_provenance(client):
+    goal = create_active_goal(client, "Manual task provenance")
+
+    response = client.post("/tasks", json={"goal_id": goal["goal_id"], "title": "Manual task"})
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+    task = response.json()
+
+    assert response.status_code == 201
+    assert task["planner_source"] is None
+    assert task["planner_suggestion_index"] is None
+    assert task["planner_priority_hint"] is None
+    assert task["planner_suggestion_description"] is None
+    assert len(tasks) == 1
+    assert tasks[0]["planner_source"] is None
+    assert tasks[0]["planner_suggestion_index"] is None
+    assert tasks[0]["planner_priority_hint"] is None
+    assert tasks[0]["planner_suggestion_description"] is None


### PR DESCRIPTION
﻿## Summary
- Persist planner provenance on tasks created from plan suggestions.
- Return provenance fields from task create/get/list APIs.
- Surface a compact Planner provenance line in the task UI while leaving manual tasks untagged.

## Validation
- `python -m pytest tests/test_goal_ops.py -q -k "schema_migrations or goal_plan or manual_task_create_has_no_planner_provenance"`
- `git diff --check`
- `python -m pytest`

## Notes
- No CI or guard workflow refactors.
- `artifacts/` remains untracked and untouched.
