### PR TITLE
[codex] Add duplicate-aware planner preview

### DIFF
--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -75,6 +75,8 @@ class PlannerTaskSuggestion(BaseModel):
     description: str
     priority_hint: str
     source: str
+    task_exists: bool = False
+    existing_task_id: str | None = None
 
 
 class PlannerPreviewResponse(BaseModel):

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -37,10 +37,23 @@ def get_goal(goal_id: str, services: AppServices = Depends(get_services)) -> dic
     return services.state_manager.get_goal(goal_id)
 
 
+def _preview_goal_plan(goal_id: str, services: AppServices) -> dict:
+    goal = services.state_manager.get_goal(goal_id)
+    plan = services.planner.create_plan(goal)
+    existing_by_title = {}
+    for task in services.execution_layer.list_tasks(goal_id=goal_id):
+        existing_by_title.setdefault(task["title"], task)
+
+    for suggestion in plan["suggestions"]:
+        existing = existing_by_title.get(suggestion["title"])
+        suggestion["task_exists"] = existing is not None
+        suggestion["existing_task_id"] = existing["task_id"] if existing is not None else None
+    return plan
+
+
 @router.post("/{goal_id}/plan", response_model=PlannerPreviewResponse)
 def preview_goal_plan(goal_id: str, services: AppServices = Depends(get_services)) -> dict:
-    goal = services.state_manager.get_goal(goal_id)
-    return services.planner.create_plan(goal)
+    return _preview_goal_plan(goal_id, services)
 
 
 @router.post("/{goal_id}/plan/tasks", status_code=201, response_model=PlannerTaskCreateResponse)
@@ -49,25 +62,16 @@ def create_task_from_plan_suggestion(
     request: PlannerTaskCreateRequest,
     services: AppServices = Depends(get_services),
 ) -> dict:
-    goal = services.state_manager.get_goal(goal_id)
-    plan = services.planner.create_plan(goal)
+    plan = _preview_goal_plan(goal_id, services)
     suggestions = plan["suggestions"]
     if request.suggestion_index >= len(suggestions):
         raise DomainError(
             f"Planner suggestion index {request.suggestion_index} not found for goal {goal_id}"
         )
     suggestion = suggestions[request.suggestion_index]
-    duplicate = next(
-        (
-            task
-            for task in services.execution_layer.list_tasks(goal_id=goal_id)
-            if task["title"] == suggestion["title"]
-        ),
-        None,
-    )
-    if duplicate is not None:
+    if suggestion["task_exists"]:
         raise ConflictError(
-            f"Planner suggestion already exists as task {duplicate['task_id']} for goal {goal_id}"
+            f"Planner suggestion already exists as task {suggestion['existing_task_id']} for goal {goal_id}"
         )
     task = services.execution_layer.create_task(
         goal_id=goal_id,

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -507,6 +507,24 @@ function renderGoalButtons(goal) {
   return actionButtons.join("");
 }
 
+function renderPlannerSuggestionStatus(item) {
+  if (!item.task_exists) {
+    return `<div class="meta">${escapeHtml(item.source)}</div>`;
+  }
+  const existingTask = item.existing_task_id ? ` as ${escapeHtml(item.existing_task_id)}` : "";
+  return `<div class="meta">${escapeHtml(item.source)} &middot; Already created${existingTask}</div>`;
+}
+
+function renderPlannerSuggestionAction(item, index) {
+  if (item.task_exists) {
+    return `<button type="button" class="secondary" disabled>Already created</button>`;
+  }
+  return (
+    `<button type="button" class="secondary" data-mutation-control="true" `
+    + `data-plan-suggestion-index="${index}">Create task</button>`
+  );
+}
+
 function renderPlannerPreview(preview) {
   const container = document.getElementById("planner-preview");
   if (!container) return;
@@ -528,13 +546,13 @@ function renderPlannerPreview(preview) {
           <div class="entity-header">
             <div>
               <div class="entity-title">${escapeHtml(item.title)}</div>
-              <div class="meta">${escapeHtml(item.source)}</div>
+              ${renderPlannerSuggestionStatus(item)}
             </div>
             <span class="pill state-${escapeHtml(item.priority_hint)}">${escapeHtml(item.priority_hint)}</span>
           </div>
           <p class="meta">${escapeHtml(item.description)}</p>
           <div class="actions">
-            <button type="button" class="secondary" data-mutation-control="true" data-plan-suggestion-index="${index}">Create task</button>
+            ${renderPlannerSuggestionAction(item, index)}
           </div>
         </article>
       `).join("")}
@@ -1409,19 +1427,21 @@ async function createTaskFromPlannerSuggestion(indexValue) {
     throw new Error("Run Plan Preview before creating a suggested task.");
   }
   const suggestionIndex = parsePlannerSuggestionIndex(indexValue);
+  const goalId = plannerPreview.goal_id;
   ensureMutationAllowed("Planner task creation");
-  await api(`/goals/${encodeURIComponent(plannerPreview.goal_id)}/plan/tasks`, {
+  await api(`/goals/${encodeURIComponent(goalId)}/plan/tasks`, {
     method: "POST",
     body: JSON.stringify({
       suggestion_index: suggestionIndex,
     }),
   });
-  selectedGoalId = plannerPreview.goal_id;
-  document.getElementById("task-goal-id").value = plannerPreview.goal_id;
-  document.getElementById("event-correlation-id").value = plannerPreview.goal_id;
-  document.getElementById("trace-goal-id").value = plannerPreview.goal_id;
-  document.getElementById("fault-goal-id").value = plannerPreview.goal_id;
+  selectedGoalId = goalId;
+  document.getElementById("task-goal-id").value = goalId;
+  document.getElementById("event-correlation-id").value = goalId;
+  document.getElementById("trace-goal-id").value = goalId;
+  document.getElementById("fault-goal-id").value = goalId;
   await refreshAll();
+  await runPlannerPreview(goalId);
   setActiveJump("tasks-section");
 }
 

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -15604,6 +15604,8 @@ def test_268_goal_plan_preview_returns_deterministic_suggestions(client):
     assert payload["goal_title"] == "Launch supervised planner"
     assert payload["source"] == "deterministic_planner"
     assert 3 <= len(payload["suggestions"]) <= 5
+    assert all(suggestion["task_exists"] is False for suggestion in payload["suggestions"])
+    assert all(suggestion["existing_task_id"] is None for suggestion in payload["suggestions"])
 
 
 def test_269_goal_plan_preview_suggestions_have_expected_fields(client):
@@ -15615,11 +15617,20 @@ def test_269_goal_plan_preview_suggestions_have_expected_fields(client):
     payload = client.post(f"/goals/{goal['goal_id']}/plan").json()
 
     for suggestion in payload["suggestions"]:
-        assert set(suggestion) == {"title", "description", "priority_hint", "source"}
+        assert set(suggestion) == {
+            "title",
+            "description",
+            "priority_hint",
+            "source",
+            "task_exists",
+            "existing_task_id",
+        }
         assert suggestion["title"]
         assert suggestion["description"]
         assert suggestion["priority_hint"] in {"low", "medium", "high"}
         assert suggestion["source"] == "deterministic_planner"
+        assert suggestion["task_exists"] is False
+        assert suggestion["existing_task_id"] is None
 
 
 def test_270_goal_plan_preview_unknown_goal_returns_404(client):
@@ -15642,6 +15653,8 @@ def test_271_goal_plan_preview_does_not_create_tasks(client):
     assert response.status_code == 200
     assert before == []
     assert after == []
+    assert all(suggestion["task_exists"] is False for suggestion in response.json()["suggestions"])
+    assert all(suggestion["existing_task_id"] is None for suggestion in response.json()["suggestions"])
 
 
 def test_272_goal_plan_preview_suggestion_endpoint_creates_one_task(client):
@@ -15661,6 +15674,8 @@ def test_272_goal_plan_preview_suggestion_endpoint_creates_one_task(client):
     assert payload["goal_id"] == goal["goal_id"]
     assert payload["suggestion_index"] == 0
     assert payload["suggestion"] == selected
+    assert payload["suggestion"]["task_exists"] is False
+    assert payload["suggestion"]["existing_task_id"] is None
     assert payload["task"]["title"] == selected["title"]
     assert payload["task"]["planner_source"] == selected["source"]
     assert payload["task"]["planner_suggestion_index"] == 0
@@ -15674,6 +15689,24 @@ def test_272_goal_plan_preview_suggestion_endpoint_creates_one_task(client):
     assert tasks[0]["planner_suggestion_index"] == 0
     assert tasks[0]["planner_priority_hint"] == selected["priority_hint"]
     assert tasks[0]["planner_suggestion_description"] == selected["description"]
+
+
+def test_272b_goal_plan_preview_marks_existing_suggestion_after_task_create(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Mark planner duplicate", "urgency": 0.7, "value": 0.6, "deadline_score": 0.2},
+    ).json()
+    before = client.post(f"/goals/{goal['goal_id']}/plan").json()
+
+    created = client.post(f"/goals/{goal['goal_id']}/plan/tasks", json={"suggestion_index": 0}).json()
+    after = client.post(f"/goals/{goal['goal_id']}/plan").json()
+
+    assert before["suggestions"][0]["task_exists"] is False
+    assert before["suggestions"][0]["existing_task_id"] is None
+    assert after["suggestions"][0]["task_exists"] is True
+    assert after["suggestions"][0]["existing_task_id"] == created["task"]["task_id"]
+    assert after["suggestions"][1]["task_exists"] is False
+    assert after["suggestions"][1]["existing_task_id"] is None
 
 
 def test_273_goal_plan_task_create_unknown_goal_returns_404(client):


### PR DESCRIPTION
﻿## Summary
- Annotate planner suggestions with duplicate status based on existing task titles.
- Return `task_exists` and `existing_task_id` in plan preview responses.
- Disable already-created planner suggestions in the UI and refresh the preview after task creation.

## Validation
- `python -m pytest tests/test_goal_ops.py -q -k "goal_plan"`
- `git diff --check`
- `python -m pytest`

## Notes
- No CI or guard workflow changes.
- `artifacts/` remains untracked and untouched.
