### PR TITLE
[codex] Add bulk supervised planner task creation

### DIFF
--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -90,11 +90,22 @@ class PlannerTaskCreateRequest(BaseModel):
     suggestion_index: int = Field(ge=0)
 
 
+class PlannerBulkTaskCreateRequest(BaseModel):
+    suggestion_indexes: list[int] = Field(min_length=1, max_length=5)
+
+
 class PlannerTaskCreateResponse(BaseModel):
     goal_id: str
     suggestion_index: int
     suggestion: PlannerTaskSuggestion
     task: dict[str, Any]
+
+
+class PlannerBulkTaskCreateResponse(BaseModel):
+    goal_id: str
+    requested_suggestion_indexes: list[int]
+    created: list[dict[str, Any]]
+    skipped_duplicates: list[dict[str, Any]]
 
 
 class TaskCreateRequest(BaseModel):

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -4,6 +4,8 @@ from goal_ops_console.models import (
     ConflictError,
     DomainError,
     GoalCreateRequest,
+    PlannerBulkTaskCreateRequest,
+    PlannerBulkTaskCreateResponse,
     PlannerPreviewResponse,
     PlannerTaskCreateRequest,
     PlannerTaskCreateResponse,
@@ -51,6 +53,29 @@ def _preview_goal_plan(goal_id: str, services: AppServices) -> dict:
     return plan
 
 
+def _get_plan_suggestion(plan: dict, suggestion_index: int, goal_id: str) -> dict:
+    suggestions = plan["suggestions"]
+    if suggestion_index < 0 or suggestion_index >= len(suggestions):
+        raise DomainError(f"Planner suggestion index {suggestion_index} not found for goal {goal_id}")
+    return suggestions[suggestion_index]
+
+
+def _create_task_from_suggestion(
+    goal_id: str,
+    suggestion_index: int,
+    suggestion: dict,
+    services: AppServices,
+) -> dict:
+    return services.execution_layer.create_task(
+        goal_id=goal_id,
+        title=suggestion["title"],
+        planner_source=suggestion["source"],
+        planner_suggestion_index=suggestion_index,
+        planner_priority_hint=suggestion["priority_hint"],
+        planner_suggestion_description=suggestion["description"],
+    )
+
+
 @router.post("/{goal_id}/plan", response_model=PlannerPreviewResponse)
 def preview_goal_plan(goal_id: str, services: AppServices = Depends(get_services)) -> dict:
     return _preview_goal_plan(goal_id, services)
@@ -63,29 +88,69 @@ def create_task_from_plan_suggestion(
     services: AppServices = Depends(get_services),
 ) -> dict:
     plan = _preview_goal_plan(goal_id, services)
-    suggestions = plan["suggestions"]
-    if request.suggestion_index >= len(suggestions):
-        raise DomainError(
-            f"Planner suggestion index {request.suggestion_index} not found for goal {goal_id}"
-        )
-    suggestion = suggestions[request.suggestion_index]
+    suggestion = _get_plan_suggestion(plan, request.suggestion_index, goal_id)
     if suggestion["task_exists"]:
         raise ConflictError(
             f"Planner suggestion already exists as task {suggestion['existing_task_id']} for goal {goal_id}"
         )
-    task = services.execution_layer.create_task(
-        goal_id=goal_id,
-        title=suggestion["title"],
-        planner_source=suggestion["source"],
-        planner_suggestion_index=request.suggestion_index,
-        planner_priority_hint=suggestion["priority_hint"],
-        planner_suggestion_description=suggestion["description"],
-    )
+    task = _create_task_from_suggestion(goal_id, request.suggestion_index, suggestion, services)
     return {
         "goal_id": goal_id,
         "suggestion_index": request.suggestion_index,
         "suggestion": suggestion,
         "task": task,
+    }
+
+
+@router.post("/{goal_id}/plan/tasks/bulk", status_code=201, response_model=PlannerBulkTaskCreateResponse)
+def create_tasks_from_plan_suggestions(
+    goal_id: str,
+    request: PlannerBulkTaskCreateRequest,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    plan = _preview_goal_plan(goal_id, services)
+    for suggestion_index in request.suggestion_indexes:
+        _get_plan_suggestion(plan, suggestion_index, goal_id)
+
+    created_by_title: dict[str, dict] = {}
+    created: list[dict] = []
+    skipped_duplicates: list[dict] = []
+
+    for suggestion_index in request.suggestion_indexes:
+        suggestion = _get_plan_suggestion(plan, suggestion_index, goal_id)
+        in_request_duplicate = created_by_title.get(suggestion["title"])
+        existing_task_id = suggestion["existing_task_id"] or (
+            in_request_duplicate["task"]["task_id"] if in_request_duplicate is not None else None
+        )
+        if suggestion["task_exists"] or existing_task_id is not None:
+            skipped_duplicates.append(
+                {
+                    "suggestion_index": suggestion_index,
+                    "suggestion": {
+                        **suggestion,
+                        "task_exists": True,
+                        "existing_task_id": existing_task_id,
+                    },
+                    "existing_task_id": existing_task_id,
+                    "reason": "already_exists",
+                }
+            )
+            continue
+
+        task = _create_task_from_suggestion(goal_id, suggestion_index, suggestion, services)
+        created_item = {
+            "suggestion_index": suggestion_index,
+            "suggestion": suggestion,
+            "task": task,
+        }
+        created.append(created_item)
+        created_by_title[suggestion["title"]] = created_item
+
+    return {
+        "goal_id": goal_id,
+        "requested_suggestion_indexes": request.suggestion_indexes,
+        "created": created,
+        "skipped_duplicates": skipped_duplicates,
     }
 
 

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -525,6 +525,16 @@ function renderPlannerSuggestionAction(item, index) {
   );
 }
 
+function renderPlannerSuggestionSelection(item, index) {
+  if (item.task_exists) {
+    return "";
+  }
+  return (
+    `<label class="meta"><input type="checkbox" data-plan-select-index="${index}"> `
+    + "Select for bulk create</label>"
+  );
+}
+
 function renderPlannerPreview(preview) {
   const container = document.getElementById("planner-preview");
   if (!container) return;
@@ -536,10 +546,15 @@ function renderPlannerPreview(preview) {
     return;
   }
   const suggestions = preview.suggestions || [];
+  const selectableCount = suggestions.filter((item) => !item.task_exists).length;
   container.innerHTML = `
     <span class="meta">Planner Preview · ${escapeHtml(preview.source)}</span>
     <h3>${escapeHtml(preview.goal_title)}</h3>
     <div class="meta">${escapeHtml(preview.goal_id)} · ${suggestions.length} suggested tasks · no tasks created automatically</div>
+    <div class="actions" style="margin-top:0.75rem;">
+      <button type="button" class="secondary" data-mutation-control="true" data-plan-bulk-create="true" ${selectableCount ? "" : "disabled"}>Create selected tasks</button>
+      <span class="meta">${selectableCount} selectable suggestions</span>
+    </div>
     <div class="stack-list" style="margin-top:0.75rem;">
       ${suggestions.map((item, index) => `
         <article class="entity-card">
@@ -551,6 +566,7 @@ function renderPlannerPreview(preview) {
             <span class="pill state-${escapeHtml(item.priority_hint)}">${escapeHtml(item.priority_hint)}</span>
           </div>
           <p class="meta">${escapeHtml(item.description)}</p>
+          ${renderPlannerSuggestionSelection(item, index)}
           <div class="actions">
             ${renderPlannerSuggestionAction(item, index)}
           </div>
@@ -1422,6 +1438,11 @@ function parsePlannerSuggestionIndex(indexValue) {
   return index;
 }
 
+function selectedPlannerSuggestionIndexes() {
+  return Array.from(document.querySelectorAll("[data-plan-select-index]:checked"))
+    .map((input) => parsePlannerSuggestionIndex(input.dataset.planSelectIndex));
+}
+
 async function createTaskFromPlannerSuggestion(indexValue) {
   if (!plannerPreview?.goal_id) {
     throw new Error("Run Plan Preview before creating a suggested task.");
@@ -1433,6 +1454,32 @@ async function createTaskFromPlannerSuggestion(indexValue) {
     method: "POST",
     body: JSON.stringify({
       suggestion_index: suggestionIndex,
+    }),
+  });
+  selectedGoalId = goalId;
+  document.getElementById("task-goal-id").value = goalId;
+  document.getElementById("event-correlation-id").value = goalId;
+  document.getElementById("trace-goal-id").value = goalId;
+  document.getElementById("fault-goal-id").value = goalId;
+  await refreshAll();
+  await runPlannerPreview(goalId);
+  setActiveJump("tasks-section");
+}
+
+async function createTasksFromSelectedPlannerSuggestions() {
+  if (!plannerPreview?.goal_id) {
+    throw new Error("Run Plan Preview before creating suggested tasks.");
+  }
+  const suggestionIndexes = selectedPlannerSuggestionIndexes();
+  if (!suggestionIndexes.length) {
+    throw new Error("Select at least one planner suggestion before bulk creation.");
+  }
+  const goalId = plannerPreview.goal_id;
+  ensureMutationAllowed("Bulk planner task creation");
+  await api(`/goals/${encodeURIComponent(goalId)}/plan/tasks/bulk`, {
+    method: "POST",
+    body: JSON.stringify({
+      suggestion_indexes: suggestionIndexes,
     }),
   });
   selectedGoalId = goalId;
@@ -1807,6 +1854,7 @@ document.addEventListener("click", async (event) => {
   const selectGoal = event.target.dataset.selectGoal;
   const planGoal = event.target.dataset.planGoal;
   const planSuggestionIndex = event.target.dataset.planSuggestionIndex;
+  const planBulkCreate = event.target.dataset.planBulkCreate;
   const operatorAction = event.target.dataset.operatorAction;
   const jumpTarget = event.target.dataset.jumpTarget;
 
@@ -1852,6 +1900,11 @@ document.addEventListener("click", async (event) => {
     if (planSuggestionIndex !== undefined) {
       showError("task-error", null);
       await createTaskFromPlannerSuggestion(planSuggestionIndex);
+    }
+
+    if (planBulkCreate) {
+      showError("task-error", null);
+      await createTasksFromSelectedPlannerSuggestions();
     }
 
     if (taskAction && taskId) {

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -15767,6 +15767,76 @@ def test_276_goal_plan_task_create_allows_different_suggestion(client):
     }
 
 
+def test_276b_goal_plan_bulk_task_create_creates_selected_suggestions(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Bulk create planner tasks", "urgency": 0.7, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    preview = client.post(f"/goals/{goal['goal_id']}/plan").json()
+
+    response = client.post(
+        f"/goals/{goal['goal_id']}/plan/tasks/bulk",
+        json={"suggestion_indexes": [0, 1]},
+    )
+    payload = response.json()
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+    after = client.post(f"/goals/{goal['goal_id']}/plan").json()
+
+    assert response.status_code == 201
+    assert payload["goal_id"] == goal["goal_id"]
+    assert payload["requested_suggestion_indexes"] == [0, 1]
+    assert payload["skipped_duplicates"] == []
+    assert [item["suggestion_index"] for item in payload["created"]] == [0, 1]
+    assert {item["task"]["title"] for item in payload["created"]} == {
+        preview["suggestions"][0]["title"],
+        preview["suggestions"][1]["title"],
+    }
+    assert len(tasks) == 2
+    assert {task["planner_suggestion_index"] for task in tasks} == {0, 1}
+    assert after["suggestions"][0]["task_exists"] is True
+    assert after["suggestions"][1]["task_exists"] is True
+
+
+def test_276c_goal_plan_bulk_task_create_skips_existing_duplicates(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Bulk skip duplicate planner task", "urgency": 0.7, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    existing = client.post(f"/goals/{goal['goal_id']}/plan/tasks", json={"suggestion_index": 0}).json()
+
+    response = client.post(
+        f"/goals/{goal['goal_id']}/plan/tasks/bulk",
+        json={"suggestion_indexes": [0, 1]},
+    )
+    payload = response.json()
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    assert response.status_code == 201
+    assert [item["suggestion_index"] for item in payload["created"]] == [1]
+    assert len(payload["skipped_duplicates"]) == 1
+    assert payload["skipped_duplicates"][0]["suggestion_index"] == 0
+    assert payload["skipped_duplicates"][0]["existing_task_id"] == existing["task"]["task_id"]
+    assert payload["skipped_duplicates"][0]["reason"] == "already_exists"
+    assert len(tasks) == 2
+
+
+def test_276d_goal_plan_bulk_task_create_invalid_index_does_not_create_tasks(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Bulk reject invalid planner index", "urgency": 0.4, "value": 0.4, "deadline_score": 0.2},
+    ).json()
+
+    response = client.post(
+        f"/goals/{goal['goal_id']}/plan/tasks/bulk",
+        json={"suggestion_indexes": [0, 99]},
+    )
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == f"Planner suggestion index 99 not found for goal {goal['goal_id']}"
+    assert tasks == []
+
+
 def test_277_manual_task_create_has_no_planner_provenance(client):
     goal = create_active_goal(client, "Manual task provenance")
 


### PR DESCRIPTION
﻿## Summary
- Add a supervised bulk planner task creation endpoint for selected suggestion indexes.
- Return created tasks and skipped duplicate suggestions separately.
- Add planner-preview checkboxes and a Create selected tasks action that refreshes the preview after creation.

## Validation
- `python -m pytest tests/test_goal_ops.py -q -k "goal_plan"`
- `git diff --check`
- `python -m pytest`

## Notes
- No CI or guard workflow changes.
- `artifacts/` remains untracked and untouched.
