### PR TITLE
[codex] Add planner suggestion review overrides

### DIFF
--- a/goal_ops_console/database.py
+++ b/goal_ops_console/database.py
@@ -342,6 +342,16 @@ VALUES (2, 'task_planner_provenance', datetime('now'));
 COMMIT;
 """,
     ),
+    (
+        3,
+        """
+BEGIN IMMEDIATE;
+ALTER TABLE tasks ADD COLUMN planner_operator_overrides TEXT;
+INSERT INTO schema_migrations (version, name, applied_at)
+VALUES (3, 'task_planner_operator_overrides', datetime('now'));
+COMMIT;
+""",
+    ),
 )
 T = TypeVar("T")
 

--- a/goal_ops_console/execution_layer.py
+++ b/goal_ops_console/execution_layer.py
@@ -1,3 +1,4 @@
+import json
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -37,6 +38,7 @@ class ExecutionLayer:
         planner_suggestion_index: int | None = None,
         planner_priority_hint: str | None = None,
         planner_suggestion_description: str | None = None,
+        planner_operator_overrides: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         goal = self.state_manager.get_goal(goal_id)
         if goal["state"] in {"archived", "cancelled"}:
@@ -52,12 +54,20 @@ class ExecutionLayer:
                 "suggestion_index": planner_suggestion_index,
                 "priority_hint": planner_priority_hint,
             }
+            if planner_operator_overrides is not None:
+                event_payload["planner"]["operator_overrides"] = planner_operator_overrides
+        planner_operator_overrides_json = (
+            json.dumps(planner_operator_overrides, sort_keys=True)
+            if planner_operator_overrides is not None
+            else None
+        )
         with self.db.transaction() as tx:
             tx.execute(
                 "INSERT INTO tasks "
                 "(task_id, goal_id, title, planner_source, planner_suggestion_index, "
-                "planner_priority_hint, planner_suggestion_description, created_at, updated_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "planner_priority_hint, planner_suggestion_description, planner_operator_overrides, "
+                "created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 task_id,
                 goal_id,
                 title,
@@ -65,6 +75,7 @@ class ExecutionLayer:
                 planner_suggestion_index,
                 planner_priority_hint,
                 planner_suggestion_description,
+                planner_operator_overrides_json,
                 timestamp,
                 timestamp,
             )
@@ -102,6 +113,7 @@ class ExecutionLayer:
                        t.planner_suggestion_index,
                        t.planner_priority_hint,
                        t.planner_suggestion_description,
+                       t.planner_operator_overrides,
                        ts.correlation_id,
                        ts.status,
                        ts.retry_count,
@@ -116,7 +128,7 @@ class ExecutionLayer:
                 ORDER BY ts.created_at ASC""",
             *params,
         )
-        return [dict(row) for row in rows]
+        return [self._task_from_row(row) for row in rows]
 
     def get_task(self, task_id: str) -> dict[str, Any]:
         row = self.db.fetch_one(
@@ -127,6 +139,7 @@ class ExecutionLayer:
                       t.planner_suggestion_index,
                       t.planner_priority_hint,
                       t.planner_suggestion_description,
+                      t.planner_operator_overrides,
                       ts.correlation_id,
                       ts.status,
                       ts.retry_count,
@@ -142,7 +155,17 @@ class ExecutionLayer:
         )
         if row is None:
             raise NotFoundError(f"Task {task_id} not found")
-        return dict(row)
+        return self._task_from_row(row)
+
+    @staticmethod
+    def _task_from_row(row: Any) -> dict[str, Any]:
+        task = dict(row)
+        raw_overrides = task.get("planner_operator_overrides")
+        if isinstance(raw_overrides, str) and raw_overrides:
+            task["planner_operator_overrides"] = json.loads(raw_overrides)
+        else:
+            task["planner_operator_overrides"] = None
+        return task
 
     def simulate_success(self, task_id: str) -> dict[str, Any]:
         with self.db.transaction() as tx:

--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -86,18 +86,28 @@ class PlannerPreviewResponse(BaseModel):
     suggestions: list[PlannerTaskSuggestion]
 
 
+class PlannerTaskSuggestionOverride(BaseModel):
+    title: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = Field(default=None, max_length=1_000)
+    priority_hint: Literal["low", "medium", "high"] | None = None
+
+
 class PlannerTaskCreateRequest(BaseModel):
     suggestion_index: int = Field(ge=0)
+    override: PlannerTaskSuggestionOverride | None = None
 
 
 class PlannerBulkTaskCreateRequest(BaseModel):
     suggestion_indexes: list[int] = Field(min_length=1, max_length=5)
+    overrides: dict[int, PlannerTaskSuggestionOverride] = Field(default_factory=dict)
 
 
 class PlannerTaskCreateResponse(BaseModel):
     goal_id: str
     suggestion_index: int
     suggestion: PlannerTaskSuggestion
+    applied_suggestion: PlannerTaskSuggestion
+    operator_override: dict[str, Any] | None = None
     task: dict[str, Any]
 
 

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -9,6 +9,7 @@ from goal_ops_console.models import (
     PlannerPreviewResponse,
     PlannerTaskCreateRequest,
     PlannerTaskCreateResponse,
+    PlannerTaskSuggestionOverride,
 )
 from goal_ops_console.services import AppServices, get_services
 
@@ -42,15 +43,20 @@ def get_goal(goal_id: str, services: AppServices = Depends(get_services)) -> dic
 def _preview_goal_plan(goal_id: str, services: AppServices) -> dict:
     goal = services.state_manager.get_goal(goal_id)
     plan = services.planner.create_plan(goal)
-    existing_by_title = {}
-    for task in services.execution_layer.list_tasks(goal_id=goal_id):
-        existing_by_title.setdefault(task["title"], task)
+    existing_by_title = _existing_tasks_by_title(goal_id, services)
 
     for suggestion in plan["suggestions"]:
         existing = existing_by_title.get(suggestion["title"])
         suggestion["task_exists"] = existing is not None
         suggestion["existing_task_id"] = existing["task_id"] if existing is not None else None
     return plan
+
+
+def _existing_tasks_by_title(goal_id: str, services: AppServices) -> dict[str, dict]:
+    existing_by_title = {}
+    for task in services.execution_layer.list_tasks(goal_id=goal_id):
+        existing_by_title.setdefault(task["title"], task)
+    return existing_by_title
 
 
 def _get_plan_suggestion(plan: dict, suggestion_index: int, goal_id: str) -> dict:
@@ -60,19 +66,40 @@ def _get_plan_suggestion(plan: dict, suggestion_index: int, goal_id: str) -> dic
     return suggestions[suggestion_index]
 
 
+def _override_to_dict(override: PlannerTaskSuggestionOverride | None) -> dict | None:
+    if override is None:
+        return None
+    values = override.model_dump(exclude_none=True)
+    return values or None
+
+
+def _apply_suggestion_override(suggestion: dict, override: PlannerTaskSuggestionOverride | None) -> tuple[dict, dict | None]:
+    override_values = _override_to_dict(override)
+    if override_values is None:
+        return dict(suggestion), None
+    applied_suggestion = {**suggestion, **override_values}
+    if "title" in override_values:
+        applied_suggestion["task_exists"] = False
+        applied_suggestion["existing_task_id"] = None
+    return applied_suggestion, override_values
+
+
 def _create_task_from_suggestion(
     goal_id: str,
     suggestion_index: int,
-    suggestion: dict,
+    original_suggestion: dict,
+    applied_suggestion: dict,
     services: AppServices,
+    operator_override: dict | None = None,
 ) -> dict:
     return services.execution_layer.create_task(
         goal_id=goal_id,
-        title=suggestion["title"],
-        planner_source=suggestion["source"],
+        title=applied_suggestion["title"],
+        planner_source=original_suggestion["source"],
         planner_suggestion_index=suggestion_index,
-        planner_priority_hint=suggestion["priority_hint"],
-        planner_suggestion_description=suggestion["description"],
+        planner_priority_hint=original_suggestion["priority_hint"],
+        planner_suggestion_description=original_suggestion["description"],
+        planner_operator_overrides=operator_override,
     )
 
 
@@ -89,15 +116,27 @@ def create_task_from_plan_suggestion(
 ) -> dict:
     plan = _preview_goal_plan(goal_id, services)
     suggestion = _get_plan_suggestion(plan, request.suggestion_index, goal_id)
-    if suggestion["task_exists"]:
+    applied_suggestion, operator_override = _apply_suggestion_override(suggestion, request.override)
+    existing_by_title = _existing_tasks_by_title(goal_id, services)
+    existing = existing_by_title.get(applied_suggestion["title"])
+    if existing is not None:
         raise ConflictError(
-            f"Planner suggestion already exists as task {suggestion['existing_task_id']} for goal {goal_id}"
+            f"Planner suggestion already exists as task {existing['task_id']} for goal {goal_id}"
         )
-    task = _create_task_from_suggestion(goal_id, request.suggestion_index, suggestion, services)
+    task = _create_task_from_suggestion(
+        goal_id,
+        request.suggestion_index,
+        suggestion,
+        applied_suggestion,
+        services,
+        operator_override,
+    )
     return {
         "goal_id": goal_id,
         "suggestion_index": request.suggestion_index,
         "suggestion": suggestion,
+        "applied_suggestion": applied_suggestion,
+        "operator_override": operator_override,
         "task": task,
     }
 
@@ -111,40 +150,76 @@ def create_tasks_from_plan_suggestions(
     plan = _preview_goal_plan(goal_id, services)
     for suggestion_index in request.suggestion_indexes:
         _get_plan_suggestion(plan, suggestion_index, goal_id)
+    requested_indexes = set(request.suggestion_indexes)
+    for override_index in request.overrides:
+        if override_index not in requested_indexes:
+            raise DomainError(f"Planner override index {override_index} was not requested for goal {goal_id}")
 
+    resolved_suggestions = []
+    for suggestion_index in request.suggestion_indexes:
+        suggestion = _get_plan_suggestion(plan, suggestion_index, goal_id)
+        applied_suggestion, operator_override = _apply_suggestion_override(
+            suggestion,
+            request.overrides.get(suggestion_index),
+        )
+        resolved_suggestions.append(
+            {
+                "suggestion_index": suggestion_index,
+                "suggestion": suggestion,
+                "applied_suggestion": applied_suggestion,
+                "operator_override": operator_override,
+            }
+        )
+
+    existing_by_title = _existing_tasks_by_title(goal_id, services)
     created_by_title: dict[str, dict] = {}
     created: list[dict] = []
     skipped_duplicates: list[dict] = []
 
-    for suggestion_index in request.suggestion_indexes:
-        suggestion = _get_plan_suggestion(plan, suggestion_index, goal_id)
-        in_request_duplicate = created_by_title.get(suggestion["title"])
-        existing_task_id = suggestion["existing_task_id"] or (
+    for item in resolved_suggestions:
+        suggestion_index = item["suggestion_index"]
+        suggestion = item["suggestion"]
+        applied_suggestion = item["applied_suggestion"]
+        operator_override = item["operator_override"]
+        existing = existing_by_title.get(applied_suggestion["title"])
+        in_request_duplicate = created_by_title.get(applied_suggestion["title"])
+        existing_task_id = (existing["task_id"] if existing is not None else None) or (
             in_request_duplicate["task"]["task_id"] if in_request_duplicate is not None else None
         )
-        if suggestion["task_exists"] or existing_task_id is not None:
+        if existing_task_id is not None:
             skipped_duplicates.append(
                 {
                     "suggestion_index": suggestion_index,
-                    "suggestion": {
-                        **suggestion,
+                    "suggestion": suggestion,
+                    "applied_suggestion": {
+                        **applied_suggestion,
                         "task_exists": True,
                         "existing_task_id": existing_task_id,
                     },
+                    "operator_override": operator_override,
                     "existing_task_id": existing_task_id,
                     "reason": "already_exists",
                 }
             )
             continue
 
-        task = _create_task_from_suggestion(goal_id, suggestion_index, suggestion, services)
+        task = _create_task_from_suggestion(
+            goal_id,
+            suggestion_index,
+            suggestion,
+            applied_suggestion,
+            services,
+            operator_override,
+        )
         created_item = {
             "suggestion_index": suggestion_index,
             "suggestion": suggestion,
+            "applied_suggestion": applied_suggestion,
+            "operator_override": operator_override,
             "task": task,
         }
         created.append(created_item)
-        created_by_title[suggestion["title"]] = created_item
+        created_by_title[applied_suggestion["title"]] = created_item
 
     return {
         "goal_id": goal_id,

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -535,6 +535,32 @@ function renderPlannerSuggestionSelection(item, index) {
   );
 }
 
+function renderPlannerSuggestionEditor(item, index) {
+  if (item.task_exists) {
+    return "";
+  }
+  return `
+    <div class="entity-grid" style="margin-top:0.75rem;">
+      <label class="entity-metric">
+        <span class="meta">Review title</span>
+        <input type="text" data-plan-title-index="${index}" value="${escapeHtml(item.title)}">
+      </label>
+      <label class="entity-metric">
+        <span class="meta">Review priority</span>
+        <select data-plan-priority-index="${index}">
+          ${["low", "medium", "high"].map((priority) => (
+            `<option value="${priority}" ${priority === item.priority_hint ? "selected" : ""}>${priority}</option>`
+          )).join("")}
+        </select>
+      </label>
+    </div>
+    <label class="meta" style="display:block;margin-top:0.75rem;">
+      Review description
+      <textarea data-plan-description-index="${index}" rows="3">${escapeHtml(item.description)}</textarea>
+    </label>
+  `;
+}
+
 function renderPlannerPreview(preview) {
   const container = document.getElementById("planner-preview");
   if (!container) return;
@@ -566,6 +592,7 @@ function renderPlannerPreview(preview) {
             <span class="pill state-${escapeHtml(item.priority_hint)}">${escapeHtml(item.priority_hint)}</span>
           </div>
           <p class="meta">${escapeHtml(item.description)}</p>
+          ${renderPlannerSuggestionEditor(item, index)}
           ${renderPlannerSuggestionSelection(item, index)}
           <div class="actions">
             ${renderPlannerSuggestionAction(item, index)}
@@ -611,6 +638,12 @@ function renderTaskPlannerProvenance(task) {
   }
   if (task.planner_priority_hint) {
     parts.push(`priority: ${escapeHtml(task.planner_priority_hint)}`);
+  }
+  if (task.planner_operator_overrides && typeof task.planner_operator_overrides === "object") {
+    const editedFields = Object.keys(task.planner_operator_overrides).sort();
+    if (editedFields.length) {
+      parts.push(`operator edits: ${escapeHtml(editedFields.join(", "))}`);
+    }
   }
   return `<div class="meta">${parts.join(" &middot; ")}</div>`;
 }
@@ -1443,19 +1476,57 @@ function selectedPlannerSuggestionIndexes() {
     .map((input) => parsePlannerSuggestionIndex(input.dataset.planSelectIndex));
 }
 
+function collectPlannerSuggestionOverride(index) {
+  const suggestion = plannerPreview?.suggestions?.[index];
+  if (!suggestion) {
+    throw new Error("Planner suggestion is no longer available. Run Plan Preview again.");
+  }
+
+  const title = document.querySelector(`[data-plan-title-index="${index}"]`)?.value.trim() || "";
+  const description = document.querySelector(`[data-plan-description-index="${index}"]`)?.value.trim() || "";
+  const priorityHint = document.querySelector(`[data-plan-priority-index="${index}"]`)?.value || "";
+  const override = {};
+  if (title !== suggestion.title) {
+    override.title = title;
+  }
+  if (description !== suggestion.description) {
+    override.description = description;
+  }
+  if (priorityHint !== suggestion.priority_hint) {
+    override.priority_hint = priorityHint;
+  }
+  return Object.keys(override).length ? override : null;
+}
+
+function collectPlannerSuggestionOverrides(indexes) {
+  return indexes.reduce((overrides, index) => {
+    const override = collectPlannerSuggestionOverride(index);
+    if (override) {
+      overrides[index] = override;
+    }
+    return overrides;
+  }, {});
+}
+
 async function createTaskFromPlannerSuggestion(indexValue) {
   if (!plannerPreview?.goal_id) {
     throw new Error("Run Plan Preview before creating a suggested task.");
   }
   const suggestionIndex = parsePlannerSuggestionIndex(indexValue);
   const goalId = plannerPreview.goal_id;
+  const override = collectPlannerSuggestionOverride(suggestionIndex);
   ensureMutationAllowed("Planner task creation");
-  await api(`/goals/${encodeURIComponent(goalId)}/plan/tasks`, {
+  const response = await api(`/goals/${encodeURIComponent(goalId)}/plan/tasks`, {
     method: "POST",
     body: JSON.stringify({
       suggestion_index: suggestionIndex,
+      ...(override ? { override } : {}),
     }),
   });
+  document.getElementById("system-feedback").textContent = (
+    `Created planner task ${response.task.task_id}`
+    + `${override ? " with operator edits." : "."}`
+  );
   selectedGoalId = goalId;
   document.getElementById("task-goal-id").value = goalId;
   document.getElementById("event-correlation-id").value = goalId;
@@ -1475,13 +1546,19 @@ async function createTasksFromSelectedPlannerSuggestions() {
     throw new Error("Select at least one planner suggestion before bulk creation.");
   }
   const goalId = plannerPreview.goal_id;
+  const overrides = collectPlannerSuggestionOverrides(suggestionIndexes);
   ensureMutationAllowed("Bulk planner task creation");
-  await api(`/goals/${encodeURIComponent(goalId)}/plan/tasks/bulk`, {
+  const response = await api(`/goals/${encodeURIComponent(goalId)}/plan/tasks/bulk`, {
     method: "POST",
     body: JSON.stringify({
       suggestion_indexes: suggestionIndexes,
+      overrides,
     }),
   });
+  document.getElementById("system-feedback").textContent = (
+    `Bulk planner create completed: ${response.created.length} created, `
+    + `${response.skipped_duplicates.length} duplicates skipped.`
+  );
   selectedGoalId = goalId;
   document.getElementById("task-goal-id").value = goalId;
   document.getElementById("event-correlation-id").value = goalId;

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1191,6 +1191,17 @@ def test_53_task_planner_provenance_schema_migration(services):
     }.issubset(columns)
 
 
+def test_53b_task_planner_operator_override_schema_migration(services):
+    row = services.db.fetch_one(
+        "SELECT version, name FROM schema_migrations WHERE version = 3"
+    )
+    columns = {column["name"] for column in services.db.fetch_all("PRAGMA table_info(tasks)")}
+
+    assert row is not None
+    assert row["name"] == "task_planner_operator_overrides"
+    assert "planner_operator_overrides" in columns
+
+
 def test_54_workflow_start_is_idempotent_with_idempotency_key(client):
     first = client.post(
         "/workflows/maintenance.retention_cleanup/start",
@@ -15709,6 +15720,44 @@ def test_272b_goal_plan_preview_marks_existing_suggestion_after_task_create(clie
     assert after["suggestions"][1]["existing_task_id"] is None
 
 
+def test_272c_goal_plan_task_create_applies_operator_override_with_original_provenance(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Review suggested planner task", "urgency": 0.7, "value": 0.7, "deadline_score": 0.3},
+    ).json()
+    preview = client.post(f"/goals/{goal['goal_id']}/plan").json()
+    selected = preview["suggestions"][0]
+    priority_override = "low" if selected["priority_hint"] != "low" else "high"
+    override = {
+        "title": "Operator reviewed task title",
+        "description": "Operator reviewed task description.",
+        "priority_hint": priority_override,
+    }
+
+    response = client.post(
+        f"/goals/{goal['goal_id']}/plan/tasks",
+        json={"suggestion_index": 0, "override": override},
+    )
+    payload = response.json()
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    assert response.status_code == 201
+    assert payload["suggestion"] == selected
+    assert payload["applied_suggestion"]["title"] == override["title"]
+    assert payload["applied_suggestion"]["description"] == override["description"]
+    assert payload["applied_suggestion"]["priority_hint"] == override["priority_hint"]
+    assert payload["operator_override"] == override
+    assert payload["task"]["title"] == override["title"]
+    assert payload["task"]["planner_source"] == selected["source"]
+    assert payload["task"]["planner_suggestion_index"] == 0
+    assert payload["task"]["planner_priority_hint"] == selected["priority_hint"]
+    assert payload["task"]["planner_suggestion_description"] == selected["description"]
+    assert payload["task"]["planner_operator_overrides"] == override
+    assert len(tasks) == 1
+    assert tasks[0]["title"] == override["title"]
+    assert tasks[0]["planner_operator_overrides"] == override
+
+
 def test_273_goal_plan_task_create_unknown_goal_returns_404(client):
     response = client.post("/goals/missing-goal/plan/tasks", json={"suggestion_index": 0})
 
@@ -15820,6 +15869,42 @@ def test_276c_goal_plan_bulk_task_create_skips_existing_duplicates(client):
     assert len(tasks) == 2
 
 
+def test_276c2_goal_plan_bulk_task_create_uses_overrides_and_skips_applied_duplicate_titles(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Bulk reviewed duplicate titles", "urgency": 0.7, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    shared_title = "Operator reviewed shared task"
+
+    response = client.post(
+        f"/goals/{goal['goal_id']}/plan/tasks/bulk",
+        json={
+            "suggestion_indexes": [0, 1],
+            "overrides": {
+                0: {"title": shared_title},
+                1: {"title": shared_title, "description": "Second reviewed description."},
+            },
+        },
+    )
+    payload = response.json()
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    assert response.status_code == 201
+    assert [item["suggestion_index"] for item in payload["created"]] == [0]
+    assert payload["created"][0]["applied_suggestion"]["title"] == shared_title
+    assert payload["created"][0]["operator_override"] == {"title": shared_title}
+    assert len(payload["skipped_duplicates"]) == 1
+    assert payload["skipped_duplicates"][0]["suggestion_index"] == 1
+    assert payload["skipped_duplicates"][0]["existing_task_id"] == payload["created"][0]["task"]["task_id"]
+    assert payload["skipped_duplicates"][0]["operator_override"] == {
+        "title": shared_title,
+        "description": "Second reviewed description.",
+    }
+    assert len(tasks) == 1
+    assert tasks[0]["title"] == shared_title
+    assert tasks[0]["planner_operator_overrides"] == {"title": shared_title}
+
+
 def test_276d_goal_plan_bulk_task_create_invalid_index_does_not_create_tasks(client):
     goal = client.post(
         "/goals",
@@ -15837,6 +15922,26 @@ def test_276d_goal_plan_bulk_task_create_invalid_index_does_not_create_tasks(cli
     assert tasks == []
 
 
+def test_276e_goal_plan_bulk_task_create_unrequested_override_index_does_not_create_tasks(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Bulk reject unrequested override", "urgency": 0.4, "value": 0.4, "deadline_score": 0.2},
+    ).json()
+
+    response = client.post(
+        f"/goals/{goal['goal_id']}/plan/tasks/bulk",
+        json={
+            "suggestion_indexes": [0],
+            "overrides": {1: {"title": "Unrequested override"}},
+        },
+    )
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == f"Planner override index 1 was not requested for goal {goal['goal_id']}"
+    assert tasks == []
+
+
 def test_277_manual_task_create_has_no_planner_provenance(client):
     goal = create_active_goal(client, "Manual task provenance")
 
@@ -15849,8 +15954,10 @@ def test_277_manual_task_create_has_no_planner_provenance(client):
     assert task["planner_suggestion_index"] is None
     assert task["planner_priority_hint"] is None
     assert task["planner_suggestion_description"] is None
+    assert task["planner_operator_overrides"] is None
     assert len(tasks) == 1
     assert tasks[0]["planner_source"] is None
     assert tasks[0]["planner_suggestion_index"] is None
     assert tasks[0]["planner_priority_hint"] is None
     assert tasks[0]["planner_suggestion_description"] is None
+    assert tasks[0]["planner_operator_overrides"] is None


### PR DESCRIPTION
﻿## Summary
- Add optional operator overrides when creating planner-suggested tasks singly or in bulk.
- Preserve original deterministic planner provenance while storing operator edits separately.
- Make planner preview cards editable in the UI before explicit task creation.

## Validation
- `python -m pytest tests/test_goal_ops.py -q -k "goal_plan or task_planner"`
- `python -m pytest`
- `git diff --check`
- `node --check goal_ops_console/static/app.js`

## Notes
- No CI/guard refactor included.
- `artifacts/` remains untracked and untouched.
