### PR TITLE
Persist planner suggestion rationales

### DIFF
--- a/goal_ops_console/database.py
+++ b/goal_ops_console/database.py
@@ -352,6 +352,16 @@ VALUES (3, 'task_planner_operator_overrides', datetime('now'));
 COMMIT;
 """,
     ),
+    (
+        4,
+        """
+BEGIN IMMEDIATE;
+ALTER TABLE tasks ADD COLUMN planner_suggestion_rationale TEXT;
+INSERT INTO schema_migrations (version, name, applied_at)
+VALUES (4, 'task_planner_suggestion_rationale', datetime('now'));
+COMMIT;
+""",
+    ),
 )
 T = TypeVar("T")
 

--- a/goal_ops_console/execution_layer.py
+++ b/goal_ops_console/execution_layer.py
@@ -38,6 +38,7 @@ class ExecutionLayer:
         planner_suggestion_index: int | None = None,
         planner_priority_hint: str | None = None,
         planner_suggestion_description: str | None = None,
+        planner_suggestion_rationale: str | None = None,
         planner_operator_overrides: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         goal = self.state_manager.get_goal(goal_id)
@@ -53,6 +54,7 @@ class ExecutionLayer:
                 "source": planner_source,
                 "suggestion_index": planner_suggestion_index,
                 "priority_hint": planner_priority_hint,
+                "rationale": planner_suggestion_rationale,
             }
             if planner_operator_overrides is not None:
                 event_payload["planner"]["operator_overrides"] = planner_operator_overrides
@@ -65,9 +67,10 @@ class ExecutionLayer:
             tx.execute(
                 "INSERT INTO tasks "
                 "(task_id, goal_id, title, planner_source, planner_suggestion_index, "
-                "planner_priority_hint, planner_suggestion_description, planner_operator_overrides, "
+                "planner_priority_hint, planner_suggestion_description, planner_suggestion_rationale, "
+                "planner_operator_overrides, "
                 "created_at, updated_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 task_id,
                 goal_id,
                 title,
@@ -75,6 +78,7 @@ class ExecutionLayer:
                 planner_suggestion_index,
                 planner_priority_hint,
                 planner_suggestion_description,
+                planner_suggestion_rationale,
                 planner_operator_overrides_json,
                 timestamp,
                 timestamp,
@@ -113,6 +117,7 @@ class ExecutionLayer:
                        t.planner_suggestion_index,
                        t.planner_priority_hint,
                        t.planner_suggestion_description,
+                       t.planner_suggestion_rationale,
                        t.planner_operator_overrides,
                        ts.correlation_id,
                        ts.status,
@@ -139,6 +144,7 @@ class ExecutionLayer:
                       t.planner_suggestion_index,
                       t.planner_priority_hint,
                       t.planner_suggestion_description,
+                      t.planner_suggestion_rationale,
                       t.planner_operator_overrides,
                       ts.correlation_id,
                       ts.status,

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -99,6 +99,7 @@ def _create_task_from_suggestion(
         planner_suggestion_index=suggestion_index,
         planner_priority_hint=original_suggestion["priority_hint"],
         planner_suggestion_description=original_suggestion["description"],
+        planner_suggestion_rationale=original_suggestion["rationale"],
         planner_operator_overrides=operator_override,
     )
 

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -646,7 +646,10 @@ function renderTaskPlannerProvenance(task) {
       parts.push(`operator edits: ${escapeHtml(editedFields.join(", "))}`);
     }
   }
-  return `<div class="meta">${parts.join(" &middot; ")}</div>`;
+  const rationale = task.planner_suggestion_rationale
+    ? `<div class="meta"><strong>Why suggested:</strong> ${escapeHtml(task.planner_suggestion_rationale)}</div>`
+    : "";
+  return `<div class="meta">${parts.join(" &middot; ")}</div>${rationale}`;
 }
 
 function renderGoals(goals) {
@@ -705,6 +708,7 @@ function renderTasks(tasks) {
     task.planner_suggestion_index,
     task.planner_priority_hint,
     task.planner_suggestion_description,
+    task.planner_suggestion_rationale,
   ]);
   if (!filteredTasks.length) {
     container.innerHTML = `<div class="meta">${filteredEmptyMessage("No tasks for the current selection.")}</div>`;

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1202,6 +1202,17 @@ def test_53b_task_planner_operator_override_schema_migration(services):
     assert "planner_operator_overrides" in columns
 
 
+def test_53c_task_planner_rationale_schema_migration(services):
+    row = services.db.fetch_one(
+        "SELECT version, name FROM schema_migrations WHERE version = 4"
+    )
+    columns = {column["name"] for column in services.db.fetch_all("PRAGMA table_info(tasks)")}
+
+    assert row is not None
+    assert row["name"] == "task_planner_suggestion_rationale"
+    assert "planner_suggestion_rationale" in columns
+
+
 def test_54_workflow_start_is_idempotent_with_idempotency_key(client):
     first = client.post(
         "/workflows/maintenance.retention_cleanup/start",
@@ -15714,6 +15725,7 @@ def test_272_goal_plan_preview_suggestion_endpoint_creates_one_task(client):
     assert payload["task"]["planner_suggestion_index"] == 0
     assert payload["task"]["planner_priority_hint"] == selected["priority_hint"]
     assert payload["task"]["planner_suggestion_description"] == selected["description"]
+    assert payload["task"]["planner_suggestion_rationale"] == selected["rationale"]
     assert len(tasks) == 1
     assert tasks[0]["goal_id"] == goal["goal_id"]
     assert tasks[0]["title"] == selected["title"]
@@ -15722,6 +15734,7 @@ def test_272_goal_plan_preview_suggestion_endpoint_creates_one_task(client):
     assert tasks[0]["planner_suggestion_index"] == 0
     assert tasks[0]["planner_priority_hint"] == selected["priority_hint"]
     assert tasks[0]["planner_suggestion_description"] == selected["description"]
+    assert tasks[0]["planner_suggestion_rationale"] == selected["rationale"]
 
 
 def test_272b_goal_plan_preview_marks_existing_suggestion_after_task_create(client):
@@ -15774,9 +15787,11 @@ def test_272c_goal_plan_task_create_applies_operator_override_with_original_prov
     assert payload["task"]["planner_suggestion_index"] == 0
     assert payload["task"]["planner_priority_hint"] == selected["priority_hint"]
     assert payload["task"]["planner_suggestion_description"] == selected["description"]
+    assert payload["task"]["planner_suggestion_rationale"] == selected["rationale"]
     assert payload["task"]["planner_operator_overrides"] == override
     assert len(tasks) == 1
     assert tasks[0]["title"] == override["title"]
+    assert tasks[0]["planner_suggestion_rationale"] == selected["rationale"]
     assert tasks[0]["planner_operator_overrides"] == override
 
 
@@ -15924,6 +15939,7 @@ def test_276c2_goal_plan_bulk_task_create_uses_overrides_and_skips_applied_dupli
     }
     assert len(tasks) == 1
     assert tasks[0]["title"] == shared_title
+    assert tasks[0]["planner_suggestion_rationale"]
     assert tasks[0]["planner_operator_overrides"] == {"title": shared_title}
 
 
@@ -15976,10 +15992,12 @@ def test_277_manual_task_create_has_no_planner_provenance(client):
     assert task["planner_suggestion_index"] is None
     assert task["planner_priority_hint"] is None
     assert task["planner_suggestion_description"] is None
+    assert task["planner_suggestion_rationale"] is None
     assert task["planner_operator_overrides"] is None
     assert len(tasks) == 1
     assert tasks[0]["planner_source"] is None
     assert tasks[0]["planner_suggestion_index"] is None
     assert tasks[0]["planner_priority_hint"] is None
     assert tasks[0]["planner_suggestion_description"] is None
+    assert tasks[0]["planner_suggestion_rationale"] is None
     assert tasks[0]["planner_operator_overrides"] is None


### PR DESCRIPTION
## Summary
- persist planner suggestion rationale on tasks created from planner preview
- include rationale in planner task provenance events and task API responses
- show the persisted rationale in the task list provenance UI

## Test Plan
- python -m pytest tests/test_goal_ops.py -q -k "task_planner or goal_plan"
- node --check goal_ops_console/static/app.js
- python -m pytest