### PR TITLE
[codex] Add planner review decisions

### DIFF
--- a/goal_ops_console/database.py
+++ b/goal_ops_console/database.py
@@ -362,6 +362,36 @@ VALUES (4, 'task_planner_suggestion_rationale', datetime('now'));
 COMMIT;
 """,
     ),
+    (
+        5,
+        """
+BEGIN IMMEDIATE;
+CREATE TABLE IF NOT EXISTS planner_suggestion_reviews (
+  goal_id                    TEXT NOT NULL,
+  suggestion_index           INTEGER NOT NULL,
+  decision                   TEXT NOT NULL,
+  comment                    TEXT,
+  task_id                    TEXT,
+  planner_source             TEXT NOT NULL,
+  suggestion_title           TEXT NOT NULL,
+  suggestion_description     TEXT NOT NULL,
+  suggestion_rationale       TEXT NOT NULL,
+  suggestion_priority_hint   TEXT NOT NULL,
+  operator_override          TEXT,
+  created_at                 TEXT NOT NULL,
+  updated_at                 TEXT NOT NULL,
+  PRIMARY KEY(goal_id, suggestion_index),
+  FOREIGN KEY(goal_id) REFERENCES goals(goal_id),
+  FOREIGN KEY(task_id) REFERENCES tasks(task_id),
+  CHECK(decision IN ('created', 'deferred', 'rejected'))
+);
+CREATE INDEX IF NOT EXISTS idx_planner_suggestion_reviews_goal_updated
+ON planner_suggestion_reviews(goal_id, updated_at DESC);
+INSERT INTO schema_migrations (version, name, applied_at)
+VALUES (5, 'planner_suggestion_reviews', datetime('now'));
+COMMIT;
+""",
+    ),
 )
 T = TypeVar("T")
 

--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -78,6 +78,10 @@ class PlannerTaskSuggestion(BaseModel):
     source: str
     task_exists: bool = False
     existing_task_id: str | None = None
+    review_decision: Literal["pending", "created", "deferred", "rejected"] = "pending"
+    review_comment: str | None = None
+    review_task_id: str | None = None
+    reviewed_at: str | None = None
 
 
 class PlannerPreviewResponse(BaseModel):
@@ -103,12 +107,42 @@ class PlannerBulkTaskCreateRequest(BaseModel):
     overrides: dict[int, PlannerTaskSuggestionOverride] = Field(default_factory=dict)
 
 
+class PlannerSuggestionReview(BaseModel):
+    goal_id: str
+    suggestion_index: int
+    decision: Literal["created", "deferred", "rejected"]
+    comment: str | None = None
+    task_id: str | None = None
+    planner_source: str
+    suggestion_title: str
+    suggestion_description: str
+    suggestion_rationale: str
+    suggestion_priority_hint: str
+    operator_override: dict[str, Any] | None = None
+    created_at: str
+    updated_at: str
+
+
+class PlannerReviewDecisionRequest(BaseModel):
+    suggestion_index: int = Field(ge=0)
+    decision: Literal["deferred", "rejected"]
+    comment: str | None = Field(default=None, max_length=500)
+
+
+class PlannerReviewDecisionResponse(BaseModel):
+    goal_id: str
+    suggestion_index: int
+    suggestion: PlannerTaskSuggestion
+    review: PlannerSuggestionReview
+
+
 class PlannerTaskCreateResponse(BaseModel):
     goal_id: str
     suggestion_index: int
     suggestion: PlannerTaskSuggestion
     applied_suggestion: PlannerTaskSuggestion
     operator_override: dict[str, Any] | None = None
+    review: PlannerSuggestionReview | None = None
     task: dict[str, Any]
 
 

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -1,5 +1,9 @@
+import json
+from typing import Any
+
 from fastapi import APIRouter, Depends
 
+from goal_ops_console.database import now_utc
 from goal_ops_console.models import (
     ConflictError,
     DomainError,
@@ -7,6 +11,8 @@ from goal_ops_console.models import (
     PlannerBulkTaskCreateRequest,
     PlannerBulkTaskCreateResponse,
     PlannerPreviewResponse,
+    PlannerReviewDecisionRequest,
+    PlannerReviewDecisionResponse,
     PlannerTaskCreateRequest,
     PlannerTaskCreateResponse,
     PlannerTaskSuggestionOverride,
@@ -44,11 +50,22 @@ def _preview_goal_plan(goal_id: str, services: AppServices) -> dict:
     goal = services.state_manager.get_goal(goal_id)
     plan = services.planner.create_plan(goal)
     existing_by_title = _existing_tasks_by_title(goal_id, services)
+    existing_by_index = _existing_tasks_by_suggestion_index(goal_id, services)
+    reviews_by_index = _planner_reviews_by_index(goal_id, services)
 
-    for suggestion in plan["suggestions"]:
-        existing = existing_by_title.get(suggestion["title"])
+    for suggestion_index, suggestion in enumerate(plan["suggestions"]):
+        existing = existing_by_index.get(suggestion_index) or existing_by_title.get(suggestion["title"])
+        review = reviews_by_index.get(suggestion_index)
         suggestion["task_exists"] = existing is not None
         suggestion["existing_task_id"] = existing["task_id"] if existing is not None else None
+        suggestion["review_decision"] = _suggestion_review_decision(review, existing)
+        suggestion["review_comment"] = review["comment"] if review is not None else None
+        suggestion["review_task_id"] = (
+            review["task_id"]
+            if review is not None
+            else suggestion["existing_task_id"]
+        )
+        suggestion["reviewed_at"] = review["updated_at"] if review is not None else None
     return plan
 
 
@@ -57,6 +74,15 @@ def _existing_tasks_by_title(goal_id: str, services: AppServices) -> dict[str, d
     for task in services.execution_layer.list_tasks(goal_id=goal_id):
         existing_by_title.setdefault(task["title"], task)
     return existing_by_title
+
+
+def _existing_tasks_by_suggestion_index(goal_id: str, services: AppServices) -> dict[int, dict]:
+    existing_by_index = {}
+    for task in services.execution_layer.list_tasks(goal_id=goal_id):
+        suggestion_index = task.get("planner_suggestion_index")
+        if isinstance(suggestion_index, int):
+            existing_by_index.setdefault(suggestion_index, task)
+    return existing_by_index
 
 
 def _get_plan_suggestion(plan: dict, suggestion_index: int, goal_id: str) -> dict:
@@ -104,9 +130,184 @@ def _create_task_from_suggestion(
     )
 
 
+def _planner_review_from_row(row: Any) -> dict:
+    review = dict(row)
+    raw_override = review.get("operator_override")
+    if isinstance(raw_override, str) and raw_override:
+        review["operator_override"] = json.loads(raw_override)
+    else:
+        review["operator_override"] = None
+    return review
+
+
+def _planner_reviews_by_index(goal_id: str, services: AppServices) -> dict[int, dict]:
+    rows = services.db.fetch_all(
+        """SELECT goal_id,
+                  suggestion_index,
+                  decision,
+                  comment,
+                  task_id,
+                  planner_source,
+                  suggestion_title,
+                  suggestion_description,
+                  suggestion_rationale,
+                  suggestion_priority_hint,
+                  operator_override,
+                  created_at,
+                  updated_at
+           FROM planner_suggestion_reviews
+           WHERE goal_id = ?""",
+        goal_id,
+    )
+    return {int(row["suggestion_index"]): _planner_review_from_row(row) for row in rows}
+
+
+def _get_planner_review(goal_id: str, suggestion_index: int, services: AppServices) -> dict | None:
+    row = services.db.fetch_one(
+        """SELECT goal_id,
+                  suggestion_index,
+                  decision,
+                  comment,
+                  task_id,
+                  planner_source,
+                  suggestion_title,
+                  suggestion_description,
+                  suggestion_rationale,
+                  suggestion_priority_hint,
+                  operator_override,
+                  created_at,
+                  updated_at
+           FROM planner_suggestion_reviews
+           WHERE goal_id = ? AND suggestion_index = ?""",
+        goal_id,
+        suggestion_index,
+    )
+    return _planner_review_from_row(row) if row is not None else None
+
+
+def _suggestion_review_decision(review: dict | None, existing_task: dict | None) -> str:
+    if review is not None:
+        return review["decision"]
+    if existing_task is not None:
+        return "created"
+    return "pending"
+
+
+def _normalized_review_comment(comment: str | None) -> str | None:
+    cleaned = (comment or "").strip()
+    return cleaned or None
+
+
+def _create_planner_review(
+    *,
+    goal_id: str,
+    suggestion_index: int,
+    suggestion: dict,
+    services: AppServices,
+    decision: str,
+    comment: str | None = None,
+    task_id: str | None = None,
+    operator_override: dict | None = None,
+) -> dict:
+    existing_review = _get_planner_review(goal_id, suggestion_index, services)
+    if existing_review is not None:
+        raise ConflictError(
+            f"Planner suggestion {suggestion_index} already has review decision "
+            f"{existing_review['decision']} for goal {goal_id}"
+        )
+    timestamp = now_utc()
+    normalized_comment = _normalized_review_comment(comment)
+    operator_override_json = (
+        json.dumps(operator_override, sort_keys=True)
+        if operator_override is not None
+        else None
+    )
+    with services.db.transaction() as tx:
+        tx.execute(
+            """INSERT INTO planner_suggestion_reviews
+               (goal_id, suggestion_index, decision, comment, task_id, planner_source,
+                suggestion_title, suggestion_description, suggestion_rationale,
+                suggestion_priority_hint, operator_override, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            goal_id,
+            suggestion_index,
+            decision,
+            normalized_comment,
+            task_id,
+            suggestion["source"],
+            suggestion["title"],
+            suggestion["description"],
+            suggestion["rationale"],
+            suggestion["priority_hint"],
+            operator_override_json,
+            timestamp,
+            timestamp,
+        )
+        services.event_bus.record_event(
+            "planner.suggestion_reviewed",
+            goal_id,
+            f"{goal_id}:planner:{suggestion_index}",
+            {
+                "goal_id": goal_id,
+                "suggestion_index": suggestion_index,
+                "decision": decision,
+                "comment": normalized_comment,
+                "task_id": task_id,
+                "source": suggestion["source"],
+            },
+            tx=tx,
+        )
+    review = _get_planner_review(goal_id, suggestion_index, services)
+    assert review is not None
+    return review
+
+
+def _ensure_suggestion_can_be_created(goal_id: str, suggestion_index: int, services: AppServices) -> None:
+    existing_review = _get_planner_review(goal_id, suggestion_index, services)
+    if existing_review is not None:
+        if existing_review["decision"] == "created" and existing_review.get("task_id"):
+            raise ConflictError(
+                f"Planner suggestion already exists as task {existing_review['task_id']} for goal {goal_id}"
+            )
+        raise ConflictError(
+            f"Planner suggestion {suggestion_index} already has review decision "
+            f"{existing_review['decision']} for goal {goal_id}"
+        )
+
+
 @router.post("/{goal_id}/plan", response_model=PlannerPreviewResponse)
 def preview_goal_plan(goal_id: str, services: AppServices = Depends(get_services)) -> dict:
     return _preview_goal_plan(goal_id, services)
+
+
+@router.post("/{goal_id}/plan/reviews", status_code=201, response_model=PlannerReviewDecisionResponse)
+def review_plan_suggestion(
+    goal_id: str,
+    request: PlannerReviewDecisionRequest,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    plan = _preview_goal_plan(goal_id, services)
+    suggestion = _get_plan_suggestion(plan, request.suggestion_index, goal_id)
+    if suggestion["task_exists"]:
+        raise ConflictError(
+            f"Planner suggestion already exists as task {suggestion['existing_task_id']} for goal {goal_id}"
+        )
+    review = _create_planner_review(
+        goal_id=goal_id,
+        suggestion_index=request.suggestion_index,
+        suggestion=suggestion,
+        services=services,
+        decision=request.decision,
+        comment=request.comment,
+    )
+    refreshed_plan = _preview_goal_plan(goal_id, services)
+    refreshed_suggestion = _get_plan_suggestion(refreshed_plan, request.suggestion_index, goal_id)
+    return {
+        "goal_id": goal_id,
+        "suggestion_index": request.suggestion_index,
+        "suggestion": refreshed_suggestion,
+        "review": review,
+    }
 
 
 @router.post("/{goal_id}/plan/tasks", status_code=201, response_model=PlannerTaskCreateResponse)
@@ -117,6 +318,11 @@ def create_task_from_plan_suggestion(
 ) -> dict:
     plan = _preview_goal_plan(goal_id, services)
     suggestion = _get_plan_suggestion(plan, request.suggestion_index, goal_id)
+    _ensure_suggestion_can_be_created(goal_id, request.suggestion_index, services)
+    if suggestion["task_exists"]:
+        raise ConflictError(
+            f"Planner suggestion already exists as task {suggestion['existing_task_id']} for goal {goal_id}"
+        )
     applied_suggestion, operator_override = _apply_suggestion_override(suggestion, request.override)
     existing_by_title = _existing_tasks_by_title(goal_id, services)
     existing = existing_by_title.get(applied_suggestion["title"])
@@ -132,12 +338,22 @@ def create_task_from_plan_suggestion(
         services,
         operator_override,
     )
+    review = _create_planner_review(
+        goal_id=goal_id,
+        suggestion_index=request.suggestion_index,
+        suggestion=suggestion,
+        services=services,
+        decision="created",
+        task_id=task["task_id"],
+        operator_override=operator_override,
+    )
     return {
         "goal_id": goal_id,
         "suggestion_index": request.suggestion_index,
         "suggestion": suggestion,
         "applied_suggestion": applied_suggestion,
         "operator_override": operator_override,
+        "review": review,
         "task": task,
     }
 
@@ -173,6 +389,8 @@ def create_tasks_from_plan_suggestions(
         )
 
     existing_by_title = _existing_tasks_by_title(goal_id, services)
+    existing_by_index = _existing_tasks_by_suggestion_index(goal_id, services)
+    existing_reviews_by_index = _planner_reviews_by_index(goal_id, services)
     created_by_title: dict[str, dict] = {}
     created: list[dict] = []
     skipped_duplicates: list[dict] = []
@@ -182,7 +400,26 @@ def create_tasks_from_plan_suggestions(
         suggestion = item["suggestion"]
         applied_suggestion = item["applied_suggestion"]
         operator_override = item["operator_override"]
-        existing = existing_by_title.get(applied_suggestion["title"])
+        existing_review = existing_reviews_by_index.get(suggestion_index)
+        if existing_review is not None:
+            reason = (
+                "already_exists"
+                if existing_review["decision"] == "created"
+                else f"review_{existing_review['decision']}"
+            )
+            skipped_duplicates.append(
+                {
+                    "suggestion_index": suggestion_index,
+                    "suggestion": suggestion,
+                    "applied_suggestion": applied_suggestion,
+                    "operator_override": operator_override,
+                    "existing_task_id": existing_review["task_id"],
+                    "review": existing_review,
+                    "reason": reason,
+                }
+            )
+            continue
+        existing = existing_by_index.get(suggestion_index) or existing_by_title.get(applied_suggestion["title"])
         in_request_duplicate = created_by_title.get(applied_suggestion["title"])
         existing_task_id = (existing["task_id"] if existing is not None else None) or (
             in_request_duplicate["task"]["task_id"] if in_request_duplicate is not None else None
@@ -212,11 +449,21 @@ def create_tasks_from_plan_suggestions(
             services,
             operator_override,
         )
+        review = _create_planner_review(
+            goal_id=goal_id,
+            suggestion_index=suggestion_index,
+            suggestion=suggestion,
+            services=services,
+            decision="created",
+            task_id=task["task_id"],
+            operator_override=operator_override,
+        )
         created_item = {
             "suggestion_index": suggestion_index,
             "suggestion": suggestion,
             "applied_suggestion": applied_suggestion,
             "operator_override": operator_override,
+            "review": review,
             "task": task,
         }
         created.append(created_item)

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -508,16 +508,28 @@ function renderGoalButtons(goal) {
 }
 
 function renderPlannerSuggestionStatus(item) {
-  if (!item.task_exists) {
-    return `<div class="meta">${escapeHtml(item.source)}</div>`;
+  const decision = plannerSuggestionDecision(item);
+  if (item.task_exists || decision === "created") {
+    const taskId = item.existing_task_id || item.review_task_id;
+    const existingTask = taskId ? ` as ${escapeHtml(taskId)}` : "";
+    return `<div class="meta">${escapeHtml(item.source)} &middot; Already created${existingTask}</div>`;
   }
-  const existingTask = item.existing_task_id ? ` as ${escapeHtml(item.existing_task_id)}` : "";
-  return `<div class="meta">${escapeHtml(item.source)} &middot; Already created${existingTask}</div>`;
+  if (decision === "deferred" || decision === "rejected") {
+    return (
+      `<div class="meta">${escapeHtml(item.source)} &middot; Review: `
+      + `${escapeHtml(decision)}</div>`
+    );
+  }
+  return `<div class="meta">${escapeHtml(item.source)} &middot; Ready for review</div>`;
 }
 
 function renderPlannerSuggestionAction(item, index) {
-  if (item.task_exists) {
+  const decision = plannerSuggestionDecision(item);
+  if (item.task_exists || decision === "created") {
     return `<button type="button" class="secondary" disabled>Already created</button>`;
+  }
+  if (decision === "deferred" || decision === "rejected") {
+    return `<button type="button" class="secondary" disabled>${escapeHtml(decision)}</button>`;
   }
   return (
     `<button type="button" class="secondary" data-mutation-control="true" `
@@ -526,7 +538,8 @@ function renderPlannerSuggestionAction(item, index) {
 }
 
 function renderPlannerSuggestionSelection(item, index) {
-  if (item.task_exists) {
+  const decision = plannerSuggestionDecision(item);
+  if (item.task_exists || decision !== "pending") {
     return "";
   }
   return (
@@ -536,7 +549,8 @@ function renderPlannerSuggestionSelection(item, index) {
 }
 
 function renderPlannerSuggestionEditor(item, index) {
-  if (item.task_exists) {
+  const decision = plannerSuggestionDecision(item);
+  if (item.task_exists || decision !== "pending") {
     return "";
   }
   return `
@@ -558,6 +572,40 @@ function renderPlannerSuggestionEditor(item, index) {
       Review description
       <textarea data-plan-description-index="${index}" rows="3">${escapeHtml(item.description)}</textarea>
     </label>
+  `;
+}
+
+function plannerSuggestionDecision(item) {
+  if (item.review_decision) {
+    return item.review_decision;
+  }
+  return item.task_exists ? "created" : "pending";
+}
+
+function renderPlannerSuggestionReviewControls(item, index) {
+  const decision = plannerSuggestionDecision(item);
+  if (decision === "deferred" || decision === "rejected") {
+    const comment = item.review_comment
+      ? `<div class="meta">Comment: ${escapeHtml(item.review_comment)}</div>`
+      : "";
+    return `
+      <div class="entity-divider"></div>
+      <div class="meta">Review decision: ${escapeHtml(decision)}</div>
+      ${comment}
+    `;
+  }
+  if (item.task_exists || decision === "created") {
+    return "";
+  }
+  return `
+    <label class="meta" style="display:block;margin-top:0.75rem;">
+      Review comment (optional)
+      <textarea data-plan-review-comment-index="${index}" rows="2" placeholder="Why defer or reject this suggestion?"></textarea>
+    </label>
+    <div class="actions">
+      <button type="button" class="secondary" data-mutation-control="true" data-plan-review-index="${index}" data-plan-review-decision="deferred">Defer</button>
+      <button type="button" class="secondary" data-mutation-control="true" data-plan-review-index="${index}" data-plan-review-decision="rejected">Reject</button>
+    </div>
   `;
 }
 
@@ -594,6 +642,7 @@ function renderPlannerPreview(preview) {
           <p class="meta">${escapeHtml(item.description)}</p>
           <p class="meta"><strong>Why suggested:</strong> ${escapeHtml(item.rationale)}</p>
           ${renderPlannerSuggestionEditor(item, index)}
+          ${renderPlannerSuggestionReviewControls(item, index)}
           ${renderPlannerSuggestionSelection(item, index)}
           <div class="actions">
             ${renderPlannerSuggestionAction(item, index)}
@@ -1513,11 +1562,51 @@ function collectPlannerSuggestionOverrides(indexes) {
   }, {});
 }
 
+function ensurePlannerSuggestionReadyForCreate(suggestion) {
+  const decision = plannerSuggestionDecision(suggestion);
+  if (decision === "deferred" || decision === "rejected") {
+    throw new Error(`Planner suggestion was already ${decision}. Run Plan Preview again or choose another suggestion.`);
+  }
+}
+
+function collectPlannerReviewComment(index) {
+  return document.querySelector(`[data-plan-review-comment-index="${index}"]`)?.value.trim() || null;
+}
+
+async function reviewPlannerSuggestion(indexValue, decision) {
+  if (!plannerPreview?.goal_id) {
+    throw new Error("Run Plan Preview before reviewing a suggested task.");
+  }
+  const suggestionIndex = parsePlannerSuggestionIndex(indexValue);
+  const goalId = plannerPreview.goal_id;
+  ensureMutationAllowed(`Planner review ${decision}`);
+  const comment = collectPlannerReviewComment(suggestionIndex);
+  const response = await api(`/goals/${encodeURIComponent(goalId)}/plan/reviews`, {
+    method: "POST",
+    body: JSON.stringify({
+      suggestion_index: suggestionIndex,
+      decision,
+      ...(comment ? { comment } : {}),
+    }),
+  });
+  document.getElementById("system-feedback").textContent = (
+    `Planner suggestion #${response.suggestion_index + 1} marked ${response.review.decision}.`
+  );
+  selectedGoalId = goalId;
+  document.getElementById("task-goal-id").value = goalId;
+  document.getElementById("event-correlation-id").value = goalId;
+  document.getElementById("trace-goal-id").value = goalId;
+  document.getElementById("fault-goal-id").value = goalId;
+  await refreshAll();
+  await runPlannerPreview(goalId);
+}
+
 async function createTaskFromPlannerSuggestion(indexValue) {
   if (!plannerPreview?.goal_id) {
     throw new Error("Run Plan Preview before creating a suggested task.");
   }
   const suggestionIndex = parsePlannerSuggestionIndex(indexValue);
+  ensurePlannerSuggestionReadyForCreate(plannerPreview.suggestions[suggestionIndex]);
   const goalId = plannerPreview.goal_id;
   const override = collectPlannerSuggestionOverride(suggestionIndex);
   ensureMutationAllowed("Planner task creation");
@@ -1550,6 +1639,7 @@ async function createTasksFromSelectedPlannerSuggestions() {
   if (!suggestionIndexes.length) {
     throw new Error("Select at least one planner suggestion before bulk creation.");
   }
+  suggestionIndexes.forEach((index) => ensurePlannerSuggestionReadyForCreate(plannerPreview.suggestions[index]));
   const goalId = plannerPreview.goal_id;
   const overrides = collectPlannerSuggestionOverrides(suggestionIndexes);
   ensureMutationAllowed("Bulk planner task creation");
@@ -1936,6 +2026,8 @@ document.addEventListener("click", async (event) => {
   const selectGoal = event.target.dataset.selectGoal;
   const planGoal = event.target.dataset.planGoal;
   const planSuggestionIndex = event.target.dataset.planSuggestionIndex;
+  const planReviewIndex = event.target.dataset.planReviewIndex;
+  const planReviewDecision = event.target.dataset.planReviewDecision;
   const planBulkCreate = event.target.dataset.planBulkCreate;
   const operatorAction = event.target.dataset.operatorAction;
   const jumpTarget = event.target.dataset.jumpTarget;
@@ -1982,6 +2074,11 @@ document.addEventListener("click", async (event) => {
     if (planSuggestionIndex !== undefined) {
       showError("task-error", null);
       await createTaskFromPlannerSuggestion(planSuggestionIndex);
+    }
+
+    if (planReviewIndex !== undefined && planReviewDecision) {
+      showError("task-error", null);
+      await reviewPlannerSuggestion(planReviewIndex, planReviewDecision);
     }
 
     if (planBulkCreate) {

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1213,6 +1213,31 @@ def test_53c_task_planner_rationale_schema_migration(services):
     assert "planner_suggestion_rationale" in columns
 
 
+def test_53d_planner_review_decisions_schema_migration(services):
+    row = services.db.fetch_one(
+        "SELECT version, name FROM schema_migrations WHERE version = 5"
+    )
+    columns = {
+        column["name"]
+        for column in services.db.fetch_all("PRAGMA table_info(planner_suggestion_reviews)")
+    }
+
+    assert row is not None
+    assert row["name"] == "planner_suggestion_reviews"
+    assert {
+        "goal_id",
+        "suggestion_index",
+        "decision",
+        "comment",
+        "task_id",
+        "suggestion_title",
+        "suggestion_description",
+        "suggestion_rationale",
+        "suggestion_priority_hint",
+        "operator_override",
+    }.issubset(columns)
+
+
 def test_54_workflow_start_is_idempotent_with_idempotency_key(client):
     first = client.post(
         "/workflows/maintenance.retention_cleanup/start",
@@ -15647,6 +15672,10 @@ def test_269_goal_plan_preview_suggestions_have_expected_fields(client):
             "source",
             "task_exists",
             "existing_task_id",
+            "review_decision",
+            "review_comment",
+            "review_task_id",
+            "reviewed_at",
         }
         assert suggestion["title"]
         assert suggestion["description"]
@@ -15655,6 +15684,10 @@ def test_269_goal_plan_preview_suggestions_have_expected_fields(client):
         assert suggestion["source"] == "deterministic_planner"
         assert suggestion["task_exists"] is False
         assert suggestion["existing_task_id"] is None
+        assert suggestion["review_decision"] == "pending"
+        assert suggestion["review_comment"] is None
+        assert suggestion["review_task_id"] is None
+        assert suggestion["reviewed_at"] is None
 
 
 def test_269b_goal_plan_preview_rationale_mentions_goal_signals(client):
@@ -15726,6 +15759,9 @@ def test_272_goal_plan_preview_suggestion_endpoint_creates_one_task(client):
     assert payload["task"]["planner_priority_hint"] == selected["priority_hint"]
     assert payload["task"]["planner_suggestion_description"] == selected["description"]
     assert payload["task"]["planner_suggestion_rationale"] == selected["rationale"]
+    assert payload["review"]["decision"] == "created"
+    assert payload["review"]["task_id"] == payload["task"]["task_id"]
+    assert payload["review"]["suggestion_rationale"] == selected["rationale"]
     assert len(tasks) == 1
     assert tasks[0]["goal_id"] == goal["goal_id"]
     assert tasks[0]["title"] == selected["title"]
@@ -15751,8 +15787,11 @@ def test_272b_goal_plan_preview_marks_existing_suggestion_after_task_create(clie
     assert before["suggestions"][0]["existing_task_id"] is None
     assert after["suggestions"][0]["task_exists"] is True
     assert after["suggestions"][0]["existing_task_id"] == created["task"]["task_id"]
+    assert after["suggestions"][0]["review_decision"] == "created"
+    assert after["suggestions"][0]["review_task_id"] == created["task"]["task_id"]
     assert after["suggestions"][1]["task_exists"] is False
     assert after["suggestions"][1]["existing_task_id"] is None
+    assert after["suggestions"][1]["review_decision"] == "pending"
 
 
 def test_272c_goal_plan_task_create_applies_operator_override_with_original_provenance(client):
@@ -15789,10 +15828,102 @@ def test_272c_goal_plan_task_create_applies_operator_override_with_original_prov
     assert payload["task"]["planner_suggestion_description"] == selected["description"]
     assert payload["task"]["planner_suggestion_rationale"] == selected["rationale"]
     assert payload["task"]["planner_operator_overrides"] == override
+    assert payload["review"]["decision"] == "created"
+    assert payload["review"]["operator_override"] == override
     assert len(tasks) == 1
     assert tasks[0]["title"] == override["title"]
     assert tasks[0]["planner_suggestion_rationale"] == selected["rationale"]
     assert tasks[0]["planner_operator_overrides"] == override
+
+
+def test_272d_goal_plan_review_defer_persists_decision_without_creating_task(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Defer planner suggestion", "urgency": 0.4, "value": 0.5, "deadline_score": 0.2},
+    ).json()
+
+    response = client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 0, "decision": "deferred", "comment": "Wait for owner input."},
+    )
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+    after = client.post(f"/goals/{goal['goal_id']}/plan").json()
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["review"]["decision"] == "deferred"
+    assert payload["review"]["comment"] == "Wait for owner input."
+    assert payload["review"]["task_id"] is None
+    assert tasks == []
+    assert after["suggestions"][0]["review_decision"] == "deferred"
+    assert after["suggestions"][0]["review_comment"] == "Wait for owner input."
+    assert after["suggestions"][0]["task_exists"] is False
+
+
+def test_272e_goal_plan_review_reject_blocks_later_task_create(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Reject planner suggestion", "urgency": 0.4, "value": 0.5, "deadline_score": 0.2},
+    ).json()
+
+    rejected = client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 0, "decision": "rejected", "comment": "Not useful now."},
+    )
+    create = client.post(f"/goals/{goal['goal_id']}/plan/tasks", json={"suggestion_index": 0})
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    assert rejected.status_code == 201
+    assert create.status_code == 409
+    assert "already has review decision rejected" in create.json()["detail"]
+    assert tasks == []
+
+
+def test_272f_goal_plan_review_invalid_index_writes_nothing(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Reject invalid review index", "urgency": 0.4, "value": 0.5, "deadline_score": 0.2},
+    ).json()
+
+    response = client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 99, "decision": "rejected"},
+    )
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == f"Planner suggestion index 99 not found for goal {goal['goal_id']}"
+    assert tasks == []
+
+
+def test_272g_goal_plan_review_unknown_goal_returns_404(client):
+    response = client.post(
+        "/goals/missing-goal/plan/reviews",
+        json={"suggestion_index": 0, "decision": "deferred"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Goal missing-goal not found"
+
+
+def test_272h_goal_plan_review_duplicate_decision_returns_409(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Reject duplicate review", "urgency": 0.4, "value": 0.5, "deadline_score": 0.2},
+    ).json()
+
+    first = client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 0, "decision": "deferred"},
+    )
+    second = client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 0, "decision": "rejected"},
+    )
+
+    assert first.status_code == 201
+    assert second.status_code == 409
+    assert "already has review decision deferred" in second.json()["detail"]
 
 
 def test_273_goal_plan_task_create_unknown_goal_returns_404(client):
@@ -15941,6 +16072,33 @@ def test_276c2_goal_plan_bulk_task_create_uses_overrides_and_skips_applied_dupli
     assert tasks[0]["title"] == shared_title
     assert tasks[0]["planner_suggestion_rationale"]
     assert tasks[0]["planner_operator_overrides"] == {"title": shared_title}
+
+
+def test_276c3_goal_plan_bulk_task_create_skips_deferred_reviews(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Bulk skips deferred planner review", "urgency": 0.7, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    deferred = client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 0, "decision": "deferred"},
+    ).json()
+
+    response = client.post(
+        f"/goals/{goal['goal_id']}/plan/tasks/bulk",
+        json={"suggestion_indexes": [0, 1]},
+    )
+    payload = response.json()
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    assert response.status_code == 201
+    assert [item["suggestion_index"] for item in payload["created"]] == [1]
+    assert len(payload["skipped_duplicates"]) == 1
+    assert payload["skipped_duplicates"][0]["suggestion_index"] == 0
+    assert payload["skipped_duplicates"][0]["review"]["decision"] == "deferred"
+    assert payload["skipped_duplicates"][0]["review"]["updated_at"] == deferred["review"]["updated_at"]
+    assert payload["skipped_duplicates"][0]["reason"] == "review_deferred"
+    assert len(tasks) == 1
 
 
 def test_276d_goal_plan_bulk_task_create_invalid_index_does_not_create_tasks(client):


### PR DESCRIPTION
﻿## Summary
- persist planner suggestion review decisions for created, deferred, and rejected suggestions
- expose `POST /goals/{goal_id}/plan/reviews` for supervised defer/reject decisions without creating tasks
- annotate plan preview suggestions with review state and update the UI to show Defer/Reject controls and disable creation for reviewed suggestions

## Stability scope
- no CI/Guard workflow changes
- no external AI, Qdrant, or LLM dependency added
- `artifacts/` remains untracked and untouched

## Validation
- `python -m pytest tests/test_goal_ops.py -q -k "planner or goal_plan or task_planner"`
- `node --check goal_ops_console\static\app.js`
- `python -m pytest`
- `git diff --check`
- Browser smoke: local temp DB, create goal, run Plan Preview, defer a suggestion with comment, confirm no task is created
