### PR TITLE
[codex] Allow planner reviews to reopen

### DIFF
--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -136,6 +136,13 @@ class PlannerReviewDecisionResponse(BaseModel):
     review: PlannerSuggestionReview
 
 
+class PlannerReviewReopenResponse(BaseModel):
+    goal_id: str
+    suggestion_index: int
+    suggestion: PlannerTaskSuggestion
+    cleared_review: PlannerSuggestionReview
+
+
 class PlannerTaskCreateResponse(BaseModel):
     goal_id: str
     suggestion_index: int

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -8,11 +8,13 @@ from goal_ops_console.models import (
     ConflictError,
     DomainError,
     GoalCreateRequest,
+    NotFoundError,
     PlannerBulkTaskCreateRequest,
     PlannerBulkTaskCreateResponse,
     PlannerPreviewResponse,
     PlannerReviewDecisionRequest,
     PlannerReviewDecisionResponse,
+    PlannerReviewReopenResponse,
     PlannerTaskCreateRequest,
     PlannerTaskCreateResponse,
     PlannerTaskSuggestionOverride,
@@ -275,6 +277,38 @@ def _ensure_suggestion_can_be_created(goal_id: str, suggestion_index: int, servi
         )
 
 
+def _reopen_planner_review(goal_id: str, suggestion_index: int, services: AppServices) -> dict:
+    existing_review = _get_planner_review(goal_id, suggestion_index, services)
+    if existing_review is None:
+        raise NotFoundError(f"Planner suggestion {suggestion_index} has no review decision for goal {goal_id}")
+    if existing_review["decision"] == "created":
+        raise ConflictError(
+            f"Planner suggestion already exists as task {existing_review['task_id']} for goal {goal_id}"
+        )
+    timestamp = now_utc()
+    with services.db.transaction() as tx:
+        tx.execute(
+            "DELETE FROM planner_suggestion_reviews WHERE goal_id = ? AND suggestion_index = ?",
+            goal_id,
+            suggestion_index,
+        )
+        services.event_bus.record_event(
+            "planner.suggestion_review_reopened",
+            goal_id,
+            f"{goal_id}:planner:{suggestion_index}",
+            {
+                "goal_id": goal_id,
+                "suggestion_index": suggestion_index,
+                "cleared_decision": existing_review["decision"],
+                "cleared_comment": existing_review["comment"],
+                "source": existing_review["planner_source"],
+                "reopened_at": timestamp,
+            },
+            tx=tx,
+        )
+    return existing_review
+
+
 @router.post("/{goal_id}/plan", response_model=PlannerPreviewResponse)
 def preview_goal_plan(goal_id: str, services: AppServices = Depends(get_services)) -> dict:
     return _preview_goal_plan(goal_id, services)
@@ -307,6 +341,25 @@ def review_plan_suggestion(
         "suggestion_index": request.suggestion_index,
         "suggestion": refreshed_suggestion,
         "review": review,
+    }
+
+
+@router.delete("/{goal_id}/plan/reviews/{suggestion_index}", response_model=PlannerReviewReopenResponse)
+def reopen_plan_suggestion_review(
+    goal_id: str,
+    suggestion_index: int,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    plan = _preview_goal_plan(goal_id, services)
+    _get_plan_suggestion(plan, suggestion_index, goal_id)
+    cleared_review = _reopen_planner_review(goal_id, suggestion_index, services)
+    refreshed_plan = _preview_goal_plan(goal_id, services)
+    refreshed_suggestion = _get_plan_suggestion(refreshed_plan, suggestion_index, goal_id)
+    return {
+        "goal_id": goal_id,
+        "suggestion_index": suggestion_index,
+        "suggestion": refreshed_suggestion,
+        "cleared_review": cleared_review,
     }
 
 

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -592,6 +592,9 @@ function renderPlannerSuggestionReviewControls(item, index) {
       <div class="entity-divider"></div>
       <div class="meta">Review decision: ${escapeHtml(decision)}</div>
       ${comment}
+      <div class="actions">
+        <button type="button" class="secondary" data-mutation-control="true" data-plan-review-reopen-index="${index}">Reopen review</button>
+      </div>
     `;
   }
   if (item.task_exists || decision === "created") {
@@ -620,7 +623,9 @@ function renderPlannerPreview(preview) {
     return;
   }
   const suggestions = preview.suggestions || [];
-  const selectableCount = suggestions.filter((item) => !item.task_exists).length;
+  const selectableCount = suggestions.filter((item) => (
+    !item.task_exists && plannerSuggestionDecision(item) === "pending"
+  )).length;
   container.innerHTML = `
     <span class="meta">Planner Preview · ${escapeHtml(preview.source)}</span>
     <h3>${escapeHtml(preview.goal_title)}</h3>
@@ -1601,6 +1606,29 @@ async function reviewPlannerSuggestion(indexValue, decision) {
   await runPlannerPreview(goalId);
 }
 
+async function reopenPlannerSuggestionReview(indexValue) {
+  if (!plannerPreview?.goal_id) {
+    throw new Error("Run Plan Preview before reopening a suggested task review.");
+  }
+  const suggestionIndex = parsePlannerSuggestionIndex(indexValue);
+  const goalId = plannerPreview.goal_id;
+  ensureMutationAllowed("Planner review reopen");
+  const response = await api(
+    `/goals/${encodeURIComponent(goalId)}/plan/reviews/${encodeURIComponent(suggestionIndex)}`,
+    { method: "DELETE" },
+  );
+  document.getElementById("system-feedback").textContent = (
+    `Planner suggestion #${response.suggestion_index + 1} reopened from ${response.cleared_review.decision}.`
+  );
+  selectedGoalId = goalId;
+  document.getElementById("task-goal-id").value = goalId;
+  document.getElementById("event-correlation-id").value = goalId;
+  document.getElementById("trace-goal-id").value = goalId;
+  document.getElementById("fault-goal-id").value = goalId;
+  await refreshAll();
+  await runPlannerPreview(goalId);
+}
+
 async function createTaskFromPlannerSuggestion(indexValue) {
   if (!plannerPreview?.goal_id) {
     throw new Error("Run Plan Preview before creating a suggested task.");
@@ -2028,6 +2056,7 @@ document.addEventListener("click", async (event) => {
   const planSuggestionIndex = event.target.dataset.planSuggestionIndex;
   const planReviewIndex = event.target.dataset.planReviewIndex;
   const planReviewDecision = event.target.dataset.planReviewDecision;
+  const planReviewReopenIndex = event.target.dataset.planReviewReopenIndex;
   const planBulkCreate = event.target.dataset.planBulkCreate;
   const operatorAction = event.target.dataset.operatorAction;
   const jumpTarget = event.target.dataset.jumpTarget;
@@ -2079,6 +2108,11 @@ document.addEventListener("click", async (event) => {
     if (planReviewIndex !== undefined && planReviewDecision) {
       showError("task-error", null);
       await reviewPlannerSuggestion(planReviewIndex, planReviewDecision);
+    }
+
+    if (planReviewReopenIndex !== undefined) {
+      showError("task-error", null);
+      await reopenPlannerSuggestionReview(planReviewReopenIndex);
     }
 
     if (planBulkCreate) {

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -15926,6 +15926,62 @@ def test_272h_goal_plan_review_duplicate_decision_returns_409(client):
     assert "already has review decision deferred" in second.json()["detail"]
 
 
+def test_272i_goal_plan_review_reopen_clears_decision_and_allows_task_create(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Reopen deferred planner review", "urgency": 0.5, "value": 0.6, "deadline_score": 0.2},
+    ).json()
+
+    deferred = client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 0, "decision": "deferred", "comment": "Needs sequencing."},
+    ).json()
+    reopened = client.delete(f"/goals/{goal['goal_id']}/plan/reviews/0")
+    after_reopen = client.post(f"/goals/{goal['goal_id']}/plan").json()
+    created = client.post(f"/goals/{goal['goal_id']}/plan/tasks", json={"suggestion_index": 0})
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    assert reopened.status_code == 200
+    payload = reopened.json()
+    assert payload["cleared_review"]["decision"] == "deferred"
+    assert payload["cleared_review"]["comment"] == deferred["review"]["comment"]
+    assert payload["suggestion"]["review_decision"] == "pending"
+    assert payload["suggestion"]["review_comment"] is None
+    assert after_reopen["suggestions"][0]["review_decision"] == "pending"
+    assert created.status_code == 201
+    assert created.json()["review"]["decision"] == "created"
+    assert len(tasks) == 1
+
+
+def test_272j_goal_plan_review_reopen_created_decision_returns_409(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Cannot reopen created planner review", "urgency": 0.5, "value": 0.6, "deadline_score": 0.2},
+    ).json()
+    created = client.post(f"/goals/{goal['goal_id']}/plan/tasks", json={"suggestion_index": 0}).json()
+
+    response = client.delete(f"/goals/{goal['goal_id']}/plan/reviews/0")
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    assert response.status_code == 409
+    assert created["task"]["task_id"] in response.json()["detail"]
+    assert len(tasks) == 1
+
+
+def test_272k_goal_plan_review_reopen_missing_decision_returns_404(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Missing planner review reopen", "urgency": 0.5, "value": 0.6, "deadline_score": 0.2},
+    ).json()
+
+    response = client.delete(f"/goals/{goal['goal_id']}/plan/reviews/0")
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == f"Planner suggestion 0 has no review decision for goal {goal['goal_id']}"
+    assert tasks == []
+
+
 def test_273_goal_plan_task_create_unknown_goal_returns_404(client):
     response = client.post("/goals/missing-goal/plan/tasks", json={"suggestion_index": 0})
 


### PR DESCRIPTION
﻿## Summary
- add a supervised reopen path for deferred or rejected planner suggestion reviews
- expose `DELETE /goals/{goal_id}/plan/reviews/{suggestion_index}` to clear a non-created review decision
- add a UI `Reopen review` action so deferred suggestions can become pending again and later create tasks explicitly

## Stability scope
- no CI/Guard workflow changes
- no schema migration or external dependency changes
- `created` reviews remain protected because they already point at tasks
- `artifacts/` remains untracked and untouched

## Validation
- `python -m pytest tests/test_goal_ops.py -q -k "planner or goal_plan or task_planner"`
- `node --check goal_ops_console\static\app.js`
- `python -m pytest`
- `git diff --check`
- Browser smoke: local temp DB, create goal, defer suggestion, reopen review, create task from reopened suggestion, confirm exactly one task
