### PR TITLE
[codex] Add planner review summary

### DIFF
--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -143,6 +143,22 @@ class PlannerReviewReopenResponse(BaseModel):
     cleared_review: PlannerSuggestionReview
 
 
+class PlannerReviewSummary(BaseModel):
+    total_suggestions: int
+    pending: int
+    created: int
+    deferred: int
+    rejected: int
+
+
+class PlannerReviewListResponse(BaseModel):
+    goal_id: str
+    goal_title: str
+    source: str
+    summary: PlannerReviewSummary
+    reviews: list[PlannerSuggestionReview]
+
+
 class PlannerTaskCreateResponse(BaseModel):
     goal_id: str
     suggestion_index: int

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -14,6 +14,7 @@ from goal_ops_console.models import (
     PlannerPreviewResponse,
     PlannerReviewDecisionRequest,
     PlannerReviewDecisionResponse,
+    PlannerReviewListResponse,
     PlannerReviewReopenResponse,
     PlannerTaskCreateRequest,
     PlannerTaskCreateResponse,
@@ -164,6 +165,35 @@ def _planner_reviews_by_index(goal_id: str, services: AppServices) -> dict[int, 
     return {int(row["suggestion_index"]): _planner_review_from_row(row) for row in rows}
 
 
+def _planner_review_summary(plan: dict) -> dict:
+    summary = {
+        "total_suggestions": len(plan["suggestions"]),
+        "pending": 0,
+        "created": 0,
+        "deferred": 0,
+        "rejected": 0,
+    }
+    for suggestion in plan["suggestions"]:
+        decision = suggestion["review_decision"]
+        summary[decision] += 1
+    return summary
+
+
+def _planner_review_list(goal_id: str, services: AppServices) -> dict:
+    plan = _preview_goal_plan(goal_id, services)
+    reviews = sorted(
+        _planner_reviews_by_index(goal_id, services).values(),
+        key=lambda review: review["suggestion_index"],
+    )
+    return {
+        "goal_id": plan["goal_id"],
+        "goal_title": plan["goal_title"],
+        "source": plan["source"],
+        "summary": _planner_review_summary(plan),
+        "reviews": reviews,
+    }
+
+
 def _get_planner_review(goal_id: str, suggestion_index: int, services: AppServices) -> dict | None:
     row = services.db.fetch_one(
         """SELECT goal_id,
@@ -312,6 +342,14 @@ def _reopen_planner_review(goal_id: str, suggestion_index: int, services: AppSer
 @router.post("/{goal_id}/plan", response_model=PlannerPreviewResponse)
 def preview_goal_plan(goal_id: str, services: AppServices = Depends(get_services)) -> dict:
     return _preview_goal_plan(goal_id, services)
+
+
+@router.get("/{goal_id}/plan/reviews", response_model=PlannerReviewListResponse)
+def list_plan_suggestion_reviews(
+    goal_id: str,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return _planner_review_list(goal_id, services)
 
 
 @router.post("/{goal_id}/plan/reviews", status_code=201, response_model=PlannerReviewDecisionResponse)

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -612,6 +612,59 @@ function renderPlannerSuggestionReviewControls(item, index) {
   `;
 }
 
+function plannerReviewSummaryFromSuggestions(suggestions) {
+  return (suggestions || []).reduce((summary, item) => {
+    const decision = plannerSuggestionDecision(item);
+    summary.total_suggestions += 1;
+    if (decision in summary) {
+      summary[decision] += 1;
+    }
+    return summary;
+  }, {
+    total_suggestions: 0,
+    pending: 0,
+    created: 0,
+    deferred: 0,
+    rejected: 0,
+  });
+}
+
+function plannerReviewQueue(preview) {
+  return preview.review_queue || {
+    summary: plannerReviewSummaryFromSuggestions(preview.suggestions || []),
+    reviews: [],
+  };
+}
+
+function renderPlannerReviewSummary(preview) {
+  const queue = plannerReviewQueue(preview);
+  const summary = queue.summary || plannerReviewSummaryFromSuggestions(preview.suggestions || []);
+  const reviews = queue.reviews || [];
+  const reviewItems = reviews.length
+    ? reviews.map((review) => {
+      const taskId = review.task_id ? ` | task ${escapeHtml(review.task_id)}` : "";
+      const comment = review.comment ? ` | ${escapeHtml(review.comment)}` : "";
+      return (
+        `<div class="meta">#${Number(review.suggestion_index) + 1} `
+        + `${escapeHtml(review.decision)} | ${escapeHtml(review.suggestion_title)}`
+        + `${taskId}${comment}</div>`
+      );
+    }).join("")
+    : `<div class="meta">No saved review decisions yet.</div>`;
+  return `
+    <div class="entity-grid" style="margin-top:0.75rem;">
+      <div class="entity-metric"><span class="meta">Pending</span><strong>${summary.pending}</strong></div>
+      <div class="entity-metric"><span class="meta">Created</span><strong>${summary.created}</strong></div>
+      <div class="entity-metric"><span class="meta">Deferred</span><strong>${summary.deferred}</strong></div>
+      <div class="entity-metric"><span class="meta">Rejected</span><strong>${summary.rejected}</strong></div>
+    </div>
+    <details style="margin-top:0.75rem;">
+      <summary class="meta">Saved review decisions (${reviews.length})</summary>
+      <div class="stack-list" style="margin-top:0.5rem;">${reviewItems}</div>
+    </details>
+  `;
+}
+
 function renderPlannerPreview(preview) {
   const container = document.getElementById("planner-preview");
   if (!container) return;
@@ -627,9 +680,10 @@ function renderPlannerPreview(preview) {
     !item.task_exists && plannerSuggestionDecision(item) === "pending"
   )).length;
   container.innerHTML = `
-    <span class="meta">Planner Preview · ${escapeHtml(preview.source)}</span>
+    <span class="meta">Planner Preview &middot; ${escapeHtml(preview.source)}</span>
     <h3>${escapeHtml(preview.goal_title)}</h3>
-    <div class="meta">${escapeHtml(preview.goal_id)} · ${suggestions.length} suggested tasks · no tasks created automatically</div>
+    <div class="meta">${escapeHtml(preview.goal_id)} &middot; ${suggestions.length} suggested tasks &middot; no tasks created automatically</div>
+    ${renderPlannerReviewSummary(preview)}
     <div class="actions" style="margin-top:0.75rem;">
       <button type="button" class="secondary" data-mutation-control="true" data-plan-bulk-create="true" ${selectableCount ? "" : "disabled"}>Create selected tasks</button>
       <span class="meta">${selectableCount} selectable suggestions</span>
@@ -1511,7 +1565,8 @@ async function runPlannerPreview(goalId) {
     throw new Error("Select a goal before requesting a plan preview.");
   }
   const preview = await api(`/goals/${encodeURIComponent(goalId)}/plan`, { method: "POST" });
-  plannerPreview = preview;
+  const reviewQueue = await api(`/goals/${encodeURIComponent(goalId)}/plan/reviews`);
+  plannerPreview = { ...preview, review_queue: reviewQueue };
   selectedGoalId = goalId;
   document.getElementById("task-goal-id").value = goalId;
   document.getElementById("event-correlation-id").value = goalId;

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -15982,6 +15982,81 @@ def test_272k_goal_plan_review_reopen_missing_decision_returns_404(client):
     assert tasks == []
 
 
+def test_272l_goal_plan_review_list_returns_summary_and_saved_decisions(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Summarize planner reviews", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    preview = client.post(f"/goals/{goal['goal_id']}/plan").json()
+    total = len(preview["suggestions"])
+
+    deferred = client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 0, "decision": "deferred", "comment": "Wait for dependency."},
+    ).json()
+    rejected = client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 1, "decision": "rejected", "comment": "Not aligned."},
+    ).json()
+    created = client.post(f"/goals/{goal['goal_id']}/plan/tasks", json={"suggestion_index": 2}).json()
+
+    response = client.get(f"/goals/{goal['goal_id']}/plan/reviews")
+    payload = response.json()
+
+    assert response.status_code == 200
+    assert payload["goal_id"] == goal["goal_id"]
+    assert payload["goal_title"] == goal["title"]
+    assert payload["source"] == "deterministic_planner"
+    assert payload["summary"] == {
+        "total_suggestions": total,
+        "pending": total - 3,
+        "created": 1,
+        "deferred": 1,
+        "rejected": 1,
+    }
+    assert [review["suggestion_index"] for review in payload["reviews"]] == [0, 1, 2]
+    assert [review["decision"] for review in payload["reviews"]] == ["deferred", "rejected", "created"]
+    assert payload["reviews"][0]["updated_at"] == deferred["review"]["updated_at"]
+    assert payload["reviews"][1]["updated_at"] == rejected["review"]["updated_at"]
+    assert payload["reviews"][2]["task_id"] == created["task"]["task_id"]
+
+
+def test_272m_goal_plan_review_list_unknown_goal_returns_404(client):
+    response = client.get("/goals/missing-goal/plan/reviews")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Goal missing-goal not found"
+
+
+def test_272n_goal_plan_review_list_updates_after_reopen(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Summarize reopened planner review", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    preview = client.post(f"/goals/{goal['goal_id']}/plan").json()
+    total = len(preview["suggestions"])
+
+    client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 0, "decision": "deferred"},
+    )
+    before = client.get(f"/goals/{goal['goal_id']}/plan/reviews").json()
+    reopened = client.delete(f"/goals/{goal['goal_id']}/plan/reviews/0")
+    after = client.get(f"/goals/{goal['goal_id']}/plan/reviews").json()
+
+    assert before["summary"]["deferred"] == 1
+    assert len(before["reviews"]) == 1
+    assert reopened.status_code == 200
+    assert after["summary"] == {
+        "total_suggestions": total,
+        "pending": total,
+        "created": 0,
+        "deferred": 0,
+        "rejected": 0,
+    }
+    assert after["reviews"] == []
+
+
 def test_273_goal_plan_task_create_unknown_goal_returns_404(client):
     response = client.post("/goals/missing-goal/plan/tasks", json={"suggestion_index": 0})
 


### PR DESCRIPTION
﻿## Summary
- Add a read-only planner review summary endpoint for existing goal plan suggestions.
- Render pending/created/deferred/rejected review counts in the Plan Preview UI.
- Show saved planner review decisions in a compact review queue without auto-creating tasks.

## Validation
- `python -m pytest tests/test_goal_ops.py -q -k "planner or goal_plan or task_planner"`
- `python -m pytest`
- `node --check goal_ops_console\static\app.js`
- `git diff --check`
- Local browser smoke against `http://127.0.0.1:8765/` covering plan preview, defer, reopen, and create-task flow.

## Notes
- No CI/Guard workflow changes.
- No external AI, Qdrant, or LLM dependency added.
- `artifacts/` remains untracked and untouched.
