### PR TITLE
[codex] Add planner review inbox

### DIFF
--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -159,6 +159,30 @@ class PlannerReviewListResponse(BaseModel):
     reviews: list[PlannerSuggestionReview]
 
 
+class PlannerReviewInboxItem(BaseModel):
+    goal_id: str
+    goal_title: str
+    state: str
+    source: str
+    summary: PlannerReviewSummary
+    last_reviewed_at: str | None = None
+    needs_review: bool
+
+
+class PlannerReviewInboxSummary(BaseModel):
+    total_goals: int
+    goals_needing_review: int
+    pending_suggestions: int
+    created: int
+    deferred: int
+    rejected: int
+
+
+class PlannerReviewInboxResponse(BaseModel):
+    summary: PlannerReviewInboxSummary
+    items: list[PlannerReviewInboxItem]
+
+
 class PlannerTaskCreateResponse(BaseModel):
     goal_id: str
     suggestion_index: int

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -14,6 +14,7 @@ from goal_ops_console.models import (
     PlannerPreviewResponse,
     PlannerReviewDecisionRequest,
     PlannerReviewDecisionResponse,
+    PlannerReviewInboxResponse,
     PlannerReviewListResponse,
     PlannerReviewReopenResponse,
     PlannerTaskCreateRequest,
@@ -194,6 +195,43 @@ def _planner_review_list(goal_id: str, services: AppServices) -> dict:
     }
 
 
+def _planner_review_inbox_item(goal: dict, services: AppServices) -> dict:
+    review_list = _planner_review_list(goal["goal_id"], services)
+    summary = review_list["summary"]
+    reviews = review_list["reviews"]
+    return {
+        "goal_id": review_list["goal_id"],
+        "goal_title": review_list["goal_title"],
+        "state": goal["state"],
+        "source": review_list["source"],
+        "summary": summary,
+        "last_reviewed_at": max((review["updated_at"] for review in reviews), default=None),
+        "needs_review": summary["pending"] > 0,
+    }
+
+
+def _planner_review_inbox(services: AppServices) -> dict:
+    items = [_planner_review_inbox_item(goal, services) for goal in services.state_manager.list_goals()]
+    items.sort(
+        key=lambda item: (
+            0 if item["needs_review"] else 1,
+            item["last_reviewed_at"] or "",
+            item["goal_title"].lower(),
+        )
+    )
+    return {
+        "summary": {
+            "total_goals": len(items),
+            "goals_needing_review": sum(1 for item in items if item["needs_review"]),
+            "pending_suggestions": sum(item["summary"]["pending"] for item in items),
+            "created": sum(item["summary"]["created"] for item in items),
+            "deferred": sum(item["summary"]["deferred"] for item in items),
+            "rejected": sum(item["summary"]["rejected"] for item in items),
+        },
+        "items": items,
+    }
+
+
 def _get_planner_review(goal_id: str, suggestion_index: int, services: AppServices) -> dict | None:
     row = services.db.fetch_one(
         """SELECT goal_id,
@@ -350,6 +388,11 @@ def list_plan_suggestion_reviews(
     services: AppServices = Depends(get_services),
 ) -> dict:
     return _planner_review_list(goal_id, services)
+
+
+@router.get("/planner/reviews", response_model=PlannerReviewInboxResponse)
+def list_planner_review_inbox(services: AppServices = Depends(get_services)) -> dict:
+    return _planner_review_inbox(services)
 
 
 @router.post("/{goal_id}/plan/reviews", status_code=201, response_model=PlannerReviewDecisionResponse)

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -47,6 +47,7 @@ const MUTATION_LOCK_FALLBACK_MESSAGE = (
 
 const viewCache = {
   goals: [],
+  plannerReviewInbox: null,
   tasks: [],
   workflows: [],
   workflowRuns: [],
@@ -452,6 +453,7 @@ function setAutoRefresh(enabled) {
 
 function rerenderFilteredViews() {
   renderGoals(viewCache.goals);
+  renderPlannerReviewInbox(viewCache.plannerReviewInbox);
   renderTasks(viewCache.tasks);
   renderWorkflows(viewCache.workflows, viewCache.workflowRuns);
   renderEvents(viewCache.events);
@@ -662,6 +664,62 @@ function renderPlannerReviewSummary(preview) {
       <summary class="meta">Saved review decisions (${reviews.length})</summary>
       <div class="stack-list" style="margin-top:0.5rem;">${reviewItems}</div>
     </details>
+  `;
+}
+
+function renderPlannerReviewInbox(payload) {
+  const container = document.getElementById("planner-review-inbox");
+  if (!container) return;
+  if (!payload) {
+    container.innerHTML = `
+      <span class="meta">Planner Review Inbox</span>
+      <p class="meta">Review coverage is loading.</p>
+    `;
+    return;
+  }
+  const summary = payload.summary || {};
+  const items = filterRows(payload.items || [], (item) => [
+    item.goal_id,
+    item.goal_title,
+    item.state,
+    item.needs_review ? "needs review" : "reviewed",
+  ]);
+  const itemMarkup = items.length
+    ? items.map((item) => {
+      const reviewState = item.needs_review ? "Needs review" : "Reviewed";
+      const lastReviewed = item.last_reviewed_at || "no saved decisions";
+      const itemSummary = item.summary || {};
+      return `
+        <article class="entity-card ${selectedGoalId === item.goal_id ? "selected" : ""}">
+          <div class="entity-header">
+            <div>
+              <div class="entity-title">${escapeHtml(item.goal_title)}</div>
+              <div class="meta">${escapeHtml(item.goal_id)} &middot; ${escapeHtml(lastReviewed)}</div>
+            </div>
+            <span class="pill ${item.needs_review ? "state-degraded" : "state-ok"}">${reviewState}</span>
+          </div>
+          <div class="entity-grid">
+            <div class="entity-metric"><span class="meta">Pending</span><strong>${itemSummary.pending || 0}</strong></div>
+            <div class="entity-metric"><span class="meta">Created</span><strong>${itemSummary.created || 0}</strong></div>
+            <div class="entity-metric"><span class="meta">Deferred</span><strong>${itemSummary.deferred || 0}</strong></div>
+            <div class="entity-metric"><span class="meta">Rejected</span><strong>${itemSummary.rejected || 0}</strong></div>
+          </div>
+          <div class="actions" style="margin-top:0.75rem;">
+            <button type="button" class="secondary" data-plan-goal="${escapeHtml(item.goal_id)}">Open Plan Preview</button>
+          </div>
+        </article>
+      `;
+    }).join("")
+    : `<div class="meta">${filteredEmptyMessage("No planner review items yet.")}</div>`;
+  container.innerHTML = `
+    <span class="meta">Planner Review Inbox &middot; ${summary.total_goals || 0} goals</span>
+    <div class="entity-grid" style="margin-top:0.75rem;">
+      <div class="entity-metric"><span class="meta">Needs Review</span><strong>${summary.goals_needing_review || 0}</strong></div>
+      <div class="entity-metric"><span class="meta">Pending</span><strong>${summary.pending_suggestions || 0}</strong></div>
+      <div class="entity-metric"><span class="meta">Created</span><strong>${summary.created || 0}</strong></div>
+      <div class="entity-metric"><span class="meta">Deferred</span><strong>${summary.deferred || 0}</strong></div>
+    </div>
+    <div class="stack-list" style="margin-top:0.75rem;">${itemMarkup}</div>
   `;
 }
 
@@ -1363,6 +1421,12 @@ async function refreshGoals() {
   updateSelectedGoalLabel();
 }
 
+async function refreshPlannerReviewInbox() {
+  const inbox = await api("/goals/planner/reviews");
+  viewCache.plannerReviewInbox = inbox;
+  renderPlannerReviewInbox(viewCache.plannerReviewInbox);
+}
+
 async function refreshWorkflows() {
   const [workflowPayload, runPayload] = await Promise.all([
     api("/workflows"),
@@ -1488,6 +1552,7 @@ async function refreshHealth() {
 async function refreshAll() {
   await Promise.all([
     refreshGoals(),
+    refreshPlannerReviewInbox(),
     refreshTasks(),
     refreshWorkflows(),
     refreshEvents(),
@@ -1508,6 +1573,7 @@ function startAutoRefreshLoop() {
       return;
     }
     refreshGoals().catch(() => {});
+    refreshPlannerReviewInbox().catch(() => {});
     refreshTasks().catch(() => {});
     refreshWorkflows().catch(() => {});
     refreshEvents().catch(() => {});
@@ -2008,7 +2074,9 @@ document.getElementById("flow-trace-form").addEventListener("submit", async (eve
   await refreshFlowTrace();
 });
 
-document.getElementById("refresh-goals").addEventListener("click", refreshGoals);
+document.getElementById("refresh-goals").addEventListener("click", async () => {
+  await Promise.all([refreshGoals(), refreshPlannerReviewInbox()]);
+});
 document.getElementById("refresh-tasks").addEventListener("click", refreshTasks);
 document.getElementById("refresh-workflows").addEventListener("click", refreshWorkflows);
 document.getElementById("refresh-events").addEventListener("click", refreshEvents);

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -842,6 +842,10 @@
         <span class="meta">Planner Preview</span>
         <p class="meta">Select a goal and use Plan Preview to generate deterministic task suggestions. Suggestions are read-only until you create tasks explicitly.</p>
       </div>
+      <div id="planner-review-inbox" class="card" aria-live="polite">
+        <span class="meta">Planner Review Inbox</span>
+        <p class="meta">Review coverage is loading.</p>
+      </div>
       <div id="goals-table"></div>
     </section>
 

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -16057,6 +16057,126 @@ def test_272n_goal_plan_review_list_updates_after_reopen(client):
     assert after["reviews"] == []
 
 
+def test_272o_goal_planner_review_inbox_returns_goal_rollup(client):
+    pending_goal = client.post(
+        "/goals",
+        json={"title": "Inbox pending planner review", "urgency": 0.6, "value": 0.5, "deadline_score": 0.2},
+    ).json()
+    mixed_goal = client.post(
+        "/goals",
+        json={"title": "Inbox mixed planner review", "urgency": 0.7, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    reviewed_goal = client.post(
+        "/goals",
+        json={"title": "Inbox reviewed planner suggestions", "urgency": 0.5, "value": 0.8, "deadline_score": 0.2},
+    ).json()
+    pending_total = len(client.post(f"/goals/{pending_goal['goal_id']}/plan").json()["suggestions"])
+    mixed_total = len(client.post(f"/goals/{mixed_goal['goal_id']}/plan").json()["suggestions"])
+    reviewed_total = len(client.post(f"/goals/{reviewed_goal['goal_id']}/plan").json()["suggestions"])
+
+    client.post(
+        f"/goals/{mixed_goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 0, "decision": "deferred", "comment": "Wait for sequencing."},
+    )
+    client.post(
+        f"/goals/{mixed_goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 1, "decision": "rejected", "comment": "Not this cycle."},
+    )
+    client.post(f"/goals/{mixed_goal['goal_id']}/plan/tasks", json={"suggestion_index": 2})
+    client.post(
+        f"/goals/{reviewed_goal['goal_id']}/plan/tasks/bulk",
+        json={"suggestion_indexes": list(range(reviewed_total)), "overrides": {}},
+    )
+
+    response = client.get("/goals/planner/reviews")
+    payload = response.json()
+    items_by_goal = {item["goal_id"]: item for item in payload["items"]}
+
+    assert response.status_code == 200
+    assert payload["summary"] == {
+        "total_goals": 3,
+        "goals_needing_review": 2,
+        "pending_suggestions": pending_total + mixed_total - 3,
+        "created": reviewed_total + 1,
+        "deferred": 1,
+        "rejected": 1,
+    }
+    assert [item["goal_id"] for item in payload["items"][:2]] == [pending_goal["goal_id"], mixed_goal["goal_id"]]
+    assert payload["items"][2]["goal_id"] == reviewed_goal["goal_id"]
+    assert items_by_goal[pending_goal["goal_id"]]["summary"]["pending"] == pending_total
+    assert items_by_goal[pending_goal["goal_id"]]["needs_review"] is True
+    assert items_by_goal[pending_goal["goal_id"]]["last_reviewed_at"] is None
+    assert items_by_goal[mixed_goal["goal_id"]]["summary"] == {
+        "total_suggestions": mixed_total,
+        "pending": mixed_total - 3,
+        "created": 1,
+        "deferred": 1,
+        "rejected": 1,
+    }
+    assert items_by_goal[mixed_goal["goal_id"]]["needs_review"] is True
+    assert items_by_goal[mixed_goal["goal_id"]]["last_reviewed_at"] is not None
+    assert items_by_goal[reviewed_goal["goal_id"]]["summary"]["pending"] == 0
+    assert items_by_goal[reviewed_goal["goal_id"]]["needs_review"] is False
+
+
+def test_272p_goal_planner_review_inbox_empty_state(client):
+    response = client.get("/goals/planner/reviews")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "summary": {
+            "total_goals": 0,
+            "goals_needing_review": 0,
+            "pending_suggestions": 0,
+            "created": 0,
+            "deferred": 0,
+            "rejected": 0,
+        },
+        "items": [],
+    }
+
+
+def test_272q_goal_planner_review_inbox_is_read_only(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Inbox read only", "urgency": 0.6, "value": 0.6, "deadline_score": 0.2},
+    ).json()
+    before_tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    response = client.get("/goals/planner/reviews")
+    after_tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+    reviews = client.get(f"/goals/{goal['goal_id']}/plan/reviews").json()["reviews"]
+
+    assert response.status_code == 200
+    assert before_tasks == []
+    assert after_tasks == []
+    assert reviews == []
+
+
+def test_272r_goal_planner_review_inbox_updates_after_reopen(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Inbox reopened review", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    total = len(client.post(f"/goals/{goal['goal_id']}/plan").json()["suggestions"])
+
+    client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 0, "decision": "deferred"},
+    )
+    before = client.get("/goals/planner/reviews").json()["items"][0]
+    reopened = client.delete(f"/goals/{goal['goal_id']}/plan/reviews/0")
+    after = client.get("/goals/planner/reviews").json()["items"][0]
+
+    assert before["summary"]["pending"] == total - 1
+    assert before["summary"]["deferred"] == 1
+    assert before["last_reviewed_at"] is not None
+    assert reopened.status_code == 200
+    assert after["summary"]["pending"] == total
+    assert after["summary"]["deferred"] == 0
+    assert after["last_reviewed_at"] is None
+
+
 def test_273_goal_plan_task_create_unknown_goal_returns_404(client):
     response = client.post("/goals/missing-goal/plan/tasks", json={"suggestion_index": 0})
 


### PR DESCRIPTION
﻿## Summary
- Add a read-only Planner Review Inbox endpoint at `/goals/planner/reviews`.
- Render a Planner Review Inbox card that summarizes Goals needing review and opens the existing Plan Preview flow.
- Keep the flow supervised: inbox reads review coverage only and does not auto-create tasks.

## Validation
- `python -m pytest tests/test_goal_ops.py -q -k "planner_review_inbox or goal_plan_review or planner or goal_plan or task_planner"`
- `python -m pytest`
- `node --check goal_ops_console\static\app.js`
- `git diff --check`
- Local browser smoke against `http://127.0.0.1:8766/` covering inbox render, Open Plan Preview, defer, and no task creation.

## Notes
- No CI/Guard workflow changes.
- No external AI, Qdrant, or LLM dependency added.
- `artifacts/` remains untracked and untouched.
