### PR TITLE
[codex] Add planner review inbox triage

### DIFF
--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, Depends
 
@@ -210,15 +210,35 @@ def _planner_review_inbox_item(goal: dict, services: AppServices) -> dict:
     }
 
 
-def _planner_review_inbox(services: AppServices) -> dict:
-    items = [_planner_review_inbox_item(goal, services) for goal in services.state_manager.list_goals()]
-    items.sort(
+def _filter_planner_review_inbox_items(items: list[dict], status: str) -> list[dict]:
+    if status == "needs_review":
+        return [item for item in items if item["needs_review"]]
+    if status == "reviewed":
+        return [item for item in items if not item["needs_review"]]
+    return items
+
+
+def _sort_planner_review_inbox_items(items: list[dict], sort: str) -> list[dict]:
+    if sort == "goal_title":
+        return sorted(items, key=lambda item: item["goal_title"].lower())
+    if sort == "last_reviewed_at":
+        sorted_items = sorted(items, key=lambda item: item["goal_title"].lower())
+        sorted_items.sort(key=lambda item: item["last_reviewed_at"] or "", reverse=True)
+        return sorted_items
+    return sorted(
+        items,
         key=lambda item: (
             0 if item["needs_review"] else 1,
             item["last_reviewed_at"] or "",
             item["goal_title"].lower(),
-        )
+        ),
     )
+
+
+def _planner_review_inbox(services: AppServices, status: str = "all", sort: str = "needs_review") -> dict:
+    items = [_planner_review_inbox_item(goal, services) for goal in services.state_manager.list_goals()]
+    items = _filter_planner_review_inbox_items(items, status)
+    items = _sort_planner_review_inbox_items(items, sort)
     return {
         "summary": {
             "total_goals": len(items),
@@ -391,8 +411,12 @@ def list_plan_suggestion_reviews(
 
 
 @router.get("/planner/reviews", response_model=PlannerReviewInboxResponse)
-def list_planner_review_inbox(services: AppServices = Depends(get_services)) -> dict:
-    return _planner_review_inbox(services)
+def list_planner_review_inbox(
+    status: Literal["all", "needs_review", "reviewed"] = "all",
+    sort: Literal["needs_review", "last_reviewed_at", "goal_title"] = "needs_review",
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return _planner_review_inbox(services, status=status, sort=sort)
 
 
 @router.post("/{goal_id}/plan/reviews", status_code=201, response_model=PlannerReviewDecisionResponse)

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -41,6 +41,8 @@ let densityMode = "comfy";
 let visualMode = "warm";
 let globalFilterTerm = "";
 let jumpScrollScheduled = false;
+let plannerReviewInboxStatus = "needs_review";
+let plannerReviewInboxSort = "needs_review";
 const MUTATION_LOCK_FALLBACK_MESSAGE = (
   "Mutating operations are blocked while runtime is in critical protection mode."
 );
@@ -638,6 +640,20 @@ function plannerReviewQueue(preview) {
   };
 }
 
+function plannerReviewInboxVisibleItems(payload) {
+  return filterRows(payload?.items || [], (item) => [
+    item.goal_id,
+    item.goal_title,
+    item.state,
+    item.needs_review ? "needs review" : "reviewed",
+  ]);
+}
+
+function nextPlannerReviewGoalId() {
+  return plannerReviewInboxVisibleItems(viewCache.plannerReviewInbox)
+    .find((item) => item.needs_review)?.goal_id || "";
+}
+
 function renderPlannerReviewSummary(preview) {
   const queue = plannerReviewQueue(preview);
   const summary = queue.summary || plannerReviewSummaryFromSuggestions(preview.suggestions || []);
@@ -678,12 +694,16 @@ function renderPlannerReviewInbox(payload) {
     return;
   }
   const summary = payload.summary || {};
-  const items = filterRows(payload.items || [], (item) => [
-    item.goal_id,
-    item.goal_title,
-    item.state,
-    item.needs_review ? "needs review" : "reviewed",
-  ]);
+  const items = plannerReviewInboxVisibleItems(payload);
+  const nextReviewItem = items.find((item) => item.needs_review);
+  const statusButtons = [
+    ["needs_review", "Needs review"],
+    ["reviewed", "Reviewed"],
+    ["all", "All"],
+  ].map(([status, label]) => (
+    `<button type="button" class="secondary ${plannerReviewInboxStatus === status ? "active" : ""}" `
+    + `data-plan-inbox-status="${status}">${label}</button>`
+  )).join("");
   const itemMarkup = items.length
     ? items.map((item) => {
       const reviewState = item.needs_review ? "Needs review" : "Reviewed";
@@ -713,6 +733,20 @@ function renderPlannerReviewInbox(payload) {
     : `<div class="meta">${filteredEmptyMessage("No planner review items yet.")}</div>`;
   container.innerHTML = `
     <span class="meta">Planner Review Inbox &middot; ${summary.total_goals || 0} goals</span>
+    <div class="actions" style="margin-top:0.75rem;">
+      ${statusButtons}
+      <label class="meta">
+        Sort
+        <select data-plan-inbox-sort="true">
+          <option value="needs_review" ${plannerReviewInboxSort === "needs_review" ? "selected" : ""}>Needs review first</option>
+          <option value="last_reviewed_at" ${plannerReviewInboxSort === "last_reviewed_at" ? "selected" : ""}>Last reviewed</option>
+          <option value="goal_title" ${plannerReviewInboxSort === "goal_title" ? "selected" : ""}>Goal title</option>
+        </select>
+      </label>
+      <button type="button" class="secondary" data-plan-next-review="true" ${nextReviewItem ? "" : "disabled"}>
+        Open next review
+      </button>
+    </div>
     <div class="entity-grid" style="margin-top:0.75rem;">
       <div class="entity-metric"><span class="meta">Needs Review</span><strong>${summary.goals_needing_review || 0}</strong></div>
       <div class="entity-metric"><span class="meta">Pending</span><strong>${summary.pending_suggestions || 0}</strong></div>
@@ -1422,7 +1456,11 @@ async function refreshGoals() {
 }
 
 async function refreshPlannerReviewInbox() {
-  const inbox = await api("/goals/planner/reviews");
+  const params = new URLSearchParams({
+    status: plannerReviewInboxStatus,
+    sort: plannerReviewInboxSort,
+  });
+  const inbox = await api(`/goals/planner/reviews?${params.toString()}`);
   viewCache.plannerReviewInbox = inbox;
   renderPlannerReviewInbox(viewCache.plannerReviewInbox);
 }
@@ -2181,6 +2219,8 @@ document.addEventListener("click", async (event) => {
   const planReviewDecision = event.target.dataset.planReviewDecision;
   const planReviewReopenIndex = event.target.dataset.planReviewReopenIndex;
   const planBulkCreate = event.target.dataset.planBulkCreate;
+  const planInboxStatus = event.target.dataset.planInboxStatus;
+  const planNextReview = event.target.dataset.planNextReview;
   const operatorAction = event.target.dataset.operatorAction;
   const jumpTarget = event.target.dataset.jumpTarget;
 
@@ -2220,6 +2260,20 @@ document.addEventListener("click", async (event) => {
 
     if (planGoal) {
       await runPlannerPreview(planGoal);
+      setActiveJump("goals-section");
+    }
+
+    if (planInboxStatus) {
+      plannerReviewInboxStatus = planInboxStatus;
+      await refreshPlannerReviewInbox();
+    }
+
+    if (planNextReview) {
+      const nextGoalId = nextPlannerReviewGoalId();
+      if (!nextGoalId) {
+        throw new Error("No planner review item is available in the current inbox view.");
+      }
+      await runPlannerPreview(nextGoalId);
       setActiveJump("goals-section");
     }
 
@@ -2289,10 +2343,22 @@ document.addEventListener("click", async (event) => {
       ? "system-feedback"
       : workflowStart || workflowCancel
         ? "workflow-error"
-        : goalAction || planGoal
+        : goalAction || planGoal || planInboxStatus || planNextReview
           ? "goal-error"
           : "task-error";
     showError(target, error);
+  }
+});
+
+document.addEventListener("change", async (event) => {
+  if (!event.target.dataset.planInboxSort) {
+    return;
+  }
+  plannerReviewInboxSort = event.target.value || "needs_review";
+  try {
+    await refreshPlannerReviewInbox();
+  } catch (error) {
+    showError("goal-error", error);
   }
 });
 

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -16177,6 +16177,94 @@ def test_272r_goal_planner_review_inbox_updates_after_reopen(client):
     assert after["last_reviewed_at"] is None
 
 
+def test_272s_goal_planner_review_inbox_filters_status(client):
+    pending_goal = client.post(
+        "/goals",
+        json={"title": "Alpha pending inbox filter", "urgency": 0.6, "value": 0.5, "deadline_score": 0.2},
+    ).json()
+    reviewed_goal = client.post(
+        "/goals",
+        json={"title": "Beta reviewed inbox filter", "urgency": 0.7, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    mixed_goal = client.post(
+        "/goals",
+        json={"title": "Gamma mixed inbox filter", "urgency": 0.7, "value": 0.6, "deadline_score": 0.2},
+    ).json()
+    pending_total = len(client.post(f"/goals/{pending_goal['goal_id']}/plan").json()["suggestions"])
+    reviewed_total = len(client.post(f"/goals/{reviewed_goal['goal_id']}/plan").json()["suggestions"])
+    mixed_total = len(client.post(f"/goals/{mixed_goal['goal_id']}/plan").json()["suggestions"])
+
+    client.post(
+        f"/goals/{reviewed_goal['goal_id']}/plan/tasks/bulk",
+        json={"suggestion_indexes": list(range(reviewed_total)), "overrides": {}},
+    )
+    client.post(
+        f"/goals/{mixed_goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 0, "decision": "deferred"},
+    )
+
+    needs_review = client.get("/goals/planner/reviews?status=needs_review&sort=goal_title").json()
+    reviewed = client.get("/goals/planner/reviews?status=reviewed&sort=goal_title").json()
+
+    assert [item["goal_id"] for item in needs_review["items"]] == [pending_goal["goal_id"], mixed_goal["goal_id"]]
+    assert needs_review["summary"] == {
+        "total_goals": 2,
+        "goals_needing_review": 2,
+        "pending_suggestions": pending_total + mixed_total - 1,
+        "created": 0,
+        "deferred": 1,
+        "rejected": 0,
+    }
+    assert [item["goal_id"] for item in reviewed["items"]] == [reviewed_goal["goal_id"]]
+    assert reviewed["summary"] == {
+        "total_goals": 1,
+        "goals_needing_review": 0,
+        "pending_suggestions": 0,
+        "created": reviewed_total,
+        "deferred": 0,
+        "rejected": 0,
+    }
+
+
+def test_272t_goal_planner_review_inbox_sorts_for_triage(client):
+    never_reviewed = client.post(
+        "/goals",
+        json={"title": "Zulu never reviewed", "urgency": 0.6, "value": 0.6, "deadline_score": 0.2},
+    ).json()
+    alphabetic_first = client.post(
+        "/goals",
+        json={"title": "Alpha never reviewed", "urgency": 0.6, "value": 0.6, "deadline_score": 0.2},
+    ).json()
+    recently_reviewed = client.post(
+        "/goals",
+        json={"title": "Middle recently reviewed", "urgency": 0.6, "value": 0.6, "deadline_score": 0.2},
+    ).json()
+
+    client.post(
+        f"/goals/{recently_reviewed['goal_id']}/plan/reviews",
+        json={"suggestion_index": 0, "decision": "deferred"},
+    )
+
+    by_title = client.get("/goals/planner/reviews?status=all&sort=goal_title").json()
+    by_last_reviewed = client.get("/goals/planner/reviews?status=all&sort=last_reviewed_at").json()
+
+    assert [item["goal_title"] for item in by_title["items"]] == [
+        alphabetic_first["title"],
+        recently_reviewed["title"],
+        never_reviewed["title"],
+    ]
+    assert by_last_reviewed["items"][0]["goal_id"] == recently_reviewed["goal_id"]
+    assert by_last_reviewed["items"][0]["last_reviewed_at"] is not None
+
+
+def test_272u_goal_planner_review_inbox_rejects_invalid_filter_values(client):
+    invalid_status = client.get("/goals/planner/reviews?status=stale")
+    invalid_sort = client.get("/goals/planner/reviews?sort=priority")
+
+    assert invalid_status.status_code == 422
+    assert invalid_sort.status_code == 422
+
+
 def test_273_goal_plan_task_create_unknown_goal_returns_404(client):
     response = client.post("/goals/missing-goal/plan/tasks", json={"suggestion_index": 0})
 


### PR DESCRIPTION
## Summary
- add status filters and sorting to the Planner Review Inbox API
- add UI triage controls for Needs review, Reviewed, All, sort order, and Open next review
- keep planner review explicit: preview/review does not auto-create tasks

## Validation
- python -m pytest -q -> 345 passed
- node --check goal_ops_console\static\app.js
- git diff --check
- external Playwright UI smoke on a temp DB: create goal, filter/sort inbox, open next review, defer one suggestion, verify taskCount=0

## Stability scope
- No CI/guard workflow changes
- No external AI/Qdrant integration
- artifacts/ left untracked and untouched
