### PR TITLE
[codex] Add planner review batch actions

### DIFF
--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -136,6 +136,20 @@ class PlannerReviewDecisionResponse(BaseModel):
     review: PlannerSuggestionReview
 
 
+class PlannerBulkReviewDecisionRequest(BaseModel):
+    suggestion_indexes: list[int] = Field(min_length=1, max_length=5)
+    decision: Literal["deferred", "rejected"]
+    comment: str | None = Field(default=None, max_length=500)
+
+
+class PlannerBulkReviewDecisionResponse(BaseModel):
+    goal_id: str
+    requested_suggestion_indexes: list[int]
+    decision: Literal["deferred", "rejected"]
+    suggestions: list[PlannerTaskSuggestion]
+    reviews: list[PlannerSuggestionReview]
+
+
 class PlannerReviewReopenResponse(BaseModel):
     goal_id: str
     suggestion_index: int

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -9,6 +9,8 @@ from goal_ops_console.models import (
     DomainError,
     GoalCreateRequest,
     NotFoundError,
+    PlannerBulkReviewDecisionRequest,
+    PlannerBulkReviewDecisionResponse,
     PlannerBulkTaskCreateRequest,
     PlannerBulkTaskCreateResponse,
     PlannerPreviewResponse,
@@ -288,6 +290,11 @@ def _normalized_review_comment(comment: str | None) -> str | None:
     return cleaned or None
 
 
+def _ensure_unique_suggestion_indexes(goal_id: str, suggestion_indexes: list[int]) -> None:
+    if len(set(suggestion_indexes)) != len(suggestion_indexes):
+        raise DomainError(f"Planner suggestion indexes must be unique for goal {goal_id}")
+
+
 def _create_planner_review(
     *,
     goal_id: str,
@@ -350,6 +357,57 @@ def _create_planner_review(
     review = _get_planner_review(goal_id, suggestion_index, services)
     assert review is not None
     return review
+
+
+def _create_planner_reviews(
+    *,
+    goal_id: str,
+    resolved_suggestions: list[tuple[int, dict]],
+    services: AppServices,
+    decision: str,
+    comment: str | None = None,
+) -> list[dict]:
+    timestamp = now_utc()
+    normalized_comment = _normalized_review_comment(comment)
+    with services.db.transaction() as tx:
+        for suggestion_index, suggestion in resolved_suggestions:
+            tx.execute(
+                """INSERT INTO planner_suggestion_reviews
+                   (goal_id, suggestion_index, decision, comment, task_id, planner_source,
+                    suggestion_title, suggestion_description, suggestion_rationale,
+                    suggestion_priority_hint, operator_override, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                goal_id,
+                suggestion_index,
+                decision,
+                normalized_comment,
+                None,
+                suggestion["source"],
+                suggestion["title"],
+                suggestion["description"],
+                suggestion["rationale"],
+                suggestion["priority_hint"],
+                None,
+                timestamp,
+                timestamp,
+            )
+            services.event_bus.record_event(
+                "planner.suggestion_reviewed",
+                goal_id,
+                f"{goal_id}:planner:{suggestion_index}",
+                {
+                    "goal_id": goal_id,
+                    "suggestion_index": suggestion_index,
+                    "decision": decision,
+                    "comment": normalized_comment,
+                    "task_id": None,
+                    "source": suggestion["source"],
+                },
+                tx=tx,
+            )
+    reviews = [_get_planner_review(goal_id, suggestion_index, services) for suggestion_index, _ in resolved_suggestions]
+    assert all(review is not None for review in reviews)
+    return [review for review in reviews if review is not None]
 
 
 def _ensure_suggestion_can_be_created(goal_id: str, suggestion_index: int, services: AppServices) -> None:
@@ -446,6 +504,51 @@ def review_plan_suggestion(
         "suggestion_index": request.suggestion_index,
         "suggestion": refreshed_suggestion,
         "review": review,
+    }
+
+
+@router.post("/{goal_id}/plan/reviews/bulk", status_code=201, response_model=PlannerBulkReviewDecisionResponse)
+def review_plan_suggestions_bulk(
+    goal_id: str,
+    request: PlannerBulkReviewDecisionRequest,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    plan = _preview_goal_plan(goal_id, services)
+    _ensure_unique_suggestion_indexes(goal_id, request.suggestion_indexes)
+    existing_reviews_by_index = _planner_reviews_by_index(goal_id, services)
+    resolved_suggestions = []
+    for suggestion_index in request.suggestion_indexes:
+        suggestion = _get_plan_suggestion(plan, suggestion_index, goal_id)
+        if suggestion["task_exists"]:
+            raise ConflictError(
+                f"Planner suggestion already exists as task {suggestion['existing_task_id']} for goal {goal_id}"
+            )
+        existing_review = existing_reviews_by_index.get(suggestion_index)
+        if existing_review is not None:
+            raise ConflictError(
+                f"Planner suggestion {suggestion_index} already has review decision "
+                f"{existing_review['decision']} for goal {goal_id}"
+            )
+        resolved_suggestions.append((suggestion_index, suggestion))
+
+    reviews = _create_planner_reviews(
+        goal_id=goal_id,
+        resolved_suggestions=resolved_suggestions,
+        services=services,
+        decision=request.decision,
+        comment=request.comment,
+    )
+    refreshed_plan = _preview_goal_plan(goal_id, services)
+    refreshed_suggestions = [
+        _get_plan_suggestion(refreshed_plan, suggestion_index, goal_id)
+        for suggestion_index in request.suggestion_indexes
+    ]
+    return {
+        "goal_id": goal_id,
+        "requested_suggestion_indexes": request.suggestion_indexes,
+        "decision": request.decision,
+        "suggestions": refreshed_suggestions,
+        "reviews": reviews,
     }
 
 

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -548,7 +548,7 @@ function renderPlannerSuggestionSelection(item, index) {
   }
   return (
     `<label class="meta"><input type="checkbox" data-plan-select-index="${index}"> `
-    + "Select for bulk create</label>"
+    + "Select for batch actions</label>"
   );
 }
 
@@ -778,8 +778,14 @@ function renderPlannerPreview(preview) {
     ${renderPlannerReviewSummary(preview)}
     <div class="actions" style="margin-top:0.75rem;">
       <button type="button" class="secondary" data-mutation-control="true" data-plan-bulk-create="true" ${selectableCount ? "" : "disabled"}>Create selected tasks</button>
+      <button type="button" class="secondary" data-mutation-control="true" data-plan-bulk-review-decision="deferred" ${selectableCount ? "" : "disabled"}>Defer selected</button>
+      <button type="button" class="secondary" data-mutation-control="true" data-plan-bulk-review-decision="rejected" ${selectableCount ? "" : "disabled"}>Reject selected</button>
       <span class="meta">${selectableCount} selectable suggestions</span>
     </div>
+    <label class="meta" style="display:block;margin-top:0.75rem;">
+      Batch review comment (optional)
+      <textarea data-plan-bulk-review-comment="true" rows="2" placeholder="Shared note for Defer selected or Reject selected"></textarea>
+    </label>
     <div class="stack-list" style="margin-top:0.75rem;">
       ${suggestions.map((item, index) => `
         <article class="entity-card">
@@ -1728,6 +1734,19 @@ function collectPlannerSuggestionOverrides(indexes) {
 
 function ensurePlannerSuggestionReadyForCreate(suggestion) {
   const decision = plannerSuggestionDecision(suggestion);
+  if (suggestion?.task_exists || decision === "created") {
+    throw new Error("Planner suggestion was already created. Run Plan Preview again or choose another suggestion.");
+  }
+  if (decision === "deferred" || decision === "rejected") {
+    throw new Error(`Planner suggestion was already ${decision}. Run Plan Preview again or choose another suggestion.`);
+  }
+}
+
+function ensurePlannerSuggestionReadyForReview(suggestion) {
+  const decision = plannerSuggestionDecision(suggestion);
+  if (suggestion?.task_exists || decision === "created") {
+    throw new Error("Planner suggestion was already created. Run Plan Preview again or choose another suggestion.");
+  }
   if (decision === "deferred" || decision === "rejected") {
     throw new Error(`Planner suggestion was already ${decision}. Run Plan Preview again or choose another suggestion.`);
   }
@@ -1735,6 +1754,10 @@ function ensurePlannerSuggestionReadyForCreate(suggestion) {
 
 function collectPlannerReviewComment(index) {
   return document.querySelector(`[data-plan-review-comment-index="${index}"]`)?.value.trim() || null;
+}
+
+function collectPlannerBulkReviewComment() {
+  return document.querySelector("[data-plan-bulk-review-comment]")?.value.trim() || null;
 }
 
 async function reviewPlannerSuggestion(indexValue, decision) {
@@ -1763,6 +1786,42 @@ async function reviewPlannerSuggestion(indexValue, decision) {
   document.getElementById("fault-goal-id").value = goalId;
   await refreshAll();
   await runPlannerPreview(goalId);
+}
+
+async function reviewSelectedPlannerSuggestions(decision) {
+  if (!plannerPreview?.goal_id) {
+    throw new Error("Run Plan Preview before reviewing suggested tasks.");
+  }
+  if (!["deferred", "rejected"].includes(decision)) {
+    throw new Error(`Unsupported planner review decision: ${decision}`);
+  }
+  const suggestionIndexes = selectedPlannerSuggestionIndexes();
+  if (!suggestionIndexes.length) {
+    throw new Error("Select at least one planner suggestion before bulk review.");
+  }
+  suggestionIndexes.forEach((index) => ensurePlannerSuggestionReadyForReview(plannerPreview.suggestions[index]));
+  const goalId = plannerPreview.goal_id;
+  const comment = collectPlannerBulkReviewComment();
+  ensureMutationAllowed(`Bulk planner review ${decision}`);
+  const response = await api(`/goals/${encodeURIComponent(goalId)}/plan/reviews/bulk`, {
+    method: "POST",
+    body: JSON.stringify({
+      suggestion_indexes: suggestionIndexes,
+      decision,
+      ...(comment ? { comment } : {}),
+    }),
+  });
+  document.getElementById("system-feedback").textContent = (
+    `Bulk planner review completed: ${response.reviews.length} suggestions marked ${response.decision}.`
+  );
+  selectedGoalId = goalId;
+  document.getElementById("task-goal-id").value = goalId;
+  document.getElementById("event-correlation-id").value = goalId;
+  document.getElementById("trace-goal-id").value = goalId;
+  document.getElementById("fault-goal-id").value = goalId;
+  await refreshAll();
+  await runPlannerPreview(goalId);
+  setActiveJump("goals-section");
 }
 
 async function reopenPlannerSuggestionReview(indexValue) {
@@ -2219,6 +2278,7 @@ document.addEventListener("click", async (event) => {
   const planReviewDecision = event.target.dataset.planReviewDecision;
   const planReviewReopenIndex = event.target.dataset.planReviewReopenIndex;
   const planBulkCreate = event.target.dataset.planBulkCreate;
+  const planBulkReviewDecision = event.target.dataset.planBulkReviewDecision;
   const planInboxStatus = event.target.dataset.planInboxStatus;
   const planNextReview = event.target.dataset.planNextReview;
   const operatorAction = event.target.dataset.operatorAction;
@@ -2285,6 +2345,11 @@ document.addEventListener("click", async (event) => {
     if (planReviewIndex !== undefined && planReviewDecision) {
       showError("task-error", null);
       await reviewPlannerSuggestion(planReviewIndex, planReviewDecision);
+    }
+
+    if (planBulkReviewDecision) {
+      showError("task-error", null);
+      await reviewSelectedPlannerSuggestions(planBulkReviewDecision);
     }
 
     if (planReviewReopenIndex !== undefined) {

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -16265,6 +16265,101 @@ def test_272u_goal_planner_review_inbox_rejects_invalid_filter_values(client):
     assert invalid_sort.status_code == 422
 
 
+def test_272v_goal_plan_bulk_review_defers_selected_without_tasks(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Bulk defer planner reviews", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    total = len(client.post(f"/goals/{goal['goal_id']}/plan").json()["suggestions"])
+
+    response = client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews/bulk",
+        json={"suggestion_indexes": [0, 1], "decision": "deferred", "comment": "Batch hold for owner."},
+    )
+    payload = response.json()
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+    after = client.post(f"/goals/{goal['goal_id']}/plan").json()
+    review_list = client.get(f"/goals/{goal['goal_id']}/plan/reviews").json()
+
+    assert response.status_code == 201
+    assert payload["goal_id"] == goal["goal_id"]
+    assert payload["requested_suggestion_indexes"] == [0, 1]
+    assert payload["decision"] == "deferred"
+    assert [review["suggestion_index"] for review in payload["reviews"]] == [0, 1]
+    assert {review["decision"] for review in payload["reviews"]} == {"deferred"}
+    assert {review["comment"] for review in payload["reviews"]} == {"Batch hold for owner."}
+    assert [suggestion["review_decision"] for suggestion in payload["suggestions"]] == ["deferred", "deferred"]
+    assert [after["suggestions"][index]["review_decision"] for index in [0, 1]] == ["deferred", "deferred"]
+    assert tasks == []
+    assert review_list["summary"] == {
+        "total_suggestions": total,
+        "pending": total - 2,
+        "created": 0,
+        "deferred": 2,
+        "rejected": 0,
+    }
+
+
+def test_272w_goal_plan_bulk_review_rejects_existing_review_without_partial_writes(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Bulk review existing decision", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 0, "decision": "deferred"},
+    )
+
+    response = client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews/bulk",
+        json={"suggestion_indexes": [0, 1], "decision": "rejected", "comment": "Batch reject."},
+    )
+    reviews = client.get(f"/goals/{goal['goal_id']}/plan/reviews").json()["reviews"]
+    after = client.post(f"/goals/{goal['goal_id']}/plan").json()
+
+    assert response.status_code == 409
+    assert "already has review decision deferred" in response.json()["detail"]
+    assert [review["suggestion_index"] for review in reviews] == [0]
+    assert after["suggestions"][0]["review_decision"] == "deferred"
+    assert after["suggestions"][1]["review_decision"] == "pending"
+
+
+def test_272x_goal_plan_bulk_review_invalid_index_writes_nothing(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Bulk review invalid index", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+
+    response = client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews/bulk",
+        json={"suggestion_indexes": [0, 99], "decision": "rejected"},
+    )
+    tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+    reviews = client.get(f"/goals/{goal['goal_id']}/plan/reviews").json()["reviews"]
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == f"Planner suggestion index 99 not found for goal {goal['goal_id']}"
+    assert tasks == []
+    assert reviews == []
+
+
+def test_272y_goal_plan_bulk_review_duplicate_indexes_write_nothing(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Bulk review duplicate indexes", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+
+    response = client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews/bulk",
+        json={"suggestion_indexes": [0, 0], "decision": "deferred"},
+    )
+    reviews = client.get(f"/goals/{goal['goal_id']}/plan/reviews").json()["reviews"]
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == f"Planner suggestion indexes must be unique for goal {goal['goal_id']}"
+    assert reviews == []
+
+
 def test_273_goal_plan_task_create_unknown_goal_returns_404(client):
     response = client.post("/goals/missing-goal/plan/tasks", json={"suggestion_index": 0})
 


### PR DESCRIPTION
## Summary
- add bulk planner review request/response models and POST /goals/{goal_id}/plan/reviews/bulk
- add Planner Preview batch controls to defer or reject selected pending suggestions with an optional shared comment
- preserve supervised behavior: batch review records decisions only and does not create tasks

## Validation
- python -m pytest tests/test_goal_ops.py -q -k "planner_review or goal_plan_review or planner_review_inbox or bulk_review or goal_plan_bulk" -> 29 passed
- python -m pytest -q -> 349 passed
- node --check goal_ops_console\static\app.js
- git diff --check
- external Playwright UI smoke on a temp DB: create goal, open next review, defer selected, reject remaining selected, verify deferred=2 rejected=2 taskCount=0

## Stability scope
- No CI/guard workflow changes
- No external AI/Qdrant integration
- artifacts/ left untracked and untouched
