### PR TITLE
Add planner review audit history

### DIFF
--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -173,6 +173,31 @@ class PlannerReviewListResponse(BaseModel):
     reviews: list[PlannerSuggestionReview]
 
 
+class PlannerReviewAuditEntry(BaseModel):
+    seq: int
+    event_id: str
+    event_type: Literal["planner.suggestion_reviewed", "planner.suggestion_review_reopened"]
+    action: Literal["reviewed", "reopened"]
+    goal_id: str
+    suggestion_index: int
+    suggestion_title: str
+    decision: Literal["created", "deferred", "rejected"] | None = None
+    cleared_decision: Literal["created", "deferred", "rejected"] | None = None
+    comment: str | None = None
+    cleared_comment: str | None = None
+    task_id: str | None = None
+    source: str
+    emitted_at: str
+
+
+class PlannerReviewAuditResponse(BaseModel):
+    goal_id: str
+    goal_title: str
+    source: str
+    summary: PlannerReviewSummary
+    entries: list[PlannerReviewAuditEntry]
+
+
 class PlannerReviewInboxItem(BaseModel):
     goal_id: str
     goal_title: str

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Literal
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from goal_ops_console.database import now_utc
 from goal_ops_console.models import (
@@ -14,6 +14,7 @@ from goal_ops_console.models import (
     PlannerBulkTaskCreateRequest,
     PlannerBulkTaskCreateResponse,
     PlannerPreviewResponse,
+    PlannerReviewAuditResponse,
     PlannerReviewDecisionRequest,
     PlannerReviewDecisionResponse,
     PlannerReviewInboxResponse,
@@ -26,6 +27,11 @@ from goal_ops_console.models import (
 from goal_ops_console.services import AppServices, get_services
 
 router = APIRouter(prefix="/goals", tags=["goals"])
+
+_PLANNER_REVIEW_AUDIT_EVENT_TYPES = (
+    "planner.suggestion_reviewed",
+    "planner.suggestion_review_reopened",
+)
 
 
 @router.get("")
@@ -194,6 +200,72 @@ def _planner_review_list(goal_id: str, services: AppServices) -> dict:
         "source": plan["source"],
         "summary": _planner_review_summary(plan),
         "reviews": reviews,
+    }
+
+
+def _planner_review_event_payload(row: Any) -> dict:
+    raw_payload = row["payload"]
+    payload = json.loads(raw_payload) if raw_payload else {}
+    data = payload.get("data", {}) if isinstance(payload, dict) else {}
+    return data if isinstance(data, dict) else {}
+
+
+def _planner_review_audit_entry(row: Any, goal_id: str, plan: dict) -> dict | None:
+    data = _planner_review_event_payload(row)
+    raw_suggestion_index = data.get("suggestion_index")
+    if not isinstance(raw_suggestion_index, int) or raw_suggestion_index < 0:
+        return None
+
+    suggestion = plan["suggestions"][raw_suggestion_index] if raw_suggestion_index < len(plan["suggestions"]) else {}
+    event_type = row["event_type"]
+    is_reopen = event_type == "planner.suggestion_review_reopened"
+    decision = None if is_reopen else data.get("decision")
+    cleared_decision = data.get("cleared_decision") if is_reopen else None
+    comment = None if is_reopen else data.get("comment")
+    cleared_comment = data.get("cleared_comment") if is_reopen else None
+    return {
+        "seq": row["seq"],
+        "event_id": row["event_id"],
+        "event_type": event_type,
+        "action": "reopened" if is_reopen else "reviewed",
+        "goal_id": data.get("goal_id") or goal_id,
+        "suggestion_index": raw_suggestion_index,
+        "suggestion_title": suggestion.get("title") or f"Suggestion #{raw_suggestion_index + 1}",
+        "decision": decision,
+        "cleared_decision": cleared_decision,
+        "comment": comment,
+        "cleared_comment": cleared_comment,
+        "task_id": None if is_reopen else data.get("task_id"),
+        "source": data.get("source") or suggestion.get("source") or plan["source"],
+        "emitted_at": row["emitted_at"],
+    }
+
+
+def _planner_review_audit(goal_id: str, services: AppServices, *, limit: int = 100) -> dict:
+    plan = _preview_goal_plan(goal_id, services)
+    placeholders = ", ".join("?" for _ in _PLANNER_REVIEW_AUDIT_EVENT_TYPES)
+    rows = services.db.fetch_all(
+        f"""SELECT seq, event_id, event_type, entity_id, correlation_id, payload, emitted_at
+            FROM events
+            WHERE entity_id = ?
+              AND event_type IN ({placeholders})
+            ORDER BY seq DESC
+            LIMIT ?""",
+        goal_id,
+        *_PLANNER_REVIEW_AUDIT_EVENT_TYPES,
+        limit,
+    )
+    entries = [
+        entry
+        for entry in (_planner_review_audit_entry(row, goal_id, plan) for row in rows)
+        if entry is not None
+    ]
+    return {
+        "goal_id": plan["goal_id"],
+        "goal_title": plan["goal_title"],
+        "source": plan["source"],
+        "summary": _planner_review_summary(plan),
+        "entries": entries,
     }
 
 
@@ -466,6 +538,15 @@ def list_plan_suggestion_reviews(
     services: AppServices = Depends(get_services),
 ) -> dict:
     return _planner_review_list(goal_id, services)
+
+
+@router.get("/{goal_id}/plan/reviews/audit", response_model=PlannerReviewAuditResponse)
+def list_plan_suggestion_review_audit(
+    goal_id: str,
+    limit: int = Query(default=100, ge=1, le=500),
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return _planner_review_audit(goal_id, services, limit=limit)
 
 
 @router.get("/planner/reviews", response_model=PlannerReviewInboxResponse)

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -683,6 +683,44 @@ function renderPlannerReviewSummary(preview) {
   `;
 }
 
+function plannerReviewAudit(preview) {
+  return preview.review_audit || {
+    entries: [],
+  };
+}
+
+function renderPlannerReviewAuditEntry(entry) {
+  const suggestionNumber = Number(entry.suggestion_index) + 1;
+  const title = entry.suggestion_title || `Suggestion #${suggestionNumber}`;
+  const taskId = entry.task_id ? ` | task ${escapeHtml(entry.task_id)}` : "";
+  if (entry.action === "reopened") {
+    const comment = entry.cleared_comment ? ` | ${escapeHtml(entry.cleared_comment)}` : "";
+    return (
+      `<div class="meta">#${suggestionNumber} reopened from ${escapeHtml(entry.cleared_decision || "reviewed")} `
+      + `| ${escapeHtml(title)} | ${escapeHtml(entry.emitted_at)}${comment}</div>`
+    );
+  }
+  const comment = entry.comment ? ` | ${escapeHtml(entry.comment)}` : "";
+  return (
+    `<div class="meta">#${suggestionNumber} ${escapeHtml(entry.decision || "reviewed")} `
+    + `| ${escapeHtml(title)} | ${escapeHtml(entry.emitted_at)}${taskId}${comment}</div>`
+  );
+}
+
+function renderPlannerReviewAudit(preview) {
+  const audit = plannerReviewAudit(preview);
+  const entries = audit.entries || [];
+  const auditItems = entries.length
+    ? entries.map((entry) => renderPlannerReviewAuditEntry(entry)).join("")
+    : `<div class="meta">No planner review history yet.</div>`;
+  return `
+    <details style="margin-top:0.75rem;">
+      <summary class="meta">Review history (${entries.length})</summary>
+      <div class="stack-list" style="margin-top:0.5rem;">${auditItems}</div>
+    </details>
+  `;
+}
+
 function renderPlannerReviewInbox(payload) {
   const container = document.getElementById("planner-review-inbox");
   if (!container) return;
@@ -776,6 +814,7 @@ function renderPlannerPreview(preview) {
     <h3>${escapeHtml(preview.goal_title)}</h3>
     <div class="meta">${escapeHtml(preview.goal_id)} &middot; ${suggestions.length} suggested tasks &middot; no tasks created automatically</div>
     ${renderPlannerReviewSummary(preview)}
+    ${renderPlannerReviewAudit(preview)}
     <div class="actions" style="margin-top:0.75rem;">
       <button type="button" class="secondary" data-mutation-control="true" data-plan-bulk-create="true" ${selectableCount ? "" : "disabled"}>Create selected tasks</button>
       <button type="button" class="secondary" data-mutation-control="true" data-plan-bulk-review-decision="deferred" ${selectableCount ? "" : "disabled"}>Defer selected</button>
@@ -1676,7 +1715,8 @@ async function runPlannerPreview(goalId) {
   }
   const preview = await api(`/goals/${encodeURIComponent(goalId)}/plan`, { method: "POST" });
   const reviewQueue = await api(`/goals/${encodeURIComponent(goalId)}/plan/reviews`);
-  plannerPreview = { ...preview, review_queue: reviewQueue };
+  const reviewAudit = await api(`/goals/${encodeURIComponent(goalId)}/plan/reviews/audit`);
+  plannerPreview = { ...preview, review_queue: reviewQueue, review_audit: reviewAudit };
   selectedGoalId = goalId;
   document.getElementById("task-goal-id").value = goalId;
   document.getElementById("event-correlation-id").value = goalId;

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -16360,6 +16360,107 @@ def test_272y_goal_plan_bulk_review_duplicate_indexes_write_nothing(client):
     assert reviews == []
 
 
+def test_272z_goal_plan_review_audit_lists_decision_timeline(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Audit planner review history", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    total = len(client.post(f"/goals/{goal['goal_id']}/plan").json()["suggestions"])
+
+    client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 0, "decision": "deferred", "comment": "Wait for sequencing."},
+    )
+    client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews/bulk",
+        json={"suggestion_indexes": [1, 2], "decision": "rejected", "comment": "Batch no-go."},
+    )
+    reopened = client.delete(f"/goals/{goal['goal_id']}/plan/reviews/0")
+    created = client.post(f"/goals/{goal['goal_id']}/plan/tasks", json={"suggestion_index": 0})
+
+    response = client.get(f"/goals/{goal['goal_id']}/plan/reviews/audit")
+    payload = response.json()
+    entries = payload["entries"]
+
+    assert response.status_code == 200
+    assert reopened.status_code == 200
+    assert created.status_code == 201
+    assert payload["goal_id"] == goal["goal_id"]
+    assert payload["goal_title"] == goal["title"]
+    assert payload["source"] == "deterministic_planner"
+    assert payload["summary"] == {
+        "total_suggestions": total,
+        "pending": total - 3,
+        "created": 1,
+        "deferred": 0,
+        "rejected": 2,
+    }
+    assert [entry["seq"] for entry in entries] == sorted((entry["seq"] for entry in entries), reverse=True)
+    assert [entry["event_type"] for entry in entries].count("planner.suggestion_reviewed") == 4
+    assert [entry["event_type"] for entry in entries].count("planner.suggestion_review_reopened") == 1
+    assert entries[0]["action"] == "reviewed"
+    assert entries[0]["decision"] == "created"
+    assert entries[0]["suggestion_index"] == 0
+    assert entries[0]["task_id"] == created.json()["task"]["task_id"]
+    assert entries[1]["action"] == "reopened"
+    assert entries[1]["cleared_decision"] == "deferred"
+    assert entries[1]["cleared_comment"] == "Wait for sequencing."
+    assert entries[-1]["decision"] == "deferred"
+    assert entries[-1]["comment"] == "Wait for sequencing."
+    assert {
+        (entry["suggestion_index"], entry["decision"], entry["comment"])
+        for entry in entries
+        if entry["decision"] == "rejected"
+    } == {
+        (1, "rejected", "Batch no-go."),
+        (2, "rejected", "Batch no-go."),
+    }
+    assert all(entry["suggestion_title"] for entry in entries)
+    assert all(entry["source"] == "deterministic_planner" for entry in entries)
+
+
+def test_272za_goal_plan_review_audit_limit_returns_newest_entries(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Limit planner review audit", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews/bulk",
+        json={"suggestion_indexes": [0, 1, 2], "decision": "deferred", "comment": "Batch hold."},
+    )
+
+    full = client.get(f"/goals/{goal['goal_id']}/plan/reviews/audit").json()["entries"]
+    limited = client.get(f"/goals/{goal['goal_id']}/plan/reviews/audit?limit=2")
+
+    assert limited.status_code == 200
+    assert limited.json()["entries"] == full[:2]
+
+
+def test_272zb_goal_plan_review_audit_empty_and_read_only(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Empty planner review audit", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    before_tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    response = client.get(f"/goals/{goal['goal_id']}/plan/reviews/audit")
+    after_tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+    reviews = client.get(f"/goals/{goal['goal_id']}/plan/reviews").json()["reviews"]
+
+    assert response.status_code == 200
+    assert response.json()["entries"] == []
+    assert before_tasks == []
+    assert after_tasks == []
+    assert reviews == []
+
+
+def test_272zc_goal_plan_review_audit_unknown_goal_returns_404(client):
+    response = client.get("/goals/missing-goal/plan/reviews/audit")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Goal missing-goal not found"
+
+
 def test_273_goal_plan_task_create_unknown_goal_returns_404(client):
     response = client.post("/goals/missing-goal/plan/tasks", json={"suggestion_index": 0})
 


### PR DESCRIPTION
﻿## Summary
- add a read-only planner review audit endpoint backed by existing planner review events
- surface review history in Planner Preview, including reviewed and reopened entries
- cover audit history, limit handling, empty state, and unknown-goal behavior with tests

## Validation
- python -m pytest tests/test_goal_ops.py -q -k "planner_review or goal_plan_review or planner_review_inbox or bulk_review"
- node --check goal_ops_console\static\app.js
- python -m pytest -q
- browser smoke against local temp DB: Review history visible, reopened entry visible, comment visible
