### PR TITLE
[codex] Add planner deferred follow-up queue

### DIFF
--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -222,6 +222,30 @@ class PlannerReviewInboxResponse(BaseModel):
     items: list[PlannerReviewInboxItem]
 
 
+class PlannerDeferredFollowupItem(BaseModel):
+    goal_id: str
+    goal_title: str
+    state: str
+    source: str
+    suggestion_index: int
+    suggestion_title: str
+    suggestion_description: str
+    suggestion_rationale: str
+    priority_hint: str
+    comment: str | None = None
+    deferred_at: str
+
+
+class PlannerDeferredFollowupSummary(BaseModel):
+    total_followups: int
+    goals_with_followups: int
+
+
+class PlannerDeferredFollowupResponse(BaseModel):
+    summary: PlannerDeferredFollowupSummary
+    items: list[PlannerDeferredFollowupItem]
+
+
 class PlannerTaskCreateResponse(BaseModel):
     goal_id: str
     suggestion_index: int

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -13,6 +13,7 @@ from goal_ops_console.models import (
     PlannerBulkReviewDecisionResponse,
     PlannerBulkTaskCreateRequest,
     PlannerBulkTaskCreateResponse,
+    PlannerDeferredFollowupResponse,
     PlannerPreviewResponse,
     PlannerReviewAuditResponse,
     PlannerReviewDecisionRequest,
@@ -326,6 +327,50 @@ def _planner_review_inbox(services: AppServices, status: str = "all", sort: str 
     }
 
 
+def _planner_deferred_followup_item(goal: dict, review: dict) -> dict:
+    return {
+        "goal_id": goal["goal_id"],
+        "goal_title": goal["title"],
+        "state": goal["state"],
+        "source": review["planner_source"],
+        "suggestion_index": review["suggestion_index"],
+        "suggestion_title": review["suggestion_title"],
+        "suggestion_description": review["suggestion_description"],
+        "suggestion_rationale": review["suggestion_rationale"],
+        "priority_hint": review["suggestion_priority_hint"],
+        "comment": review["comment"],
+        "deferred_at": review["updated_at"],
+    }
+
+
+def _sort_planner_deferred_followups(items: list[dict]) -> list[dict]:
+    sorted_items = sorted(
+        items,
+        key=lambda item: (item["goal_title"].lower(), item["suggestion_index"]),
+    )
+    sorted_items.sort(key=lambda item: item["deferred_at"], reverse=True)
+    return sorted_items
+
+
+def _planner_deferred_followups(services: AppServices) -> dict:
+    items = []
+    for goal in services.state_manager.list_goals():
+        reviews = _planner_reviews_by_index(goal["goal_id"], services).values()
+        items.extend(
+            _planner_deferred_followup_item(goal, review)
+            for review in reviews
+            if review["decision"] == "deferred"
+        )
+    items = _sort_planner_deferred_followups(items)
+    return {
+        "summary": {
+            "total_followups": len(items),
+            "goals_with_followups": len({item["goal_id"] for item in items}),
+        },
+        "items": items,
+    }
+
+
 def _get_planner_review(goal_id: str, suggestion_index: int, services: AppServices) -> dict | None:
     row = services.db.fetch_one(
         """SELECT goal_id,
@@ -556,6 +601,13 @@ def list_planner_review_inbox(
     services: AppServices = Depends(get_services),
 ) -> dict:
     return _planner_review_inbox(services, status=status, sort=sort)
+
+
+@router.get("/planner/reviews/followups", response_model=PlannerDeferredFollowupResponse)
+def list_planner_deferred_followups(
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return _planner_deferred_followups(services)
 
 
 @router.post("/{goal_id}/plan/reviews", status_code=201, response_model=PlannerReviewDecisionResponse)

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -50,6 +50,7 @@ const MUTATION_LOCK_FALLBACK_MESSAGE = (
 const viewCache = {
   goals: [],
   plannerReviewInbox: null,
+  plannerDeferredFollowups: null,
   tasks: [],
   workflows: [],
   workflowRuns: [],
@@ -456,6 +457,7 @@ function setAutoRefresh(enabled) {
 function rerenderFilteredViews() {
   renderGoals(viewCache.goals);
   renderPlannerReviewInbox(viewCache.plannerReviewInbox);
+  renderPlannerDeferredFollowups(viewCache.plannerDeferredFollowups);
   renderTasks(viewCache.tasks);
   renderWorkflows(viewCache.workflows, viewCache.workflowRuns);
   renderEvents(viewCache.events);
@@ -790,6 +792,71 @@ function renderPlannerReviewInbox(payload) {
       <div class="entity-metric"><span class="meta">Pending</span><strong>${summary.pending_suggestions || 0}</strong></div>
       <div class="entity-metric"><span class="meta">Created</span><strong>${summary.created || 0}</strong></div>
       <div class="entity-metric"><span class="meta">Deferred</span><strong>${summary.deferred || 0}</strong></div>
+    </div>
+    <div class="stack-list" style="margin-top:0.75rem;">${itemMarkup}</div>
+  `;
+}
+
+function plannerDeferredFollowupVisibleItems(payload) {
+  return filterRows(payload?.items || [], (item) => [
+    item.goal_id,
+    item.goal_title,
+    item.state,
+    item.suggestion_title,
+    item.suggestion_description,
+    item.suggestion_rationale,
+    item.priority_hint,
+    item.comment || "",
+    item.deferred_at,
+  ]);
+}
+
+function renderPlannerDeferredFollowups(payload) {
+  const container = document.getElementById("planner-deferred-followups");
+  if (!container) return;
+  if (!payload) {
+    container.innerHTML = `
+      <span class="meta">Deferred Follow-ups</span>
+      <p class="meta">Deferred planner suggestions are loading.</p>
+    `;
+    return;
+  }
+  const summary = payload.summary || {};
+  const items = plannerDeferredFollowupVisibleItems(payload);
+  const itemMarkup = items.length
+    ? items.map((item) => {
+      const comment = item.comment ? `<div class="meta">Comment: ${escapeHtml(item.comment)}</div>` : "";
+      return `
+        <article class="entity-card ${selectedGoalId === item.goal_id ? "selected" : ""}">
+          <div class="entity-header">
+            <div>
+              <div class="entity-title">${escapeHtml(item.suggestion_title)}</div>
+              <div class="meta">
+                ${escapeHtml(item.goal_title)}
+                &middot; #${Number(item.suggestion_index) + 1}
+                &middot; ${escapeHtml(item.deferred_at)}
+              </div>
+            </div>
+            <span class="pill ${stateClass(item.priority_hint)}">${escapeHtml(item.priority_hint)}</span>
+          </div>
+          <p class="meta">${escapeHtml(item.suggestion_description)}</p>
+          <p class="meta"><strong>Why suggested:</strong> ${escapeHtml(item.suggestion_rationale)}</p>
+          ${comment}
+          <div class="actions" style="margin-top:0.75rem;">
+            <button type="button" class="secondary" data-plan-goal="${escapeHtml(item.goal_id)}">Open Plan Preview</button>
+          </div>
+        </article>
+      `;
+    }).join("")
+    : `<div class="meta">${filteredEmptyMessage("No deferred planner follow-ups yet.")}</div>`;
+  container.innerHTML = `
+    <span class="meta">Deferred Follow-ups &middot; ${summary.total_followups || 0} suggestions</span>
+    <div class="actions" style="margin-top:0.75rem;">
+      <button type="button" class="secondary" data-plan-followups-refresh="true">Refresh follow-ups</button>
+    </div>
+    <div class="entity-grid" style="margin-top:0.75rem;">
+      <div class="entity-metric"><span class="meta">Follow-ups</span><strong>${summary.total_followups || 0}</strong></div>
+      <div class="entity-metric"><span class="meta">Goals</span><strong>${summary.goals_with_followups || 0}</strong></div>
     </div>
     <div class="stack-list" style="margin-top:0.75rem;">${itemMarkup}</div>
   `;
@@ -1510,6 +1577,12 @@ async function refreshPlannerReviewInbox() {
   renderPlannerReviewInbox(viewCache.plannerReviewInbox);
 }
 
+async function refreshPlannerDeferredFollowups() {
+  const payload = await api("/goals/planner/reviews/followups");
+  viewCache.plannerDeferredFollowups = payload;
+  renderPlannerDeferredFollowups(viewCache.plannerDeferredFollowups);
+}
+
 async function refreshWorkflows() {
   const [workflowPayload, runPayload] = await Promise.all([
     api("/workflows"),
@@ -1636,6 +1709,7 @@ async function refreshAll() {
   await Promise.all([
     refreshGoals(),
     refreshPlannerReviewInbox(),
+    refreshPlannerDeferredFollowups(),
     refreshTasks(),
     refreshWorkflows(),
     refreshEvents(),
@@ -1657,6 +1731,7 @@ function startAutoRefreshLoop() {
     }
     refreshGoals().catch(() => {});
     refreshPlannerReviewInbox().catch(() => {});
+    refreshPlannerDeferredFollowups().catch(() => {});
     refreshTasks().catch(() => {});
     refreshWorkflows().catch(() => {});
     refreshEvents().catch(() => {});
@@ -1723,6 +1798,8 @@ async function runPlannerPreview(goalId) {
   document.getElementById("trace-goal-id").value = goalId;
   document.getElementById("fault-goal-id").value = goalId;
   renderPlannerPreview(plannerPreview);
+  renderPlannerReviewInbox(viewCache.plannerReviewInbox);
+  renderPlannerDeferredFollowups(viewCache.plannerDeferredFollowups);
   updateSelectedGoalLabel();
 }
 
@@ -2212,7 +2289,7 @@ document.getElementById("flow-trace-form").addEventListener("submit", async (eve
 });
 
 document.getElementById("refresh-goals").addEventListener("click", async () => {
-  await Promise.all([refreshGoals(), refreshPlannerReviewInbox()]);
+  await Promise.all([refreshGoals(), refreshPlannerReviewInbox(), refreshPlannerDeferredFollowups()]);
 });
 document.getElementById("refresh-tasks").addEventListener("click", refreshTasks);
 document.getElementById("refresh-workflows").addEventListener("click", refreshWorkflows);
@@ -2320,6 +2397,7 @@ document.addEventListener("click", async (event) => {
   const planBulkCreate = event.target.dataset.planBulkCreate;
   const planBulkReviewDecision = event.target.dataset.planBulkReviewDecision;
   const planInboxStatus = event.target.dataset.planInboxStatus;
+  const planFollowupsRefresh = event.target.dataset.planFollowupsRefresh;
   const planNextReview = event.target.dataset.planNextReview;
   const operatorAction = event.target.dataset.operatorAction;
   const jumpTarget = event.target.dataset.jumpTarget;
@@ -2366,6 +2444,10 @@ document.addEventListener("click", async (event) => {
     if (planInboxStatus) {
       plannerReviewInboxStatus = planInboxStatus;
       await refreshPlannerReviewInbox();
+    }
+
+    if (planFollowupsRefresh) {
+      await refreshPlannerDeferredFollowups();
     }
 
     if (planNextReview) {
@@ -2448,7 +2530,7 @@ document.addEventListener("click", async (event) => {
       ? "system-feedback"
       : workflowStart || workflowCancel
         ? "workflow-error"
-        : goalAction || planGoal || planInboxStatus || planNextReview
+        : goalAction || planGoal || planInboxStatus || planFollowupsRefresh || planNextReview
           ? "goal-error"
           : "task-error";
     showError(target, error);

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -846,6 +846,10 @@
         <span class="meta">Planner Review Inbox</span>
         <p class="meta">Review coverage is loading.</p>
       </div>
+      <div id="planner-deferred-followups" class="card" aria-live="polite">
+        <span class="meta">Deferred Follow-ups</span>
+        <p class="meta">Deferred planner suggestions are loading.</p>
+      </div>
       <div id="goals-table"></div>
     </section>
 

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -16265,6 +16265,158 @@ def test_272u_goal_planner_review_inbox_rejects_invalid_filter_values(client):
     assert invalid_sort.status_code == 422
 
 
+def test_272ua_goal_planner_deferred_followups_returns_deferred_items(client):
+    alpha_goal = client.post(
+        "/goals",
+        json={"title": "Alpha deferred followups", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    beta_goal = client.post(
+        "/goals",
+        json={"title": "Beta deferred followups", "urgency": 0.5, "value": 0.8, "deadline_score": 0.1},
+    ).json()
+    alpha_preview = client.post(f"/goals/{alpha_goal['goal_id']}/plan").json()
+    beta_preview = client.post(f"/goals/{beta_goal['goal_id']}/plan").json()
+
+    client.post(
+        f"/goals/{alpha_goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 0, "decision": "deferred", "comment": "Wait for owner input."},
+    )
+    client.post(
+        f"/goals/{alpha_goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 1, "decision": "deferred"},
+    )
+    client.post(
+        f"/goals/{alpha_goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 2, "decision": "rejected", "comment": "Not useful now."},
+    )
+    client.post(f"/goals/{beta_goal['goal_id']}/plan/tasks", json={"suggestion_index": 0})
+    client.post(
+        f"/goals/{beta_goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 1, "decision": "deferred", "comment": "Sequence after launch."},
+    )
+
+    response = client.get("/goals/planner/reviews/followups")
+    payload = response.json()
+    items_by_key = {(item["goal_id"], item["suggestion_index"]): item for item in payload["items"]}
+
+    assert response.status_code == 200
+    assert payload["summary"] == {"total_followups": 3, "goals_with_followups": 2}
+    assert set(items_by_key) == {
+        (alpha_goal["goal_id"], 0),
+        (alpha_goal["goal_id"], 1),
+        (beta_goal["goal_id"], 1),
+    }
+    assert client.get(f"/tasks?goal_id={alpha_goal['goal_id']}").json() == []
+    assert len(client.get(f"/tasks?goal_id={beta_goal['goal_id']}").json()) == 1
+
+    alpha_item = items_by_key[(alpha_goal["goal_id"], 0)]
+    alpha_suggestion = alpha_preview["suggestions"][0]
+    assert alpha_item["goal_title"] == alpha_goal["title"]
+    assert alpha_item["state"] == alpha_goal["state"]
+    assert alpha_item["source"] == "deterministic_planner"
+    assert alpha_item["suggestion_title"] == alpha_suggestion["title"]
+    assert alpha_item["suggestion_description"] == alpha_suggestion["description"]
+    assert alpha_item["suggestion_rationale"] == alpha_suggestion["rationale"]
+    assert alpha_item["priority_hint"] == alpha_suggestion["priority_hint"]
+    assert alpha_item["comment"] == "Wait for owner input."
+    assert alpha_item["deferred_at"]
+
+    beta_item = items_by_key[(beta_goal["goal_id"], 1)]
+    beta_suggestion = beta_preview["suggestions"][1]
+    assert beta_item["suggestion_title"] == beta_suggestion["title"]
+    assert beta_item["comment"] == "Sequence after launch."
+
+
+def test_272ub_goal_planner_deferred_followups_empty_and_read_only(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Empty deferred followups", "urgency": 0.6, "value": 0.6, "deadline_score": 0.2},
+    ).json()
+    before_tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    response = client.get("/goals/planner/reviews/followups")
+    after_tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+    reviews = client.get(f"/goals/{goal['goal_id']}/plan/reviews").json()["reviews"]
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "summary": {"total_followups": 0, "goals_with_followups": 0},
+        "items": [],
+    }
+    assert before_tasks == []
+    assert after_tasks == []
+    assert reviews == []
+
+
+def test_272uc_goal_planner_deferred_followups_sort_newest_then_title(client):
+    older_goal = client.post(
+        "/goals",
+        json={"title": "Zulu same deferred", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    tie_first_goal = client.post(
+        "/goals",
+        json={"title": "Alpha same deferred", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    newest_goal = client.post(
+        "/goals",
+        json={"title": "Newest deferred", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+
+    for goal in [older_goal, tie_first_goal, newest_goal]:
+        client.post(
+            f"/goals/{goal['goal_id']}/plan/reviews",
+            json={"suggestion_index": 0, "decision": "deferred"},
+        )
+
+    db = client.app.state.services.db
+    db.execute(
+        "UPDATE planner_suggestion_reviews SET updated_at = ? WHERE goal_id = ?",
+        "2026-01-02 00:00:00",
+        older_goal["goal_id"],
+    )
+    db.execute(
+        "UPDATE planner_suggestion_reviews SET updated_at = ? WHERE goal_id = ?",
+        "2026-01-02 00:00:00",
+        tie_first_goal["goal_id"],
+    )
+    db.execute(
+        "UPDATE planner_suggestion_reviews SET updated_at = ? WHERE goal_id = ?",
+        "2026-01-03 00:00:00",
+        newest_goal["goal_id"],
+    )
+
+    payload = client.get("/goals/planner/reviews/followups").json()
+
+    assert [item["goal_title"] for item in payload["items"]] == [
+        newest_goal["title"],
+        tie_first_goal["title"],
+        older_goal["title"],
+    ]
+
+
+def test_272ud_goal_planner_deferred_followups_updates_after_reopen(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Reopen deferred followup", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 0, "decision": "deferred"},
+    )
+
+    before = client.get("/goals/planner/reviews/followups").json()
+    reopened = client.delete(f"/goals/{goal['goal_id']}/plan/reviews/0")
+    after = client.get("/goals/planner/reviews/followups").json()
+
+    assert before["summary"] == {"total_followups": 1, "goals_with_followups": 1}
+    assert before["items"][0]["goal_id"] == goal["goal_id"]
+    assert reopened.status_code == 200
+    assert after == {
+        "summary": {"total_followups": 0, "goals_with_followups": 0},
+        "items": [],
+    }
+
+
 def test_272v_goal_plan_bulk_review_defers_selected_without_tasks(client):
     goal = client.post(
         "/goals",


### PR DESCRIPTION
﻿## Summary
- Adds a read-only deferred follow-up queue for planner suggestions marked `deferred`.
- Exposes `GET /goals/planner/reviews/followups` with summary and suggestion detail fields.
- Adds a UI card that shows deferred follow-ups and opens the existing Plan Preview for supervised review.

## Why
Deferred planner decisions were persisted but easy to lose inside per-goal review state. This makes them visible as an operator queue without creating tasks automatically or changing planner execution semantics.

## Validation
- `python -m pytest tests\test_goal_ops.py -q -k "planner_review or plan_review or deferred_followups or followups"`
- `node --check goal_ops_console\static\app.js`
- `git diff --check`
- `python -m pytest -q`
- Browser smoke against local app: deferred card visible and Follow-up button opens Plan Preview
