### PR TITLE
[codex] Show next planner suggestion in inbox

### DIFF
--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -198,6 +198,15 @@ class PlannerReviewAuditResponse(BaseModel):
     entries: list[PlannerReviewAuditEntry]
 
 
+class PlannerReviewInboxNextSuggestion(BaseModel):
+    suggestion_index: int
+    title: str
+    description: str
+    rationale: str
+    priority_hint: str
+    source: str
+
+
 class PlannerReviewInboxItem(BaseModel):
     goal_id: str
     goal_title: str
@@ -206,6 +215,7 @@ class PlannerReviewInboxItem(BaseModel):
     summary: PlannerReviewSummary
     last_reviewed_at: str | None = None
     needs_review: bool
+    next_suggestion: PlannerReviewInboxNextSuggestion | None = None
 
 
 class PlannerReviewInboxSummary(BaseModel):

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -270,18 +270,36 @@ def _planner_review_audit(goal_id: str, services: AppServices, *, limit: int = 1
     }
 
 
+def _planner_review_inbox_next_suggestion(plan: dict) -> dict | None:
+    for suggestion_index, suggestion in enumerate(plan["suggestions"]):
+        if suggestion["review_decision"] == "pending":
+            return {
+                "suggestion_index": suggestion_index,
+                "title": suggestion["title"],
+                "description": suggestion["description"],
+                "rationale": suggestion["rationale"],
+                "priority_hint": suggestion["priority_hint"],
+                "source": suggestion["source"],
+            }
+    return None
+
+
 def _planner_review_inbox_item(goal: dict, services: AppServices) -> dict:
-    review_list = _planner_review_list(goal["goal_id"], services)
-    summary = review_list["summary"]
-    reviews = review_list["reviews"]
+    plan = _preview_goal_plan(goal["goal_id"], services)
+    reviews = sorted(
+        _planner_reviews_by_index(goal["goal_id"], services).values(),
+        key=lambda review: review["suggestion_index"],
+    )
+    summary = _planner_review_summary(plan)
     return {
-        "goal_id": review_list["goal_id"],
-        "goal_title": review_list["goal_title"],
+        "goal_id": plan["goal_id"],
+        "goal_title": plan["goal_title"],
         "state": goal["state"],
-        "source": review_list["source"],
+        "source": plan["source"],
         "summary": summary,
         "last_reviewed_at": max((review["updated_at"] for review in reviews), default=None),
         "needs_review": summary["pending"] > 0,
+        "next_suggestion": _planner_review_inbox_next_suggestion(plan),
     }
 
 

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -648,6 +648,10 @@ function plannerReviewInboxVisibleItems(payload) {
     item.goal_title,
     item.state,
     item.needs_review ? "needs review" : "reviewed",
+    item.next_suggestion?.title || "",
+    item.next_suggestion?.description || "",
+    item.next_suggestion?.rationale || "",
+    item.next_suggestion?.priority_hint || "",
   ]);
 }
 
@@ -749,6 +753,23 @@ function renderPlannerReviewInbox(payload) {
       const reviewState = item.needs_review ? "Needs review" : "Reviewed";
       const lastReviewed = item.last_reviewed_at || "no saved decisions";
       const itemSummary = item.summary || {};
+      const nextSuggestion = item.next_suggestion
+        ? `
+          <div class="card" style="background:rgba(255,255,255,0.48);">
+            <div class="entity-header">
+              <div>
+                <div class="meta">Next pending suggestion #${Number(item.next_suggestion.suggestion_index) + 1}</div>
+                <div class="entity-title">${escapeHtml(item.next_suggestion.title)}</div>
+              </div>
+              <span class="pill ${stateClass(item.next_suggestion.priority_hint)}">
+                ${escapeHtml(item.next_suggestion.priority_hint)}
+              </span>
+            </div>
+            <p class="meta">${escapeHtml(item.next_suggestion.description)}</p>
+            <p class="meta"><strong>Why suggested:</strong> ${escapeHtml(item.next_suggestion.rationale)}</p>
+          </div>
+        `
+        : `<div class="meta">No pending planner suggestions.</div>`;
       return `
         <article class="entity-card ${selectedGoalId === item.goal_id ? "selected" : ""}">
           <div class="entity-header">
@@ -764,6 +785,7 @@ function renderPlannerReviewInbox(payload) {
             <div class="entity-metric"><span class="meta">Deferred</span><strong>${itemSummary.deferred || 0}</strong></div>
             <div class="entity-metric"><span class="meta">Rejected</span><strong>${itemSummary.rejected || 0}</strong></div>
           </div>
+          ${nextSuggestion}
           <div class="actions" style="margin-top:0.75rem;">
             <button type="button" class="secondary" data-plan-goal="${escapeHtml(item.goal_id)}">Open Plan Preview</button>
           </div>

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -16117,6 +16117,56 @@ def test_272o_goal_planner_review_inbox_returns_goal_rollup(client):
     assert items_by_goal[mixed_goal["goal_id"]]["last_reviewed_at"] is not None
     assert items_by_goal[reviewed_goal["goal_id"]]["summary"]["pending"] == 0
     assert items_by_goal[reviewed_goal["goal_id"]]["needs_review"] is False
+    assert items_by_goal[reviewed_goal["goal_id"]]["next_suggestion"] is None
+
+
+def test_272o2_goal_planner_review_inbox_exposes_next_pending_suggestion(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Inbox next planner suggestion", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    preview = client.post(f"/goals/{goal['goal_id']}/plan").json()
+
+    client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 0, "decision": "deferred", "comment": "Sequence later."},
+    )
+
+    response = client.get("/goals/planner/reviews")
+    item = response.json()["items"][0]
+    expected = preview["suggestions"][1]
+
+    assert response.status_code == 200
+    assert item["goal_id"] == goal["goal_id"]
+    assert item["needs_review"] is True
+    assert item["next_suggestion"] == {
+        "suggestion_index": 1,
+        "title": expected["title"],
+        "description": expected["description"],
+        "rationale": expected["rationale"],
+        "priority_hint": expected["priority_hint"],
+        "source": expected["source"],
+    }
+    assert client.get(f"/tasks?goal_id={goal['goal_id']}").json() == []
+
+
+def test_272o3_goal_planner_review_inbox_next_suggestion_empty_when_reviewed(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Inbox fully reviewed planner suggestions", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    total = len(client.post(f"/goals/{goal['goal_id']}/plan").json()["suggestions"])
+
+    client.post(
+        f"/goals/{goal['goal_id']}/plan/tasks/bulk",
+        json={"suggestion_indexes": list(range(total)), "overrides": {}},
+    )
+
+    item = client.get("/goals/planner/reviews").json()["items"][0]
+
+    assert item["needs_review"] is False
+    assert item["summary"]["pending"] == 0
+    assert item["next_suggestion"] is None
 
 
 def test_272p_goal_planner_review_inbox_empty_state(client):


### PR DESCRIPTION
﻿## Summary
- add `next_suggestion` to Planner Review Inbox items so operators can see the next pending suggestion without opening the full preview
- render the next pending suggestion title, description, rationale, priority, and index in the inbox card
- keep the inbox read-only: no tasks or reviews are created by loading it

## Why
The inbox currently shows rollup counts but hides the concrete next item behind an extra click. This makes triage slower. Showing the next pending suggestion keeps supervision explicit while making the operator’s next step visible.

## Validation
- `node --check goal_ops_console\static\app.js`
- `python -m py_compile goal_ops_console\models.py goal_ops_console\routers\goals.py`
- `git diff --check` (line-ending warnings only)
- `python -m pytest tests\test_goal_ops.py::test_272o2_goal_planner_review_inbox_exposes_next_pending_suggestion tests\test_goal_ops.py::test_272o3_goal_planner_review_inbox_next_suggestion_empty_when_reviewed -q`
- `python -m pytest tests\test_goal_ops.py -q -k "goal_plan_preview or planner_review_inbox or deferred_followups"`
- Browser smoke on local uvicorn/temp DB: inbox renders `Next pending suggestion #1` and the concrete planner suggestion

## Notes
- No CI/Guard workflow changes.
- `artifacts/` remains intentionally untouched/untracked.
