### PR TITLE
[codex] Focus next planner review suggestion

### DIFF
--- a/goal_ops_console/routers/system.py
+++ b/goal_ops_console/routers/system.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import platform
 from datetime import UTC, datetime
@@ -21,6 +22,14 @@ router = APIRouter(tags=["system"])
 
 def _utc_iso() -> str:
     return datetime.now(UTC).isoformat()
+
+
+def _static_asset_version() -> str:
+    app_js = Path(__file__).resolve().parents[1] / "static" / "app.js"
+    try:
+        return hashlib.sha256(app_js.read_bytes()).hexdigest()[:12]
+    except OSError:
+        return SPEC_VERSION
 
 
 def _build_health_payload(services: AppServices) -> dict[str, Any]:
@@ -501,7 +510,7 @@ def dashboard(request: Request) -> HTMLResponse:
     return templates.TemplateResponse(
         request=request,
         name="index.html",
-        context={"spec_version": SPEC_VERSION},
+        context={"spec_version": SPEC_VERSION, "static_asset_version": _static_asset_version()},
     )
 
 

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -43,6 +43,7 @@ let globalFilterTerm = "";
 let jumpScrollScheduled = false;
 let plannerReviewInboxStatus = "needs_review";
 let plannerReviewInboxSort = "needs_review";
+let focusedPlannerSuggestionIndex = null;
 const MUTATION_LOCK_FALLBACK_MESSAGE = (
   "Mutating operations are blocked while runtime is in critical protection mode."
 );
@@ -655,9 +656,40 @@ function plannerReviewInboxVisibleItems(payload) {
   ]);
 }
 
-function nextPlannerReviewGoalId() {
+function nextPlannerReviewItem() {
   return plannerReviewInboxVisibleItems(viewCache.plannerReviewInbox)
-    .find((item) => item.needs_review)?.goal_id || "";
+    .find((item) => item.needs_review) || null;
+}
+
+function normalizePlannerSuggestionFocus(indexValue, suggestions) {
+  const index = Number.parseInt(indexValue, 10);
+  if (!Number.isInteger(index) || index < 0 || index >= (suggestions || []).length) {
+    return null;
+  }
+  const suggestion = suggestions[index];
+  if (suggestion?.task_exists || plannerSuggestionDecision(suggestion) !== "pending") {
+    return null;
+  }
+  return index;
+}
+
+function firstPendingPlannerSuggestionIndex(suggestions) {
+  const index = (suggestions || []).findIndex((suggestion) => (
+    !suggestion?.task_exists && plannerSuggestionDecision(suggestion) === "pending"
+  ));
+  return index >= 0 ? index : null;
+}
+
+function scrollPlannerSuggestionIntoView(index) {
+  if (!Number.isInteger(index)) {
+    return;
+  }
+  window.requestAnimationFrame(() => {
+    const target = document.querySelector(`[data-planner-suggestion-index="${index}"]`);
+    if (target) {
+      target.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  });
 }
 
 function renderPlannerReviewSummary(preview) {
@@ -923,8 +955,18 @@ function renderPlannerPreview(preview) {
       <textarea data-plan-bulk-review-comment="true" rows="2" placeholder="Shared note for Defer selected or Reject selected"></textarea>
     </label>
     <div class="stack-list" style="margin-top:0.75rem;">
-      ${suggestions.map((item, index) => `
-        <article class="entity-card">
+      ${suggestions.map((item, index) => {
+        const isFocusedReviewTarget = focusedPlannerSuggestionIndex === index
+          && !item.task_exists
+          && plannerSuggestionDecision(item) === "pending";
+        const focusMarker = isFocusedReviewTarget
+          ? `<div class="meta planner-review-focus-label"><strong>Next review target</strong> from Review Inbox.</div>`
+          : "";
+        return `
+        <article
+          class="entity-card ${isFocusedReviewTarget ? "planner-suggestion-focus" : ""}"
+          data-planner-suggestion-index="${escapeHtml(String(index))}"
+        >
           <div class="entity-header">
             <div>
               <div class="entity-title">${escapeHtml(item.title)}</div>
@@ -932,6 +974,7 @@ function renderPlannerPreview(preview) {
             </div>
             <span class="pill state-${escapeHtml(item.priority_hint)}">${escapeHtml(item.priority_hint)}</span>
           </div>
+          ${focusMarker}
           <p class="meta">${escapeHtml(item.description)}</p>
           <p class="meta"><strong>Why suggested:</strong> ${escapeHtml(item.rationale)}</p>
           ${renderPlannerSuggestionEditor(item, index)}
@@ -941,7 +984,8 @@ function renderPlannerPreview(preview) {
             ${renderPlannerSuggestionAction(item, index)}
           </div>
         </article>
-      `).join("")}
+      `;
+      }).join("")}
     </div>
   `;
   applyMutationControlState();
@@ -1814,7 +1858,7 @@ async function runOperatorAction(action) {
   await refreshAll();
 }
 
-async function runPlannerPreview(goalId) {
+async function runPlannerPreview(goalId, options = {}) {
   if (!goalId) {
     throw new Error("Select a goal before requesting a plan preview.");
   }
@@ -1822,6 +1866,13 @@ async function runPlannerPreview(goalId) {
   const reviewQueue = await api(`/goals/${encodeURIComponent(goalId)}/plan/reviews`);
   const reviewAudit = await api(`/goals/${encodeURIComponent(goalId)}/plan/reviews/audit`);
   plannerPreview = { ...preview, review_queue: reviewQueue, review_audit: reviewAudit };
+  focusedPlannerSuggestionIndex = normalizePlannerSuggestionFocus(
+    options.focusSuggestionIndex,
+    plannerPreview.suggestions,
+  );
+  if (focusedPlannerSuggestionIndex === null && options.focusNextPending) {
+    focusedPlannerSuggestionIndex = firstPendingPlannerSuggestionIndex(plannerPreview.suggestions);
+  }
   selectedGoalId = goalId;
   document.getElementById("task-goal-id").value = goalId;
   document.getElementById("event-correlation-id").value = goalId;
@@ -1831,6 +1882,7 @@ async function runPlannerPreview(goalId) {
   renderPlannerReviewInbox(viewCache.plannerReviewInbox);
   renderPlannerDeferredFollowups(viewCache.plannerDeferredFollowups);
   updateSelectedGoalLabel();
+  scrollPlannerSuggestionIntoView(focusedPlannerSuggestionIndex);
 }
 
 function parsePlannerSuggestionIndex(indexValue) {
@@ -2514,11 +2566,18 @@ document.addEventListener("click", async (event) => {
     }
 
     if (planNextReview) {
-      const nextGoalId = nextPlannerReviewGoalId();
+      const nextReviewItem = nextPlannerReviewItem();
+      const nextGoalId = nextReviewItem?.goal_id || "";
       if (!nextGoalId) {
         throw new Error("No planner review item is available in the current inbox view.");
       }
-      await runPlannerPreview(nextGoalId);
+      const focusSuggestionIndex = nextReviewItem?.next_suggestion?.suggestion_index;
+      await runPlannerPreview(nextGoalId, { focusSuggestionIndex, focusNextPending: true });
+      if (Number.isInteger(focusedPlannerSuggestionIndex)) {
+        document.getElementById("system-feedback").textContent = (
+          `Opened next review target: suggestion #${focusedPlannerSuggestionIndex + 1}.`
+        );
+      }
       setActiveJump("goals-section");
     }
 

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -583,6 +583,14 @@
       border-color: rgba(196, 106, 45, 0.45);
       box-shadow: 0 0 0 2px rgba(196, 106, 45, 0.12);
     }
+    .planner-suggestion-focus {
+      border-color: rgba(27, 102, 97, 0.46);
+      box-shadow: 0 0 0 3px rgba(27, 102, 97, 0.13), 0 18px 36px rgba(27, 102, 97, 0.12);
+      background: linear-gradient(135deg, rgba(230, 247, 242, 0.9), rgba(255, 255, 255, 0.82));
+    }
+    .planner-review-focus-label {
+      color: #1b6661;
+    }
     .entity-header {
       display: flex;
       justify-content: space-between;
@@ -1058,6 +1066,6 @@
                \-> failed -> running|exhausted|poison</pre>
     </section>
   </main>
-  <script src="/static/app.js"></script>
+  <script src="/static/app.js?v={{ static_asset_version }}"></script>
 </body>
 </html>

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -16169,6 +16169,25 @@ def test_272o3_goal_planner_review_inbox_next_suggestion_empty_when_reviewed(cli
     assert item["next_suggestion"] is None
 
 
+def test_272o4_planner_review_inbox_open_next_review_focus_contract():
+    project_root = Path(__file__).resolve().parents[1]
+    app_js = (project_root / "goal_ops_console" / "static" / "app.js").read_text(encoding="utf-8")
+    template = (project_root / "goal_ops_console" / "templates" / "index.html").read_text(encoding="utf-8")
+    system_router = (project_root / "goal_ops_console" / "routers" / "system.py").read_text(encoding="utf-8")
+
+    assert "function nextPlannerReviewItem()" in app_js
+    assert "function firstPendingPlannerSuggestionIndex(suggestions)" in app_js
+    assert "nextReviewItem?.next_suggestion?.suggestion_index" in app_js
+    assert "runPlannerPreview(nextGoalId, { focusSuggestionIndex, focusNextPending: true })" in app_js
+    assert "data-planner-suggestion-index" in app_js
+    assert "scrollPlannerSuggestionIntoView(focusedPlannerSuggestionIndex)" in app_js
+    assert "Opened next review target" in app_js
+    assert "planner-suggestion-focus" in app_js
+    assert ".planner-suggestion-focus" in template
+    assert 'src="/static/app.js?v={{ static_asset_version }}"' in template
+    assert '"static_asset_version": _static_asset_version()' in system_router
+
+
 def test_272p_goal_planner_review_inbox_empty_state(client):
     response = client.get("/goals/planner/reviews")
 


### PR DESCRIPTION
﻿## Summary
- Focuses the Planner Preview card that matches the Review Inbox `next_suggestion` when operators click `Open next review`.
- Adds a pending-suggestion fallback so stale or missing inbox indexes still focus the next actionable item from the freshly loaded preview.
- Adds a static asset hash query for `app.js` so dashboard UI changes are not hidden by browser cache.
- Adds a focused contract test for the Review Inbox to Preview handoff.

## Validation
- `node --check goal_ops_console\static\app.js`
- `python -m pytest tests\test_goal_ops.py -q -k "272o or 272p or 272q or 272r"`
- Bundled Playwright smoke: `Open next review` produced one `.planner-suggestion-focus` card at index `1` with feedback `Opened next review target: suggestion #2.`
- `python -m pytest -q` -> `360 passed in 315.17s (0:05:15)`

## Stability Scope
- No CI/guard workflow changes.
- No automatic task creation or planner mutation beyond existing explicit operator actions.
- `artifacts/` remains untracked and untouched.
