### PR TITLE
[codex] Continue planner reviews after actions

### DIFF
--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -680,6 +680,13 @@ function firstPendingPlannerSuggestionIndex(suggestions) {
   return index >= 0 ? index : null;
 }
 
+function plannerReviewContinuityMessage(prefix) {
+  if (Number.isInteger(focusedPlannerSuggestionIndex)) {
+    return `${prefix} Next review target: suggestion #${focusedPlannerSuggestionIndex + 1}.`;
+  }
+  return `${prefix} Review complete.`;
+}
+
 function scrollPlannerSuggestionIntoView(index) {
   if (!Number.isInteger(index)) {
     return;
@@ -938,6 +945,15 @@ function renderPlannerPreview(preview) {
   const selectableCount = suggestions.filter((item) => (
     !item.task_exists && plannerSuggestionDecision(item) === "pending"
   )).length;
+  const reviewComplete = suggestions.length > 0 && selectableCount === 0;
+  const completionBanner = reviewComplete
+    ? `
+      <div class="card planner-review-complete" role="status">
+        <strong>Review complete</strong>
+        <span class="meta">All planner suggestions are reviewed or already created.</span>
+      </div>
+    `
+    : "";
   container.innerHTML = `
     <span class="meta">Planner Preview &middot; ${escapeHtml(preview.source)}</span>
     <h3>${escapeHtml(preview.goal_title)}</h3>
@@ -954,13 +970,14 @@ function renderPlannerPreview(preview) {
       Batch review comment (optional)
       <textarea data-plan-bulk-review-comment="true" rows="2" placeholder="Shared note for Defer selected or Reject selected"></textarea>
     </label>
+    ${completionBanner}
     <div class="stack-list" style="margin-top:0.75rem;">
       ${suggestions.map((item, index) => {
         const isFocusedReviewTarget = focusedPlannerSuggestionIndex === index
           && !item.task_exists
           && plannerSuggestionDecision(item) === "pending";
         const focusMarker = isFocusedReviewTarget
-          ? `<div class="meta planner-review-focus-label"><strong>Next review target</strong> from Review Inbox.</div>`
+          ? `<div class="meta planner-review-focus-label"><strong>Next review target</strong> Continue with this pending suggestion.</div>`
           : "";
         return `
         <article
@@ -1975,7 +1992,7 @@ async function reviewPlannerSuggestion(indexValue, decision) {
       ...(comment ? { comment } : {}),
     }),
   });
-  document.getElementById("system-feedback").textContent = (
+  const feedbackPrefix = (
     `Planner suggestion #${response.suggestion_index + 1} marked ${response.review.decision}.`
   );
   selectedGoalId = goalId;
@@ -1984,7 +2001,8 @@ async function reviewPlannerSuggestion(indexValue, decision) {
   document.getElementById("trace-goal-id").value = goalId;
   document.getElementById("fault-goal-id").value = goalId;
   await refreshAll();
-  await runPlannerPreview(goalId);
+  await runPlannerPreview(goalId, { focusNextPending: true });
+  document.getElementById("system-feedback").textContent = plannerReviewContinuityMessage(feedbackPrefix);
 }
 
 async function reviewSelectedPlannerSuggestions(decision) {
@@ -2010,7 +2028,7 @@ async function reviewSelectedPlannerSuggestions(decision) {
       ...(comment ? { comment } : {}),
     }),
   });
-  document.getElementById("system-feedback").textContent = (
+  const feedbackPrefix = (
     `Bulk planner review completed: ${response.reviews.length} suggestions marked ${response.decision}.`
   );
   selectedGoalId = goalId;
@@ -2019,7 +2037,8 @@ async function reviewSelectedPlannerSuggestions(decision) {
   document.getElementById("trace-goal-id").value = goalId;
   document.getElementById("fault-goal-id").value = goalId;
   await refreshAll();
-  await runPlannerPreview(goalId);
+  await runPlannerPreview(goalId, { focusNextPending: true });
+  document.getElementById("system-feedback").textContent = plannerReviewContinuityMessage(feedbackPrefix);
   setActiveJump("goals-section");
 }
 
@@ -2088,7 +2107,7 @@ async function createTaskFromPlannerSuggestion(indexValue) {
       ...(override ? { override } : {}),
     }),
   });
-  document.getElementById("system-feedback").textContent = (
+  const feedbackPrefix = (
     `Created planner task ${response.task.task_id}`
     + `${override ? " with operator edits." : "."}`
   );
@@ -2098,8 +2117,9 @@ async function createTaskFromPlannerSuggestion(indexValue) {
   document.getElementById("trace-goal-id").value = goalId;
   document.getElementById("fault-goal-id").value = goalId;
   await refreshAll();
-  await runPlannerPreview(goalId);
-  setActiveJump("tasks-section");
+  await runPlannerPreview(goalId, { focusNextPending: true });
+  document.getElementById("system-feedback").textContent = plannerReviewContinuityMessage(feedbackPrefix);
+  setActiveJump("goals-section");
 }
 
 async function createTasksFromSelectedPlannerSuggestions() {
@@ -2121,7 +2141,7 @@ async function createTasksFromSelectedPlannerSuggestions() {
       overrides,
     }),
   });
-  document.getElementById("system-feedback").textContent = (
+  const feedbackPrefix = (
     `Bulk planner create completed: ${response.created.length} created, `
     + `${response.skipped_duplicates.length} duplicates skipped.`
   );
@@ -2131,8 +2151,9 @@ async function createTasksFromSelectedPlannerSuggestions() {
   document.getElementById("trace-goal-id").value = goalId;
   document.getElementById("fault-goal-id").value = goalId;
   await refreshAll();
-  await runPlannerPreview(goalId);
-  setActiveJump("tasks-section");
+  await runPlannerPreview(goalId, { focusNextPending: true });
+  document.getElementById("system-feedback").textContent = plannerReviewContinuityMessage(feedbackPrefix);
+  setActiveJump("goals-section");
 }
 
 function parseWorkflowPayload(text) {

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -591,6 +591,12 @@
     .planner-review-focus-label {
       color: #1b6661;
     }
+    .planner-review-complete {
+      border-color: rgba(43, 120, 74, 0.28);
+      background: linear-gradient(135deg, rgba(234, 248, 236, 0.9), rgba(255, 255, 255, 0.78));
+      color: #24543c;
+      margin-top: 0.75rem;
+    }
     .entity-header {
       display: flex;
       justify-content: space-between;

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -16177,13 +16177,17 @@ def test_272o4_planner_review_inbox_open_next_review_focus_contract():
 
     assert "function nextPlannerReviewItem()" in app_js
     assert "function firstPendingPlannerSuggestionIndex(suggestions)" in app_js
+    assert "function plannerReviewContinuityMessage(prefix)" in app_js
     assert "nextReviewItem?.next_suggestion?.suggestion_index" in app_js
     assert "runPlannerPreview(nextGoalId, { focusSuggestionIndex, focusNextPending: true })" in app_js
+    assert "runPlannerPreview(goalId, { focusNextPending: true })" in app_js
     assert "data-planner-suggestion-index" in app_js
     assert "scrollPlannerSuggestionIntoView(focusedPlannerSuggestionIndex)" in app_js
     assert "Opened next review target" in app_js
+    assert "Review complete" in app_js
     assert "planner-suggestion-focus" in app_js
     assert ".planner-suggestion-focus" in template
+    assert ".planner-review-complete" in template
     assert 'src="/static/app.js?v={{ static_asset_version }}"' in template
     assert '"static_asset_version": _static_asset_version()' in system_router
 


### PR DESCRIPTION
﻿## Summary
- Keeps operators in the Planner Preview after Create task, Defer, Reject, and bulk planner review/create actions.
- Automatically focuses the next pending suggestion after an action.
- Shows a clear `Review complete` state when no pending planner suggestions remain.
- Adds UI contract coverage for the continuation affordance.

## Validation
- `node --check goal_ops_console\static\app.js`
- `python -m pytest tests\test_goal_ops.py -q -k "272o or 272p or 272q or 272r"`
- Bundled Playwright smoke:
  - Create task focused next suggestion at index `1` with feedback `Next review target: suggestion #2.`
  - Final reject showed `Review complete` and no focused pending card.
- `python -m pytest -q` -> `360 passed in 311.54s (0:05:11)`

## Stability Scope
- No backend mutation semantics changed.
- No CI/guard workflow changes.
- No automatic task creation beyond existing explicit operator actions.
- `artifacts/` remains untracked and untouched.
