### PR TITLE
[codex] Add planner handoff summary

### DIFF
--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -198,6 +198,36 @@ class PlannerReviewAuditResponse(BaseModel):
     entries: list[PlannerReviewAuditEntry]
 
 
+class PlannerHandoffSuggestionItem(BaseModel):
+    suggestion_index: int
+    title: str
+    description: str
+    rationale: str
+    priority_hint: str
+    source: str
+    comment: str | None = None
+    reviewed_at: str | None = None
+
+
+class PlannerHandoffCreatedTaskItem(PlannerHandoffSuggestionItem):
+    task_id: str
+    task_title: str
+    task_status: str
+    operator_override: dict[str, Any] | None = None
+
+
+class PlannerReviewHandoffResponse(BaseModel):
+    goal_id: str
+    goal_title: str
+    source: str
+    summary: PlannerReviewSummary
+    next_operator_action: str
+    created_tasks: list[PlannerHandoffCreatedTaskItem]
+    deferred_suggestions: list[PlannerHandoffSuggestionItem]
+    rejected_suggestions: list[PlannerHandoffSuggestionItem]
+    pending_suggestions: list[PlannerHandoffSuggestionItem]
+
+
 class PlannerReviewInboxNextSuggestion(BaseModel):
     suggestion_index: int
     title: str

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -18,6 +18,7 @@ from goal_ops_console.models import (
     PlannerReviewAuditResponse,
     PlannerReviewDecisionRequest,
     PlannerReviewDecisionResponse,
+    PlannerReviewHandoffResponse,
     PlannerReviewInboxResponse,
     PlannerReviewListResponse,
     PlannerReviewReopenResponse,
@@ -267,6 +268,81 @@ def _planner_review_audit(goal_id: str, services: AppServices, *, limit: int = 1
         "source": plan["source"],
         "summary": _planner_review_summary(plan),
         "entries": entries,
+    }
+
+
+def _planner_handoff_suggestion_item(suggestion_index: int, suggestion: dict, review: dict | None = None) -> dict:
+    return {
+        "suggestion_index": suggestion_index,
+        "title": suggestion["title"],
+        "description": suggestion["description"],
+        "rationale": suggestion["rationale"],
+        "priority_hint": suggestion["priority_hint"],
+        "source": suggestion["source"],
+        "comment": review["comment"] if review is not None else None,
+        "reviewed_at": review["updated_at"] if review is not None else None,
+    }
+
+
+def _planner_handoff_next_operator_action(summary: dict) -> str:
+    if summary["pending"] > 0:
+        return "Review pending planner suggestions; create, defer, or reject the next suggestion."
+    if summary["deferred"] > 0:
+        return "Resolve deferred planner follow-ups or reopen them when ready."
+    if summary["created"] > 0:
+        return "Execute or monitor created planner tasks and validate evidence."
+    if summary["rejected"] > 0:
+        return "Confirm rejected suggestions remain intentionally out of scope."
+    return "Run Planner Preview to generate deterministic suggestions."
+
+
+def _planner_review_handoff(goal_id: str, services: AppServices) -> dict:
+    plan = _preview_goal_plan(goal_id, services)
+    summary = _planner_review_summary(plan)
+    reviews_by_index = _planner_reviews_by_index(goal_id, services)
+    tasks_by_id = {
+        task["task_id"]: task
+        for task in services.execution_layer.list_tasks(goal_id=goal_id)
+    }
+    created_tasks = []
+    deferred_suggestions = []
+    rejected_suggestions = []
+    pending_suggestions = []
+
+    for suggestion_index, suggestion in enumerate(plan["suggestions"]):
+        review = reviews_by_index.get(suggestion_index)
+        decision = suggestion["review_decision"]
+        if decision == "created":
+            task_id = suggestion["review_task_id"] or suggestion["existing_task_id"]
+            if not task_id:
+                continue
+            task = tasks_by_id.get(task_id, {})
+            created_tasks.append(
+                {
+                    **_planner_handoff_suggestion_item(suggestion_index, suggestion, review),
+                    "task_id": task_id,
+                    "task_title": task.get("title") or suggestion["title"],
+                    "task_status": task.get("status") or "unknown",
+                    "operator_override": review["operator_override"] if review is not None else None,
+                }
+            )
+        elif decision == "deferred":
+            deferred_suggestions.append(_planner_handoff_suggestion_item(suggestion_index, suggestion, review))
+        elif decision == "rejected":
+            rejected_suggestions.append(_planner_handoff_suggestion_item(suggestion_index, suggestion, review))
+        else:
+            pending_suggestions.append(_planner_handoff_suggestion_item(suggestion_index, suggestion))
+
+    return {
+        "goal_id": plan["goal_id"],
+        "goal_title": plan["goal_title"],
+        "source": plan["source"],
+        "summary": summary,
+        "next_operator_action": _planner_handoff_next_operator_action(summary),
+        "created_tasks": created_tasks,
+        "deferred_suggestions": deferred_suggestions,
+        "rejected_suggestions": rejected_suggestions,
+        "pending_suggestions": pending_suggestions,
     }
 
 
@@ -610,6 +686,14 @@ def list_plan_suggestion_review_audit(
     services: AppServices = Depends(get_services),
 ) -> dict:
     return _planner_review_audit(goal_id, services, limit=limit)
+
+
+@router.get("/{goal_id}/plan/handoff", response_model=PlannerReviewHandoffResponse)
+def get_plan_review_handoff(
+    goal_id: str,
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return _planner_review_handoff(goal_id, services)
 
 
 @router.get("/planner/reviews", response_model=PlannerReviewInboxResponse)

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -766,6 +766,118 @@ function renderPlannerReviewAudit(preview) {
   `;
 }
 
+function plannerReviewHandoff(preview) {
+  return preview.review_handoff || {
+    summary: plannerReviewSummaryFromSuggestions(preview.suggestions || []),
+    next_operator_action: "Run Planner Preview and review suggestions before handoff.",
+    created_tasks: [],
+    deferred_suggestions: [],
+    rejected_suggestions: [],
+    pending_suggestions: [],
+  };
+}
+
+function renderPlannerHandoffSuggestionItem(item) {
+  const comment = item.comment ? `<div class="meta">Comment: ${escapeHtml(item.comment)}</div>` : "";
+  const reviewedAt = item.reviewed_at ? ` &middot; ${escapeHtml(item.reviewed_at)}` : "";
+  return `
+    <div class="card planner-handoff-item">
+      <div class="entity-header">
+        <div>
+          <div class="meta">Suggestion #${Number(item.suggestion_index) + 1}${reviewedAt}</div>
+          <div class="entity-title">${escapeHtml(item.title)}</div>
+        </div>
+        <span class="pill state-${escapeHtml(item.priority_hint)}">${escapeHtml(item.priority_hint)}</span>
+      </div>
+      <p class="meta">${escapeHtml(item.description)}</p>
+      <p class="meta"><strong>Why suggested:</strong> ${escapeHtml(item.rationale)}</p>
+      ${comment}
+    </div>
+  `;
+}
+
+function renderPlannerHandoffTaskItem(item) {
+  const override = item.operator_override && typeof item.operator_override === "object"
+    ? Object.keys(item.operator_override).sort().join(", ")
+    : "";
+  const overrideLine = override ? `<div class="meta">Operator edits: ${escapeHtml(override)}</div>` : "";
+  return `
+    <div class="card planner-handoff-item">
+      <div class="entity-header">
+        <div>
+          <div class="meta">Task ${escapeHtml(item.task_id)} &middot; suggestion #${Number(item.suggestion_index) + 1}</div>
+          <div class="entity-title">${escapeHtml(item.task_title || item.title)}</div>
+        </div>
+        <span class="pill ${stateClass(item.task_status)}">${escapeHtml(item.task_status || "unknown")}</span>
+      </div>
+      <p class="meta">${escapeHtml(item.description)}</p>
+      <p class="meta"><strong>Why suggested:</strong> ${escapeHtml(item.rationale)}</p>
+      ${overrideLine}
+    </div>
+  `;
+}
+
+function renderPlannerHandoffList(title, items, emptyMessage, itemRenderer) {
+  const content = items.length
+    ? items.map((item) => itemRenderer(item)).join("")
+    : `<div class="meta">${emptyMessage}</div>`;
+  return `
+    <details class="planner-handoff-list" open>
+      <summary class="meta">${escapeHtml(title)} (${items.length})</summary>
+      <div class="stack-list" style="margin-top:0.5rem;">${content}</div>
+    </details>
+  `;
+}
+
+function renderPlannerHandoffSummary(preview) {
+  const handoff = plannerReviewHandoff(preview);
+  const summary = handoff.summary || plannerReviewSummaryFromSuggestions(preview.suggestions || []);
+  return `
+    <div class="planner-handoff-card" aria-label="Planner handoff summary">
+      <div class="entity-header">
+        <div>
+          <span class="meta">Planner Handoff Summary</span>
+          <h3>Operator handoff</h3>
+        </div>
+        <span class="pill ${summary.pending ? "state-degraded" : "state-ok"}">
+          ${summary.pending ? "needs review" : "reviewed"}
+        </span>
+      </div>
+      <p class="meta"><strong>Next operator action:</strong> ${escapeHtml(handoff.next_operator_action)}</p>
+      <div class="entity-grid">
+        <div class="entity-metric"><span class="meta">Created Tasks</span><strong>${summary.created || 0}</strong></div>
+        <div class="entity-metric"><span class="meta">Deferred</span><strong>${summary.deferred || 0}</strong></div>
+        <div class="entity-metric"><span class="meta">Rejected</span><strong>${summary.rejected || 0}</strong></div>
+        <div class="entity-metric"><span class="meta">Pending</span><strong>${summary.pending || 0}</strong></div>
+      </div>
+      ${renderPlannerHandoffList(
+        "Created tasks",
+        handoff.created_tasks || [],
+        "No planner tasks have been created from this goal yet.",
+        renderPlannerHandoffTaskItem,
+      )}
+      ${renderPlannerHandoffList(
+        "Deferred suggestions",
+        handoff.deferred_suggestions || [],
+        "No deferred planner suggestions.",
+        renderPlannerHandoffSuggestionItem,
+      )}
+      ${renderPlannerHandoffList(
+        "Rejected suggestions",
+        handoff.rejected_suggestions || [],
+        "No rejected planner suggestions.",
+        renderPlannerHandoffSuggestionItem,
+      )}
+      ${renderPlannerHandoffList(
+        "Pending suggestions",
+        handoff.pending_suggestions || [],
+        "No pending planner suggestions.",
+        renderPlannerHandoffSuggestionItem,
+      )}
+    </div>
+  `;
+}
+
 function renderPlannerReviewInbox(payload) {
   const container = document.getElementById("planner-review-inbox");
   if (!container) return;
@@ -960,6 +1072,7 @@ function renderPlannerPreview(preview) {
     <div class="meta">${escapeHtml(preview.goal_id)} &middot; ${suggestions.length} suggested tasks &middot; no tasks created automatically</div>
     ${renderPlannerReviewSummary(preview)}
     ${renderPlannerReviewAudit(preview)}
+    ${renderPlannerHandoffSummary(preview)}
     <div class="actions" style="margin-top:0.75rem;">
       <button type="button" class="secondary" data-mutation-control="true" data-plan-bulk-create="true" ${selectableCount ? "" : "disabled"}>Create selected tasks</button>
       <button type="button" class="secondary" data-mutation-control="true" data-plan-bulk-review-decision="deferred" ${selectableCount ? "" : "disabled"}>Defer selected</button>
@@ -1882,7 +1995,13 @@ async function runPlannerPreview(goalId, options = {}) {
   const preview = await api(`/goals/${encodeURIComponent(goalId)}/plan`, { method: "POST" });
   const reviewQueue = await api(`/goals/${encodeURIComponent(goalId)}/plan/reviews`);
   const reviewAudit = await api(`/goals/${encodeURIComponent(goalId)}/plan/reviews/audit`);
-  plannerPreview = { ...preview, review_queue: reviewQueue, review_audit: reviewAudit };
+  const reviewHandoff = await api(`/goals/${encodeURIComponent(goalId)}/plan/handoff`);
+  plannerPreview = {
+    ...preview,
+    review_queue: reviewQueue,
+    review_audit: reviewAudit,
+    review_handoff: reviewHandoff,
+  };
   focusedPlannerSuggestionIndex = normalizePlannerSuggestionFocus(
     options.focusSuggestionIndex,
     plannerPreview.suggestions,

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -597,6 +597,32 @@
       color: #24543c;
       margin-top: 0.75rem;
     }
+    .planner-handoff-card {
+      display: grid;
+      gap: 0.75rem;
+      margin-top: 0.85rem;
+      padding: 0.9rem;
+      border: 1px solid rgba(35, 102, 173, 0.18);
+      border-radius: 14px;
+      background:
+        radial-gradient(circle at top right, rgba(35, 102, 173, 0.11), transparent 38%),
+        rgba(255, 255, 255, 0.7);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.82);
+    }
+    .planner-handoff-card h3 {
+      margin: 0.12rem 0 0;
+    }
+    .planner-handoff-list {
+      border-top: 1px solid rgba(31, 27, 23, 0.08);
+      padding-top: 0.55rem;
+    }
+    .planner-handoff-list summary {
+      cursor: pointer;
+      font-weight: 600;
+    }
+    .planner-handoff-item {
+      background: rgba(255, 255, 255, 0.62);
+    }
     .entity-header {
       display: flex;
       justify-content: space-between;

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -16057,6 +16057,106 @@ def test_272n_goal_plan_review_list_updates_after_reopen(client):
     assert after["reviews"] == []
 
 
+def test_272n2_goal_plan_handoff_summary_groups_review_outcomes(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Handoff planner outcomes", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    preview = client.post(f"/goals/{goal['goal_id']}/plan").json()
+    total = len(preview["suggestions"])
+    created = client.post(
+        f"/goals/{goal['goal_id']}/plan/tasks",
+        json={
+            "suggestion_index": 0,
+            "override": {"title": "Handoff-ready created task", "priority_hint": "high"},
+        },
+    ).json()
+    deferred = client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 1, "decision": "deferred", "comment": "Wait for owner confirmation."},
+    ).json()
+    rejected = client.post(
+        f"/goals/{goal['goal_id']}/plan/reviews",
+        json={"suggestion_index": 2, "decision": "rejected", "comment": "Not needed this cycle."},
+    ).json()
+
+    response = client.get(f"/goals/{goal['goal_id']}/plan/handoff")
+    payload = response.json()
+
+    assert response.status_code == 200
+    assert payload["goal_id"] == goal["goal_id"]
+    assert payload["goal_title"] == goal["title"]
+    assert payload["source"] == "deterministic_planner"
+    assert payload["summary"] == {
+        "total_suggestions": total,
+        "pending": total - 3,
+        "created": 1,
+        "deferred": 1,
+        "rejected": 1,
+    }
+    assert payload["next_operator_action"] == (
+        "Review pending planner suggestions; create, defer, or reject the next suggestion."
+    )
+    assert payload["created_tasks"] == [
+        {
+            "suggestion_index": 0,
+            "title": preview["suggestions"][0]["title"],
+            "description": preview["suggestions"][0]["description"],
+            "rationale": preview["suggestions"][0]["rationale"],
+            "priority_hint": preview["suggestions"][0]["priority_hint"],
+            "source": "deterministic_planner",
+            "comment": None,
+            "reviewed_at": created["review"]["updated_at"],
+            "task_id": created["task"]["task_id"],
+            "task_title": "Handoff-ready created task",
+            "task_status": "pending",
+            "operator_override": {"priority_hint": "high", "title": "Handoff-ready created task"},
+        }
+    ]
+    assert payload["deferred_suggestions"][0]["suggestion_index"] == 1
+    assert payload["deferred_suggestions"][0]["comment"] == "Wait for owner confirmation."
+    assert payload["deferred_suggestions"][0]["reviewed_at"] == deferred["review"]["updated_at"]
+    assert payload["rejected_suggestions"][0]["suggestion_index"] == 2
+    assert payload["rejected_suggestions"][0]["comment"] == "Not needed this cycle."
+    assert payload["rejected_suggestions"][0]["reviewed_at"] == rejected["review"]["updated_at"]
+    assert [item["suggestion_index"] for item in payload["pending_suggestions"]] == list(range(3, total))
+
+
+def test_272n3_goal_plan_handoff_summary_updates_when_review_complete(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Complete planner handoff", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    total = len(client.post(f"/goals/{goal['goal_id']}/plan").json()["suggestions"])
+
+    client.post(
+        f"/goals/{goal['goal_id']}/plan/tasks/bulk",
+        json={"suggestion_indexes": list(range(total)), "overrides": {}},
+    )
+
+    payload = client.get(f"/goals/{goal['goal_id']}/plan/handoff").json()
+
+    assert payload["summary"] == {
+        "total_suggestions": total,
+        "pending": 0,
+        "created": total,
+        "deferred": 0,
+        "rejected": 0,
+    }
+    assert payload["next_operator_action"] == "Execute or monitor created planner tasks and validate evidence."
+    assert len(payload["created_tasks"]) == total
+    assert payload["deferred_suggestions"] == []
+    assert payload["rejected_suggestions"] == []
+    assert payload["pending_suggestions"] == []
+
+
+def test_272n4_goal_plan_handoff_unknown_goal_returns_404(client):
+    response = client.get("/goals/missing-goal/plan/handoff")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Goal missing-goal not found"
+
+
 def test_272o_goal_planner_review_inbox_returns_goal_rollup(client):
     pending_goal = client.post(
         "/goals",
@@ -16178,9 +16278,14 @@ def test_272o4_planner_review_inbox_open_next_review_focus_contract():
     assert "function nextPlannerReviewItem()" in app_js
     assert "function firstPendingPlannerSuggestionIndex(suggestions)" in app_js
     assert "function plannerReviewContinuityMessage(prefix)" in app_js
+    assert "function renderPlannerHandoffSummary(preview)" in app_js
+    assert "function renderPlannerHandoffList(title, items, emptyMessage, itemRenderer)" in app_js
     assert "nextReviewItem?.next_suggestion?.suggestion_index" in app_js
     assert "runPlannerPreview(nextGoalId, { focusSuggestionIndex, focusNextPending: true })" in app_js
     assert "runPlannerPreview(goalId, { focusNextPending: true })" in app_js
+    assert "/plan/handoff" in app_js
+    assert "Planner Handoff Summary" in app_js
+    assert "Next operator action" in app_js
     assert "data-planner-suggestion-index" in app_js
     assert "scrollPlannerSuggestionIntoView(focusedPlannerSuggestionIndex)" in app_js
     assert "Opened next review target" in app_js
@@ -16188,6 +16293,7 @@ def test_272o4_planner_review_inbox_open_next_review_focus_contract():
     assert "planner-suggestion-focus" in app_js
     assert ".planner-suggestion-focus" in template
     assert ".planner-review-complete" in template
+    assert ".planner-handoff-card" in template
     assert 'src="/static/app.js?v={{ static_asset_version }}"' in template
     assert '"static_asset_version": _static_asset_version()' in system_router
 


### PR DESCRIPTION
﻿## Summary
- add a read-only planner handoff summary endpoint for each goal
- group planner outcomes into created tasks, deferred, rejected, and pending suggestions
- render the handoff summary in Planner Preview with the next recommended operator action

## Validation
- python -m py_compile goal_ops_console\models.py goal_ops_console\routers\goals.py
- node --check goal_ops_console\static\app.js
- git diff --check
- targeted pytest via local readline workaround: 4 handoff/UI-contract tests passed
- planner regression pytest via local readline workaround: 44 passed, 298 deselected
- Playwright browser smoke against local server confirmed Planner Handoff Summary renders

## Notes
- Full local pytest encountered unrelated Windows/Pytest environment instability around pyreadline3/PowerShell and an existing workflow timing flake; GitHub CI is the clean authority for the full matrix.
