### PR TITLE
[codex] Add global planner handoff queue

### DIFF
--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -228,6 +228,38 @@ class PlannerReviewHandoffResponse(BaseModel):
     pending_suggestions: list[PlannerHandoffSuggestionItem]
 
 
+class PlannerGlobalHandoffItem(BaseModel):
+    goal_id: str
+    goal_title: str
+    state: str
+    source: str
+    next_operator_action: str
+    needs_operator_attention: bool
+    summary: PlannerReviewSummary
+    pending: int
+    deferred: int
+    rejected: int
+    created: int
+    last_reviewed_at: str | None = None
+    next_pending_suggestion: PlannerHandoffSuggestionItem | None = None
+    latest_deferred_suggestion: PlannerHandoffSuggestionItem | None = None
+    created_task_statuses: dict[str, int] = Field(default_factory=dict)
+
+
+class PlannerGlobalHandoffSummary(BaseModel):
+    total_goals: int
+    goals_needing_attention: int
+    pending: int
+    deferred: int
+    rejected: int
+    created: int
+
+
+class PlannerGlobalHandoffResponse(BaseModel):
+    summary: PlannerGlobalHandoffSummary
+    items: list[PlannerGlobalHandoffItem]
+
+
 class PlannerReviewInboxNextSuggestion(BaseModel):
     suggestion_index: int
     title: str

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -14,6 +14,7 @@ from goal_ops_console.models import (
     PlannerBulkTaskCreateRequest,
     PlannerBulkTaskCreateResponse,
     PlannerDeferredFollowupResponse,
+    PlannerGlobalHandoffResponse,
     PlannerPreviewResponse,
     PlannerReviewAuditResponse,
     PlannerReviewDecisionRequest,
@@ -343,6 +344,91 @@ def _planner_review_handoff(goal_id: str, services: AppServices) -> dict:
         "deferred_suggestions": deferred_suggestions,
         "rejected_suggestions": rejected_suggestions,
         "pending_suggestions": pending_suggestions,
+    }
+
+
+def _latest_deferred_suggestion(handoff: dict) -> dict | None:
+    deferred_suggestions = handoff["deferred_suggestions"]
+    if not deferred_suggestions:
+        return None
+    return max(
+        deferred_suggestions,
+        key=lambda suggestion: (suggestion["reviewed_at"] or "", -suggestion["suggestion_index"]),
+    )
+
+
+def _created_task_statuses(handoff: dict) -> dict[str, int]:
+    statuses: dict[str, int] = {}
+    for task in handoff["created_tasks"]:
+        status = task["task_status"]
+        statuses[status] = statuses.get(status, 0) + 1
+    return statuses
+
+
+def _created_tasks_need_attention(handoff: dict) -> bool:
+    return any(task["task_status"] != "succeeded" for task in handoff["created_tasks"])
+
+
+def _planner_global_handoff_item(goal: dict, services: AppServices) -> dict:
+    handoff = _planner_review_handoff(goal["goal_id"], services)
+    reviews = _planner_reviews_by_index(goal["goal_id"], services).values()
+    summary = handoff["summary"]
+    needs_operator_attention = (
+        summary["pending"] > 0
+        or summary["deferred"] > 0
+        or _created_tasks_need_attention(handoff)
+    )
+    return {
+        "goal_id": handoff["goal_id"],
+        "goal_title": handoff["goal_title"],
+        "state": goal["state"],
+        "source": handoff["source"],
+        "next_operator_action": handoff["next_operator_action"],
+        "needs_operator_attention": needs_operator_attention,
+        "summary": summary,
+        "pending": summary["pending"],
+        "deferred": summary["deferred"],
+        "rejected": summary["rejected"],
+        "created": summary["created"],
+        "last_reviewed_at": max((review["updated_at"] for review in reviews), default=None),
+        "next_pending_suggestion": (
+            handoff["pending_suggestions"][0]
+            if handoff["pending_suggestions"]
+            else None
+        ),
+        "latest_deferred_suggestion": _latest_deferred_suggestion(handoff),
+        "created_task_statuses": _created_task_statuses(handoff),
+    }
+
+
+def _sort_planner_global_handoff_items(items: list[dict]) -> list[dict]:
+    return sorted(
+        items,
+        key=lambda item: (
+            0 if item["needs_operator_attention"] else 1,
+            0 if item["pending"] > 0 else 1,
+            0 if item["deferred"] > 0 else 1,
+            0 if item["created"] > 0 else 1,
+            item["goal_title"].lower(),
+            item["goal_id"],
+        ),
+    )
+
+
+def _planner_global_handoffs(services: AppServices) -> dict:
+    items = _sort_planner_global_handoff_items(
+        [_planner_global_handoff_item(goal, services) for goal in services.state_manager.list_goals()]
+    )
+    return {
+        "summary": {
+            "total_goals": len(items),
+            "goals_needing_attention": sum(1 for item in items if item["needs_operator_attention"]),
+            "pending": sum(item["pending"] for item in items),
+            "deferred": sum(item["deferred"] for item in items),
+            "rejected": sum(item["rejected"] for item in items),
+            "created": sum(item["created"] for item in items),
+        },
+        "items": items,
     }
 
 
@@ -710,6 +796,13 @@ def list_planner_deferred_followups(
     services: AppServices = Depends(get_services),
 ) -> dict:
     return _planner_deferred_followups(services)
+
+
+@router.get("/planner/handoffs", response_model=PlannerGlobalHandoffResponse)
+def list_planner_handoffs(
+    services: AppServices = Depends(get_services),
+) -> dict:
+    return _planner_global_handoffs(services)
 
 
 @router.post("/{goal_id}/plan/reviews", status_code=201, response_model=PlannerReviewDecisionResponse)

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -52,6 +52,7 @@ const viewCache = {
   goals: [],
   plannerReviewInbox: null,
   plannerDeferredFollowups: null,
+  plannerGlobalHandoffs: null,
   tasks: [],
   workflows: [],
   workflowRuns: [],
@@ -459,6 +460,7 @@ function rerenderFilteredViews() {
   renderGoals(viewCache.goals);
   renderPlannerReviewInbox(viewCache.plannerReviewInbox);
   renderPlannerDeferredFollowups(viewCache.plannerDeferredFollowups);
+  renderPlannerGlobalHandoffs(viewCache.plannerGlobalHandoffs);
   renderTasks(viewCache.tasks);
   renderWorkflows(viewCache.workflows, viewCache.workflowRuns);
   renderEvents(viewCache.events);
@@ -668,6 +670,14 @@ function normalizePlannerSuggestionFocus(indexValue, suggestions) {
   }
   const suggestion = suggestions[index];
   if (suggestion?.task_exists || plannerSuggestionDecision(suggestion) !== "pending") {
+    return null;
+  }
+  return index;
+}
+
+function normalizePlannerSuggestionScroll(indexValue, suggestions) {
+  const index = Number.parseInt(indexValue, 10);
+  if (!Number.isInteger(index) || index < 0 || index >= (suggestions || []).length) {
     return null;
   }
   return index;
@@ -982,6 +992,177 @@ function plannerDeferredFollowupVisibleItems(payload) {
     item.comment || "",
     item.deferred_at,
   ]);
+}
+
+function plannerGlobalHandoffItems(payload) {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  return payload?.items || payload?.handoffs || payload?.goals || [];
+}
+
+function plannerGlobalHandoffNeedsAttention(item) {
+  if (typeof item?.needs_operator_attention === "boolean") {
+    return item.needs_operator_attention;
+  }
+  if (typeof item?.needs_attention === "boolean") {
+    return item.needs_attention;
+  }
+  const summary = item?.summary || {};
+  return Boolean((summary.pending || 0) > 0 || (summary.deferred || 0) > 0);
+}
+
+function plannerGlobalHandoffVisibleItems(payload) {
+  return filterRows(plannerGlobalHandoffItems(payload), (item) => [
+    item.goal_id,
+    item.goal_title || item.title,
+    item.state,
+    item.source,
+    item.next_operator_action,
+    plannerGlobalHandoffNeedsAttention(item) ? "needs attention" : "reviewed",
+    item.next_pending_suggestion?.title || "",
+    item.next_pending?.title || "",
+    item.latest_deferred_suggestion?.title || "",
+    item.first_deferred_suggestion?.title || "",
+    item.first_deferred?.title || "",
+  ]);
+}
+
+function plannerGlobalHandoffSummary(payload) {
+  const summary = payload?.summary || {};
+  const items = plannerGlobalHandoffItems(payload);
+  return {
+    total_goals: summary.total_goals ?? items.length,
+    needs_attention: (
+      summary.needs_attention
+      ?? summary.goals_needing_attention
+      ?? items.filter((item) => plannerGlobalHandoffNeedsAttention(item)).length
+    ),
+    pending: summary.pending ?? summary.pending_suggestions ?? 0,
+    created: summary.created ?? summary.created_tasks ?? 0,
+    deferred: summary.deferred ?? summary.deferred_suggestions ?? 0,
+    rejected: summary.rejected ?? summary.rejected_suggestions ?? 0,
+  };
+}
+
+function firstPlannerHandoffSuggestion(item, key, fallbackKey, alternateKey = null) {
+  const candidate = item?.[key] || item?.[fallbackKey] || (alternateKey ? item?.[alternateKey] : null);
+  if (candidate) {
+    return candidate;
+  }
+  const listKey = key === "next_pending_suggestion" ? "pending_suggestions" : "deferred_suggestions";
+  return Array.isArray(item?.[listKey]) ? item[listKey][0] : null;
+}
+
+function plannerHandoffSuggestionIndex(item) {
+  const index = Number.parseInt(item?.suggestion_index, 10);
+  return Number.isInteger(index) && index >= 0 ? index : null;
+}
+
+function renderPlannerGlobalHandoffs(payload) {
+  const container = document.getElementById("planner-global-handoffs");
+  if (!container) return;
+  if (!payload) {
+    container.innerHTML = `
+      <span class="meta">Planner Handoff Queue</span>
+      <p class="meta">Global planner handoffs are loading.</p>
+    `;
+    return;
+  }
+  if (payload.error) {
+    container.innerHTML = `
+      <span class="meta">Planner Handoff Queue</span>
+      <p class="meta">Unable to load planner handoffs: ${escapeHtml(payload.error)}</p>
+      <div class="actions" style="margin-top:0.75rem;">
+        <button type="button" class="secondary" data-plan-handoffs-refresh="true">Refresh handoffs</button>
+      </div>
+    `;
+    return;
+  }
+
+  const summary = plannerGlobalHandoffSummary(payload);
+  const items = plannerGlobalHandoffVisibleItems(payload);
+  const itemMarkup = items.length
+    ? items.map((item) => {
+      const itemSummary = item.summary || {};
+      const pendingSuggestion = firstPlannerHandoffSuggestion(item, "next_pending_suggestion", "next_pending");
+      const deferredSuggestion = firstPlannerHandoffSuggestion(
+        item,
+        "latest_deferred_suggestion",
+        "first_deferred_suggestion",
+        "first_deferred",
+      );
+      const pendingIndex = plannerHandoffSuggestionIndex(pendingSuggestion);
+      const deferredIndex = plannerHandoffSuggestionIndex(deferredSuggestion);
+      const pendingAction = pendingSuggestion
+        ? `
+          <button
+            type="button"
+            class="secondary"
+            data-plan-goal="${escapeHtml(item.goal_id)}"
+            data-plan-focus-suggestion="${escapeHtml(String(pendingIndex ?? ""))}"
+            data-plan-focus-next-pending="true"
+          >Open next pending</button>
+        `
+        : "";
+      const deferredAction = deferredSuggestion
+        ? `
+          <button
+            type="button"
+            class="secondary"
+            data-plan-goal="${escapeHtml(item.goal_id)}"
+            data-plan-focus-suggestion="${escapeHtml(String(deferredIndex ?? ""))}"
+          >Open deferred follow-up</button>
+        `
+        : "";
+      const needsAttention = plannerGlobalHandoffNeedsAttention(item);
+      const attentionLabel = needsAttention ? "Needs attention" : "Ready";
+      const statusCounts = item.created_task_statuses && Object.keys(item.created_task_statuses).length
+        ? Object.keys(item.created_task_statuses)
+          .sort()
+          .map((status) => `${status}: ${item.created_task_statuses[status]}`)
+          .join(", ")
+        : "none";
+      return `
+        <article class="entity-card planner-global-handoff-item ${selectedGoalId === item.goal_id ? "selected" : ""}">
+          <div class="entity-header">
+            <div>
+              <div class="entity-title">${escapeHtml(item.goal_title || item.title || item.goal_id)}</div>
+              <div class="meta">${escapeHtml(item.goal_id)}${item.state ? ` &middot; ${escapeHtml(item.state)}` : ""}</div>
+            </div>
+            <span class="pill ${needsAttention ? "state-degraded" : "state-ok"}">${attentionLabel}</span>
+          </div>
+          <p class="meta"><strong>Next operator action:</strong> ${escapeHtml(item.next_operator_action || "Review planner handoff status.")}</p>
+          <p class="meta"><strong>Created task statuses:</strong> ${escapeHtml(statusCounts)}</p>
+          <div class="entity-grid">
+            <div class="entity-metric"><span class="meta">Created</span><strong>${itemSummary.created || 0}</strong></div>
+            <div class="entity-metric"><span class="meta">Deferred</span><strong>${itemSummary.deferred || 0}</strong></div>
+            <div class="entity-metric"><span class="meta">Rejected</span><strong>${itemSummary.rejected || 0}</strong></div>
+            <div class="entity-metric"><span class="meta">Pending</span><strong>${itemSummary.pending || 0}</strong></div>
+          </div>
+          <div class="actions" style="margin-top:0.75rem;">
+            <button type="button" class="secondary" data-plan-goal="${escapeHtml(item.goal_id)}">Open Plan Preview</button>
+            ${pendingAction}
+            ${deferredAction}
+          </div>
+        </article>
+      `;
+    }).join("")
+    : `<div class="meta">${filteredEmptyMessage("No planner handoffs are queued.")}</div>`;
+
+  container.innerHTML = `
+    <div class="entity-header">
+      <span class="meta">Planner Handoff Queue &middot; ${summary.total_goals || 0} goals</span>
+      <button type="button" class="secondary" data-plan-handoffs-refresh="true">Refresh handoffs</button>
+    </div>
+    <div class="entity-grid" style="margin-top:0.75rem;">
+      <div class="entity-metric planner-handoff-attention"><span class="meta">Needs Attention</span><strong>${summary.needs_attention || 0}</strong></div>
+      <div class="entity-metric"><span class="meta">Pending</span><strong>${summary.pending || 0}</strong></div>
+      <div class="entity-metric"><span class="meta">Deferred</span><strong>${summary.deferred || 0}</strong></div>
+      <div class="entity-metric"><span class="meta">Created</span><strong>${summary.created || 0}</strong></div>
+    </div>
+    <div class="stack-list" style="margin-top:0.75rem;">${itemMarkup}</div>
+  `;
 }
 
 function renderPlannerDeferredFollowups(payload) {
@@ -1787,6 +1968,16 @@ async function refreshPlannerDeferredFollowups() {
   renderPlannerDeferredFollowups(viewCache.plannerDeferredFollowups);
 }
 
+async function refreshPlannerGlobalHandoffs() {
+  try {
+    const payload = await api("/goals/planner/handoffs");
+    viewCache.plannerGlobalHandoffs = payload;
+  } catch (error) {
+    viewCache.plannerGlobalHandoffs = { error: error?.message || "Request failed" };
+  }
+  renderPlannerGlobalHandoffs(viewCache.plannerGlobalHandoffs);
+}
+
 async function refreshWorkflows() {
   const [workflowPayload, runPayload] = await Promise.all([
     api("/workflows"),
@@ -1914,6 +2105,7 @@ async function refreshAll() {
     refreshGoals(),
     refreshPlannerReviewInbox(),
     refreshPlannerDeferredFollowups(),
+    refreshPlannerGlobalHandoffs(),
     refreshTasks(),
     refreshWorkflows(),
     refreshEvents(),
@@ -1936,6 +2128,7 @@ function startAutoRefreshLoop() {
     refreshGoals().catch(() => {});
     refreshPlannerReviewInbox().catch(() => {});
     refreshPlannerDeferredFollowups().catch(() => {});
+    refreshPlannerGlobalHandoffs().catch(() => {});
     refreshTasks().catch(() => {});
     refreshWorkflows().catch(() => {});
     refreshEvents().catch(() => {});
@@ -2009,6 +2202,10 @@ async function runPlannerPreview(goalId, options = {}) {
   if (focusedPlannerSuggestionIndex === null && options.focusNextPending) {
     focusedPlannerSuggestionIndex = firstPendingPlannerSuggestionIndex(plannerPreview.suggestions);
   }
+  const scrollSuggestionIndex = normalizePlannerSuggestionScroll(
+    options.focusSuggestionIndex,
+    plannerPreview.suggestions,
+  );
   selectedGoalId = goalId;
   document.getElementById("task-goal-id").value = goalId;
   document.getElementById("event-correlation-id").value = goalId;
@@ -2017,8 +2214,9 @@ async function runPlannerPreview(goalId, options = {}) {
   renderPlannerPreview(plannerPreview);
   renderPlannerReviewInbox(viewCache.plannerReviewInbox);
   renderPlannerDeferredFollowups(viewCache.plannerDeferredFollowups);
+  renderPlannerGlobalHandoffs(viewCache.plannerGlobalHandoffs);
   updateSelectedGoalLabel();
-  scrollPlannerSuggestionIntoView(focusedPlannerSuggestionIndex);
+  scrollPlannerSuggestionIntoView(focusedPlannerSuggestionIndex ?? scrollSuggestionIndex);
 }
 
 function parsePlannerSuggestionIndex(indexValue) {
@@ -2537,7 +2735,12 @@ document.getElementById("flow-trace-form").addEventListener("submit", async (eve
 });
 
 document.getElementById("refresh-goals").addEventListener("click", async () => {
-  await Promise.all([refreshGoals(), refreshPlannerReviewInbox(), refreshPlannerDeferredFollowups()]);
+  await Promise.all([
+    refreshGoals(),
+    refreshPlannerReviewInbox(),
+    refreshPlannerDeferredFollowups(),
+    refreshPlannerGlobalHandoffs(),
+  ]);
 });
 document.getElementById("refresh-tasks").addEventListener("click", refreshTasks);
 document.getElementById("refresh-workflows").addEventListener("click", refreshWorkflows);
@@ -2646,6 +2849,9 @@ document.addEventListener("click", async (event) => {
   const planBulkReviewDecision = event.target.dataset.planBulkReviewDecision;
   const planInboxStatus = event.target.dataset.planInboxStatus;
   const planFollowupsRefresh = event.target.dataset.planFollowupsRefresh;
+  const planHandoffsRefresh = event.target.dataset.planHandoffsRefresh;
+  const planFocusSuggestion = event.target.dataset.planFocusSuggestion;
+  const planFocusNextPending = event.target.dataset.planFocusNextPending;
   const planFollowupReopenGoal = event.target.dataset.planFollowupReopenGoal;
   const planFollowupReopenIndex = event.target.dataset.planFollowupReopenIndex;
   const planNextReview = event.target.dataset.planNextReview;
@@ -2687,7 +2893,10 @@ document.addEventListener("click", async (event) => {
     }
 
     if (planGoal) {
-      await runPlannerPreview(planGoal);
+      await runPlannerPreview(planGoal, {
+        focusSuggestionIndex: planFocusSuggestion,
+        focusNextPending: planFocusNextPending === "true",
+      });
       setActiveJump("goals-section");
     }
 
@@ -2698,6 +2907,10 @@ document.addEventListener("click", async (event) => {
 
     if (planFollowupsRefresh) {
       await refreshPlannerDeferredFollowups();
+    }
+
+    if (planHandoffsRefresh) {
+      await refreshPlannerGlobalHandoffs();
     }
 
     if (planFollowupReopenGoal && planFollowupReopenIndex !== undefined) {
@@ -2792,7 +3005,8 @@ document.addEventListener("click", async (event) => {
       ? "system-feedback"
       : workflowStart || workflowCancel
         ? "workflow-error"
-        : goalAction || planGoal || planInboxStatus || planFollowupsRefresh || planFollowupReopenGoal || planNextReview
+        : goalAction || planGoal || planInboxStatus || planFollowupsRefresh || planHandoffsRefresh
+          || planFollowupReopenGoal || planNextReview
           ? "goal-error"
           : "task-error";
     showError(target, error);

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -623,6 +623,18 @@
     .planner-handoff-item {
       background: rgba(255, 255, 255, 0.62);
     }
+    #planner-global-handoffs {
+      border-color: rgba(35, 102, 173, 0.16);
+      background:
+        radial-gradient(circle at top left, rgba(35, 102, 173, 0.09), transparent 34%),
+        rgba(255, 255, 255, 0.72);
+    }
+    .planner-global-handoff-item {
+      border-color: rgba(35, 102, 173, 0.12);
+    }
+    .planner-handoff-attention strong {
+      color: var(--warn);
+    }
     .entity-header {
       display: flex;
       justify-content: space-between;
@@ -885,6 +897,10 @@
       <div id="planner-review-inbox" class="card" aria-live="polite">
         <span class="meta">Planner Review Inbox</span>
         <p class="meta">Review coverage is loading.</p>
+      </div>
+      <div id="planner-global-handoffs" class="card" aria-live="polite">
+        <span class="meta">Planner Handoff Queue</span>
+        <p class="meta">Global planner handoffs are loading.</p>
       </div>
       <div id="planner-deferred-followups" class="card" aria-live="polite">
         <span class="meta">Deferred Follow-ups</span>

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -16280,20 +16280,27 @@ def test_272o4_planner_review_inbox_open_next_review_focus_contract():
     assert "function plannerReviewContinuityMessage(prefix)" in app_js
     assert "function renderPlannerHandoffSummary(preview)" in app_js
     assert "function renderPlannerHandoffList(title, items, emptyMessage, itemRenderer)" in app_js
+    assert "function renderPlannerGlobalHandoffs(payload)" in app_js
+    assert "function plannerGlobalHandoffNeedsAttention(item)" in app_js
     assert "nextReviewItem?.next_suggestion?.suggestion_index" in app_js
     assert "runPlannerPreview(nextGoalId, { focusSuggestionIndex, focusNextPending: true })" in app_js
     assert "runPlannerPreview(goalId, { focusNextPending: true })" in app_js
+    assert "/goals/planner/handoffs" in app_js
     assert "/plan/handoff" in app_js
     assert "Planner Handoff Summary" in app_js
+    assert "Planner Handoff Queue" in app_js
+    assert "Created task statuses" in app_js
     assert "Next operator action" in app_js
     assert "data-planner-suggestion-index" in app_js
-    assert "scrollPlannerSuggestionIntoView(focusedPlannerSuggestionIndex)" in app_js
+    assert "scrollPlannerSuggestionIntoView(focusedPlannerSuggestionIndex ?? scrollSuggestionIndex)" in app_js
     assert "Opened next review target" in app_js
     assert "Review complete" in app_js
     assert "planner-suggestion-focus" in app_js
     assert ".planner-suggestion-focus" in template
     assert ".planner-review-complete" in template
     assert ".planner-handoff-card" in template
+    assert "planner-global-handoffs" in template
+    assert ".planner-global-handoff-item" in template
     assert 'src="/static/app.js?v={{ static_asset_version }}"' in template
     assert '"static_asset_version": _static_asset_version()' in system_router
 

--- a/tests/test_planner_global_handoffs.py
+++ b/tests/test_planner_global_handoffs.py
@@ -1,0 +1,137 @@
+def _create_goal(client, title: str) -> dict:
+    response = client.post(
+        "/goals",
+        json={"title": title, "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def _planner_suggestion_count(client, goal_id: str) -> int:
+    response = client.post(f"/goals/{goal_id}/plan")
+    assert response.status_code == 200
+    return len(response.json()["suggestions"])
+
+
+def test_planner_global_handoffs_empty_state(client):
+    response = client.get("/goals/planner/handoffs")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "summary": {
+            "total_goals": 0,
+            "goals_needing_attention": 0,
+            "pending": 0,
+            "deferred": 0,
+            "rejected": 0,
+            "created": 0,
+        },
+        "items": [],
+    }
+
+
+def test_planner_global_handoffs_mixed_goals_rollup(client):
+    pending_goal = _create_goal(client, "Alpha pending handoff")
+    deferred_goal = _create_goal(client, "Beta deferred handoff")
+    created_goal = _create_goal(client, "Gamma created handoff")
+    rejected_goal = _create_goal(client, "Delta rejected handoff")
+
+    pending_total = _planner_suggestion_count(client, pending_goal["goal_id"])
+    deferred_total = _planner_suggestion_count(client, deferred_goal["goal_id"])
+    created_total = _planner_suggestion_count(client, created_goal["goal_id"])
+    rejected_total = _planner_suggestion_count(client, rejected_goal["goal_id"])
+
+    client.post(
+        f"/goals/{deferred_goal['goal_id']}/plan/reviews/bulk",
+        json={"suggestion_indexes": list(range(deferred_total)), "decision": "deferred", "comment": "Needs owner."},
+    )
+    client.post(
+        f"/goals/{created_goal['goal_id']}/plan/tasks/bulk",
+        json={"suggestion_indexes": list(range(created_total)), "overrides": {}},
+    )
+    client.post(
+        f"/goals/{rejected_goal['goal_id']}/plan/reviews/bulk",
+        json={"suggestion_indexes": list(range(rejected_total)), "decision": "rejected", "comment": "Out of scope."},
+    )
+
+    response = client.get("/goals/planner/handoffs")
+    payload = response.json()
+    items_by_goal = {item["goal_id"]: item for item in payload["items"]}
+
+    assert response.status_code == 200
+    assert payload["summary"] == {
+        "total_goals": 4,
+        "goals_needing_attention": 3,
+        "pending": pending_total,
+        "deferred": deferred_total,
+        "rejected": rejected_total,
+        "created": created_total,
+    }
+    assert items_by_goal[pending_goal["goal_id"]]["needs_operator_attention"] is True
+    assert items_by_goal[pending_goal["goal_id"]]["state"] == pending_goal["state"]
+    assert items_by_goal[pending_goal["goal_id"]]["last_reviewed_at"] is None
+    assert items_by_goal[pending_goal["goal_id"]]["pending"] == pending_total
+    assert items_by_goal[pending_goal["goal_id"]]["next_pending_suggestion"]["suggestion_index"] == 0
+    assert items_by_goal[deferred_goal["goal_id"]]["needs_operator_attention"] is True
+    assert items_by_goal[deferred_goal["goal_id"]]["deferred"] == deferred_total
+    assert items_by_goal[deferred_goal["goal_id"]]["latest_deferred_suggestion"]["comment"] == "Needs owner."
+    assert items_by_goal[deferred_goal["goal_id"]]["last_reviewed_at"] is not None
+    assert items_by_goal[created_goal["goal_id"]]["needs_operator_attention"] is True
+    assert items_by_goal[created_goal["goal_id"]]["created_task_statuses"] == {"pending": created_total}
+    assert items_by_goal[rejected_goal["goal_id"]]["needs_operator_attention"] is False
+    assert items_by_goal[rejected_goal["goal_id"]]["rejected"] == rejected_total
+
+
+def test_planner_global_handoffs_read_only(client):
+    goal = _create_goal(client, "Read only global handoff")
+    total = _planner_suggestion_count(client, goal["goal_id"])
+    services = client.app.state.services
+    before_reviews = services.db.fetch_scalar("SELECT COUNT(*) FROM planner_suggestion_reviews")
+    before_tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+    before_events = services.db.fetch_scalar("SELECT COUNT(*) FROM events")
+
+    response = client.get("/goals/planner/handoffs")
+
+    after_reviews = services.db.fetch_scalar("SELECT COUNT(*) FROM planner_suggestion_reviews")
+    after_tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+    after_events = services.db.fetch_scalar("SELECT COUNT(*) FROM events")
+
+    assert response.status_code == 200
+    assert response.json()["summary"]["pending"] == total
+    assert before_reviews == after_reviews == 0
+    assert before_tasks == after_tasks == []
+    assert before_events == after_events
+
+
+def test_planner_global_handoffs_sorting_and_attention(client):
+    created_goal = _create_goal(client, "A created only")
+    deferred_goal = _create_goal(client, "B deferred only")
+    pending_goal = _create_goal(client, "C pending only")
+    rejected_goal = _create_goal(client, "D rejected only")
+
+    created_total = _planner_suggestion_count(client, created_goal["goal_id"])
+    deferred_total = _planner_suggestion_count(client, deferred_goal["goal_id"])
+    rejected_total = _planner_suggestion_count(client, rejected_goal["goal_id"])
+
+    client.post(
+        f"/goals/{created_goal['goal_id']}/plan/tasks/bulk",
+        json={"suggestion_indexes": list(range(created_total)), "overrides": {}},
+    )
+    client.post(
+        f"/goals/{deferred_goal['goal_id']}/plan/reviews/bulk",
+        json={"suggestion_indexes": list(range(deferred_total)), "decision": "deferred"},
+    )
+    client.post(
+        f"/goals/{rejected_goal['goal_id']}/plan/reviews/bulk",
+        json={"suggestion_indexes": list(range(rejected_total)), "decision": "rejected"},
+    )
+
+    payload = client.get("/goals/planner/handoffs").json()
+
+    assert [item["goal_id"] for item in payload["items"]] == [
+        pending_goal["goal_id"],
+        deferred_goal["goal_id"],
+        created_goal["goal_id"],
+        rejected_goal["goal_id"],
+    ]
+    assert [item["needs_operator_attention"] for item in payload["items"]] == [True, True, True, False]


### PR DESCRIPTION
﻿## Summary
- Add a read-only `GET /goals/planner/handoffs` global rollup over existing per-goal planner handoffs.
- Surface a Planner Handoff Queue card in the Goals UI with attention status, counts, task status rollups, and navigation-only actions.
- Add focused API/UI contract coverage for empty, mixed, read-only, sorting, and frontend wiring cases.

## Stability Scope
- No DB migrations or schema changes.
- No CI, guard, release-gate, or threshold changes.
- No external AI/Qdrant/LLM dependencies.
- Planner handoff queue remains read-only; task creation/review still uses existing explicit actions.

## Validation
- `git diff --check`
- `python -m py_compile goal_ops_console\models.py goal_ops_console\routers\goals.py`
- `node --check goal_ops_console\static\app.js`
- Planner regression: `23 passed, 323 deselected`
- Local suite with Windows readline workaround: `346 passed`
- Playwright browser smoke: global handoff queue renders, refreshes, and Open next pending navigates to Planner Preview.

## Notes
- `artifacts/` remains untracked and was not staged.
