### PR TITLE
Add planner handoff triage controls

### DIFF
--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -235,6 +235,12 @@ class PlannerGlobalHandoffItem(BaseModel):
     source: str
     next_operator_action: str
     needs_operator_attention: bool
+    attention_reason: Literal[
+        "pending_review",
+        "deferred_followup",
+        "created_task_not_terminal",
+        "ready",
+    ]
     summary: PlannerReviewSummary
     pending: int
     deferred: int

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -369,22 +369,30 @@ def _created_tasks_need_attention(handoff: dict) -> bool:
     return any(task["task_status"] != "succeeded" for task in handoff["created_tasks"])
 
 
+def _planner_global_attention_reason(handoff: dict) -> str:
+    summary = handoff["summary"]
+    if summary["pending"] > 0:
+        return "pending_review"
+    if summary["deferred"] > 0:
+        return "deferred_followup"
+    if _created_tasks_need_attention(handoff):
+        return "created_task_not_terminal"
+    return "ready"
+
+
 def _planner_global_handoff_item(goal: dict, services: AppServices) -> dict:
     handoff = _planner_review_handoff(goal["goal_id"], services)
     reviews = _planner_reviews_by_index(goal["goal_id"], services).values()
     summary = handoff["summary"]
-    needs_operator_attention = (
-        summary["pending"] > 0
-        or summary["deferred"] > 0
-        or _created_tasks_need_attention(handoff)
-    )
+    attention_reason = _planner_global_attention_reason(handoff)
     return {
         "goal_id": handoff["goal_id"],
         "goal_title": handoff["goal_title"],
         "state": goal["state"],
         "source": handoff["source"],
         "next_operator_action": handoff["next_operator_action"],
-        "needs_operator_attention": needs_operator_attention,
+        "needs_operator_attention": attention_reason != "ready",
+        "attention_reason": attention_reason,
         "summary": summary,
         "pending": summary["pending"],
         "deferred": summary["deferred"],
@@ -401,24 +409,49 @@ def _planner_global_handoff_item(goal: dict, services: AppServices) -> dict:
     }
 
 
-def _sort_planner_global_handoff_items(items: list[dict]) -> list[dict]:
+def _filter_planner_global_handoff_items(items: list[dict], status: str, reason: str) -> list[dict]:
+    if status == "needs_attention":
+        items = [item for item in items if item["needs_operator_attention"]]
+    elif status == "ready":
+        items = [item for item in items if not item["needs_operator_attention"]]
+    if reason != "all":
+        items = [item for item in items if item["attention_reason"] == reason]
+    return items
+
+
+def _sort_planner_global_handoff_items(items: list[dict], sort: str) -> list[dict]:
+    if sort == "goal_title":
+        return sorted(items, key=lambda item: (item["goal_title"].lower(), item["goal_id"]))
+    if sort == "last_reviewed_at":
+        sorted_items = sorted(items, key=lambda item: (item["goal_title"].lower(), item["goal_id"]))
+        sorted_items.sort(key=lambda item: item["last_reviewed_at"] or "", reverse=True)
+        return sorted_items
+    attention_reason_rank = {
+        "pending_review": 0,
+        "deferred_followup": 1,
+        "created_task_not_terminal": 2,
+        "ready": 3,
+    }
     return sorted(
         items,
         key=lambda item: (
             0 if item["needs_operator_attention"] else 1,
-            0 if item["pending"] > 0 else 1,
-            0 if item["deferred"] > 0 else 1,
-            0 if item["created"] > 0 else 1,
+            attention_reason_rank.get(item["attention_reason"], 4),
             item["goal_title"].lower(),
             item["goal_id"],
         ),
     )
 
 
-def _planner_global_handoffs(services: AppServices) -> dict:
-    items = _sort_planner_global_handoff_items(
-        [_planner_global_handoff_item(goal, services) for goal in services.state_manager.list_goals()]
-    )
+def _planner_global_handoffs(
+    services: AppServices,
+    status: str = "all",
+    reason: str = "all",
+    sort: str = "needs_attention",
+) -> dict:
+    items = [_planner_global_handoff_item(goal, services) for goal in services.state_manager.list_goals()]
+    items = _filter_planner_global_handoff_items(items, status, reason)
+    items = _sort_planner_global_handoff_items(items, sort)
     return {
         "summary": {
             "total_goals": len(items),
@@ -800,9 +833,18 @@ def list_planner_deferred_followups(
 
 @router.get("/planner/handoffs", response_model=PlannerGlobalHandoffResponse)
 def list_planner_handoffs(
+    status: Literal["all", "needs_attention", "ready"] = Query("all"),
+    reason: Literal[
+        "all",
+        "pending_review",
+        "deferred_followup",
+        "created_task_not_terminal",
+        "ready",
+    ] = Query("all"),
+    sort: Literal["needs_attention", "last_reviewed_at", "goal_title"] = Query("needs_attention"),
     services: AppServices = Depends(get_services),
 ) -> dict:
-    return _planner_global_handoffs(services)
+    return _planner_global_handoffs(services, status=status, reason=reason, sort=sort)
 
 
 @router.post("/{goal_id}/plan/reviews", status_code=201, response_model=PlannerReviewDecisionResponse)

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -43,6 +43,9 @@ let globalFilterTerm = "";
 let jumpScrollScheduled = false;
 let plannerReviewInboxStatus = "needs_review";
 let plannerReviewInboxSort = "needs_review";
+let plannerHandoffStatus = "needs_attention";
+let plannerHandoffReason = "all";
+let plannerHandoffSort = "needs_attention";
 let focusedPlannerSuggestionIndex = null;
 const MUTATION_LOCK_FALLBACK_MESSAGE = (
   "Mutating operations are blocked while runtime is in critical protection mode."
@@ -1012,6 +1015,33 @@ function plannerGlobalHandoffNeedsAttention(item) {
   return Boolean((summary.pending || 0) > 0 || (summary.deferred || 0) > 0);
 }
 
+function plannerGlobalHandoffReason(item) {
+  if (item?.attention_reason) {
+    return item.attention_reason;
+  }
+  const summary = item?.summary || {};
+  if ((summary.pending || 0) > 0 || (item?.pending || 0) > 0) {
+    return "pending_review";
+  }
+  if ((summary.deferred || 0) > 0 || (item?.deferred || 0) > 0) {
+    return "deferred_followup";
+  }
+  if (plannerGlobalHandoffNeedsAttention(item) && ((summary.created || 0) > 0 || (item?.created || 0) > 0)) {
+    return "created_task_not_terminal";
+  }
+  return "ready";
+}
+
+function plannerGlobalHandoffReasonLabel(reason) {
+  const labels = {
+    pending_review: "Pending review",
+    deferred_followup: "Deferred follow-up",
+    created_task_not_terminal: "Created task not terminal",
+    ready: "Ready",
+  };
+  return labels[reason] || "Needs attention";
+}
+
 function plannerGlobalHandoffVisibleItems(payload) {
   return filterRows(plannerGlobalHandoffItems(payload), (item) => [
     item.goal_id,
@@ -1019,6 +1049,8 @@ function plannerGlobalHandoffVisibleItems(payload) {
     item.state,
     item.source,
     item.next_operator_action,
+    plannerGlobalHandoffReason(item),
+    plannerGlobalHandoffReasonLabel(plannerGlobalHandoffReason(item)),
     plannerGlobalHandoffNeedsAttention(item) ? "needs attention" : "reviewed",
     item.next_pending_suggestion?.title || "",
     item.next_pending?.title || "",
@@ -1082,6 +1114,14 @@ function renderPlannerGlobalHandoffs(payload) {
 
   const summary = plannerGlobalHandoffSummary(payload);
   const items = plannerGlobalHandoffVisibleItems(payload);
+  const statusButtons = [
+    ["needs_attention", "Needs attention"],
+    ["ready", "Ready"],
+    ["all", "All"],
+  ].map(([status, label]) => (
+    `<button type="button" class="secondary ${plannerHandoffStatus === status ? "active" : ""}" `
+    + `data-plan-handoffs-status="${status}">${label}</button>`
+  )).join("");
   const itemMarkup = items.length
     ? items.map((item) => {
       const itemSummary = item.summary || {};
@@ -1117,6 +1157,8 @@ function renderPlannerGlobalHandoffs(payload) {
         : "";
       const needsAttention = plannerGlobalHandoffNeedsAttention(item);
       const attentionLabel = needsAttention ? "Needs attention" : "Ready";
+      const attentionReason = plannerGlobalHandoffReason(item);
+      const attentionReasonLabel = plannerGlobalHandoffReasonLabel(attentionReason);
       const statusCounts = item.created_task_statuses && Object.keys(item.created_task_statuses).length
         ? Object.keys(item.created_task_statuses)
           .sort()
@@ -1130,7 +1172,10 @@ function renderPlannerGlobalHandoffs(payload) {
               <div class="entity-title">${escapeHtml(item.goal_title || item.title || item.goal_id)}</div>
               <div class="meta">${escapeHtml(item.goal_id)}${item.state ? ` &middot; ${escapeHtml(item.state)}` : ""}</div>
             </div>
-            <span class="pill ${needsAttention ? "state-degraded" : "state-ok"}">${attentionLabel}</span>
+            <div class="planner-handoff-badges">
+              <span class="pill ${needsAttention ? "state-degraded" : "state-ok"}">${attentionLabel}</span>
+              <span class="pill planner-handoff-reason">${escapeHtml(attentionReasonLabel)}</span>
+            </div>
           </div>
           <p class="meta"><strong>Next operator action:</strong> ${escapeHtml(item.next_operator_action || "Review planner handoff status.")}</p>
           <p class="meta"><strong>Created task statuses:</strong> ${escapeHtml(statusCounts)}</p>
@@ -1154,6 +1199,27 @@ function renderPlannerGlobalHandoffs(payload) {
     <div class="entity-header">
       <span class="meta">Planner Handoff Queue &middot; ${summary.total_goals || 0} goals</span>
       <button type="button" class="secondary" data-plan-handoffs-refresh="true">Refresh handoffs</button>
+    </div>
+    <div class="actions planner-handoff-controls" style="margin-top:0.75rem;">
+      ${statusButtons}
+      <label class="meta">
+        Reason
+        <select data-plan-handoffs-reason="true">
+          <option value="all" ${plannerHandoffReason === "all" ? "selected" : ""}>All reasons</option>
+          <option value="pending_review" ${plannerHandoffReason === "pending_review" ? "selected" : ""}>Pending review</option>
+          <option value="deferred_followup" ${plannerHandoffReason === "deferred_followup" ? "selected" : ""}>Deferred follow-up</option>
+          <option value="created_task_not_terminal" ${plannerHandoffReason === "created_task_not_terminal" ? "selected" : ""}>Created task not terminal</option>
+          <option value="ready" ${plannerHandoffReason === "ready" ? "selected" : ""}>Ready</option>
+        </select>
+      </label>
+      <label class="meta">
+        Sort
+        <select data-plan-handoffs-sort="true">
+          <option value="needs_attention" ${plannerHandoffSort === "needs_attention" ? "selected" : ""}>Needs attention first</option>
+          <option value="last_reviewed_at" ${plannerHandoffSort === "last_reviewed_at" ? "selected" : ""}>Last reviewed</option>
+          <option value="goal_title" ${plannerHandoffSort === "goal_title" ? "selected" : ""}>Goal title</option>
+        </select>
+      </label>
     </div>
     <div class="entity-grid" style="margin-top:0.75rem;">
       <div class="entity-metric planner-handoff-attention"><span class="meta">Needs Attention</span><strong>${summary.needs_attention || 0}</strong></div>
@@ -1970,7 +2036,12 @@ async function refreshPlannerDeferredFollowups() {
 
 async function refreshPlannerGlobalHandoffs() {
   try {
-    const payload = await api("/goals/planner/handoffs");
+    const params = new URLSearchParams({
+      status: plannerHandoffStatus,
+      reason: plannerHandoffReason,
+      sort: plannerHandoffSort,
+    });
+    const payload = await api(`/goals/planner/handoffs?${params.toString()}`);
     viewCache.plannerGlobalHandoffs = payload;
   } catch (error) {
     viewCache.plannerGlobalHandoffs = { error: error?.message || "Request failed" };
@@ -2848,6 +2919,7 @@ document.addEventListener("click", async (event) => {
   const planBulkCreate = event.target.dataset.planBulkCreate;
   const planBulkReviewDecision = event.target.dataset.planBulkReviewDecision;
   const planInboxStatus = event.target.dataset.planInboxStatus;
+  const planHandoffsStatus = event.target.dataset.planHandoffsStatus;
   const planFollowupsRefresh = event.target.dataset.planFollowupsRefresh;
   const planHandoffsRefresh = event.target.dataset.planHandoffsRefresh;
   const planFocusSuggestion = event.target.dataset.planFocusSuggestion;
@@ -2903,6 +2975,11 @@ document.addEventListener("click", async (event) => {
     if (planInboxStatus) {
       plannerReviewInboxStatus = planInboxStatus;
       await refreshPlannerReviewInbox();
+    }
+
+    if (planHandoffsStatus) {
+      plannerHandoffStatus = planHandoffsStatus;
+      await refreshPlannerGlobalHandoffs();
     }
 
     if (planFollowupsRefresh) {
@@ -3005,7 +3082,7 @@ document.addEventListener("click", async (event) => {
       ? "system-feedback"
       : workflowStart || workflowCancel
         ? "workflow-error"
-        : goalAction || planGoal || planInboxStatus || planFollowupsRefresh || planHandoffsRefresh
+        : goalAction || planGoal || planInboxStatus || planHandoffsStatus || planFollowupsRefresh || planHandoffsRefresh
           || planFollowupReopenGoal || planNextReview
           ? "goal-error"
           : "task-error";
@@ -3014,12 +3091,26 @@ document.addEventListener("click", async (event) => {
 });
 
 document.addEventListener("change", async (event) => {
-  if (!event.target.dataset.planInboxSort) {
+  const target = event.target;
+  const planInboxSort = target.dataset.planInboxSort;
+  const planHandoffsReason = target.dataset.planHandoffsReason;
+  const planHandoffsSort = target.dataset.planHandoffsSort;
+  if (!planInboxSort && !planHandoffsReason && !planHandoffsSort) {
     return;
   }
-  plannerReviewInboxSort = event.target.value || "needs_review";
   try {
-    await refreshPlannerReviewInbox();
+    if (planInboxSort) {
+      plannerReviewInboxSort = target.value || "needs_review";
+      await refreshPlannerReviewInbox();
+    }
+    if (planHandoffsReason) {
+      plannerHandoffReason = target.value || "all";
+      await refreshPlannerGlobalHandoffs();
+    }
+    if (planHandoffsSort) {
+      plannerHandoffSort = target.value || "needs_attention";
+      await refreshPlannerGlobalHandoffs();
+    }
   } catch (error) {
     showError("goal-error", error);
   }

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -632,6 +632,19 @@
     .planner-global-handoff-item {
       border-color: rgba(35, 102, 173, 0.12);
     }
+    .planner-handoff-controls select {
+      margin-left: 0.35rem;
+    }
+    .planner-handoff-badges {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      gap: 0.35rem;
+    }
+    .planner-handoff-reason {
+      background: rgba(35, 102, 173, 0.12);
+      color: var(--ink);
+    }
     .planner-handoff-attention strong {
       color: var(--warn);
     }

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -16282,13 +16282,20 @@ def test_272o4_planner_review_inbox_open_next_review_focus_contract():
     assert "function renderPlannerHandoffList(title, items, emptyMessage, itemRenderer)" in app_js
     assert "function renderPlannerGlobalHandoffs(payload)" in app_js
     assert "function plannerGlobalHandoffNeedsAttention(item)" in app_js
+    assert "function plannerGlobalHandoffReason(item)" in app_js
+    assert "function plannerGlobalHandoffReasonLabel(reason)" in app_js
     assert "nextReviewItem?.next_suggestion?.suggestion_index" in app_js
     assert "runPlannerPreview(nextGoalId, { focusSuggestionIndex, focusNextPending: true })" in app_js
     assert "runPlannerPreview(goalId, { focusNextPending: true })" in app_js
     assert "/goals/planner/handoffs" in app_js
+    assert "data-plan-handoffs-status" in app_js
+    assert "data-plan-handoffs-reason" in app_js
+    assert "data-plan-handoffs-sort" in app_js
+    assert "attention_reason" in app_js
     assert "/plan/handoff" in app_js
     assert "Planner Handoff Summary" in app_js
     assert "Planner Handoff Queue" in app_js
+    assert "Created task not terminal" in app_js
     assert "Created task statuses" in app_js
     assert "Next operator action" in app_js
     assert "data-planner-suggestion-index" in app_js
@@ -16301,6 +16308,8 @@ def test_272o4_planner_review_inbox_open_next_review_focus_contract():
     assert ".planner-handoff-card" in template
     assert "planner-global-handoffs" in template
     assert ".planner-global-handoff-item" in template
+    assert ".planner-handoff-controls" in template
+    assert ".planner-handoff-reason" in template
     assert 'src="/static/app.js?v={{ static_asset_version }}"' in template
     assert '"static_asset_version": _static_asset_version()' in system_router
 

--- a/tests/test_planner_global_handoffs.py
+++ b/tests/test_planner_global_handoffs.py
@@ -68,17 +68,21 @@ def test_planner_global_handoffs_mixed_goals_rollup(client):
         "created": created_total,
     }
     assert items_by_goal[pending_goal["goal_id"]]["needs_operator_attention"] is True
+    assert items_by_goal[pending_goal["goal_id"]]["attention_reason"] == "pending_review"
     assert items_by_goal[pending_goal["goal_id"]]["state"] == pending_goal["state"]
     assert items_by_goal[pending_goal["goal_id"]]["last_reviewed_at"] is None
     assert items_by_goal[pending_goal["goal_id"]]["pending"] == pending_total
     assert items_by_goal[pending_goal["goal_id"]]["next_pending_suggestion"]["suggestion_index"] == 0
     assert items_by_goal[deferred_goal["goal_id"]]["needs_operator_attention"] is True
+    assert items_by_goal[deferred_goal["goal_id"]]["attention_reason"] == "deferred_followup"
     assert items_by_goal[deferred_goal["goal_id"]]["deferred"] == deferred_total
     assert items_by_goal[deferred_goal["goal_id"]]["latest_deferred_suggestion"]["comment"] == "Needs owner."
     assert items_by_goal[deferred_goal["goal_id"]]["last_reviewed_at"] is not None
     assert items_by_goal[created_goal["goal_id"]]["needs_operator_attention"] is True
+    assert items_by_goal[created_goal["goal_id"]]["attention_reason"] == "created_task_not_terminal"
     assert items_by_goal[created_goal["goal_id"]]["created_task_statuses"] == {"pending": created_total}
     assert items_by_goal[rejected_goal["goal_id"]]["needs_operator_attention"] is False
+    assert items_by_goal[rejected_goal["goal_id"]]["attention_reason"] == "ready"
     assert items_by_goal[rejected_goal["goal_id"]]["rejected"] == rejected_total
 
 
@@ -135,3 +139,92 @@ def test_planner_global_handoffs_sorting_and_attention(client):
         rejected_goal["goal_id"],
     ]
     assert [item["needs_operator_attention"] for item in payload["items"]] == [True, True, True, False]
+    assert [item["attention_reason"] for item in payload["items"]] == [
+        "pending_review",
+        "deferred_followup",
+        "created_task_not_terminal",
+        "ready",
+    ]
+
+
+def test_planner_global_handoffs_filters_and_sorts(client):
+    pending_goal = _create_goal(client, "Zulu pending handoff")
+    deferred_goal = _create_goal(client, "Bravo deferred handoff")
+    created_goal = _create_goal(client, "Charlie created handoff")
+    ready_goal = _create_goal(client, "Alpha ready handoff")
+
+    deferred_total = _planner_suggestion_count(client, deferred_goal["goal_id"])
+    created_total = _planner_suggestion_count(client, created_goal["goal_id"])
+    ready_total = _planner_suggestion_count(client, ready_goal["goal_id"])
+    _planner_suggestion_count(client, pending_goal["goal_id"])
+
+    client.post(
+        f"/goals/{deferred_goal['goal_id']}/plan/reviews/bulk",
+        json={"suggestion_indexes": list(range(deferred_total)), "decision": "deferred"},
+    )
+    created_payload = client.post(
+        f"/goals/{created_goal['goal_id']}/plan/tasks/bulk",
+        json={"suggestion_indexes": list(range(created_total)), "overrides": {}},
+    ).json()
+    for created_item in created_payload["created"]:
+        client.post(f"/tasks/{created_item['task']['task_id']}/success")
+    client.post(
+        f"/goals/{ready_goal['goal_id']}/plan/reviews/bulk",
+        json={"suggestion_indexes": list(range(ready_total)), "decision": "rejected"},
+    )
+
+    services = client.app.state.services
+    services.db.execute(
+        "UPDATE planner_suggestion_reviews SET updated_at = ? WHERE goal_id = ?",
+        "2026-04-01 08:00:00",
+        deferred_goal["goal_id"],
+    )
+    services.db.execute(
+        "UPDATE planner_suggestion_reviews SET updated_at = ? WHERE goal_id = ?",
+        "2026-03-31 07:00:00",
+        created_goal["goal_id"],
+    )
+    services.db.execute(
+        "UPDATE planner_suggestion_reviews SET updated_at = ? WHERE goal_id = ?",
+        "2026-04-02 09:00:00",
+        ready_goal["goal_id"],
+    )
+
+    needs_attention = client.get("/goals/planner/handoffs?status=needs_attention").json()
+    ready = client.get("/goals/planner/handoffs?status=ready").json()
+    deferred_only = client.get("/goals/planner/handoffs?reason=deferred_followup").json()
+    by_title = client.get("/goals/planner/handoffs?sort=goal_title").json()
+    by_reviewed = client.get("/goals/planner/handoffs?sort=last_reviewed_at").json()
+
+    assert [item["goal_id"] for item in needs_attention["items"]] == [
+        pending_goal["goal_id"],
+        deferred_goal["goal_id"],
+    ]
+    assert needs_attention["summary"]["total_goals"] == 2
+    assert [item["goal_id"] for item in ready["items"]] == [
+        ready_goal["goal_id"],
+        created_goal["goal_id"],
+    ]
+    assert ready["summary"]["goals_needing_attention"] == 0
+    assert [item["goal_id"] for item in deferred_only["items"]] == [deferred_goal["goal_id"]]
+    assert [item["goal_title"] for item in by_title["items"]] == [
+        "Alpha ready handoff",
+        "Bravo deferred handoff",
+        "Charlie created handoff",
+        "Zulu pending handoff",
+    ]
+    assert [item["goal_id"] for item in by_reviewed["items"][:2]] == [
+        ready_goal["goal_id"],
+        deferred_goal["goal_id"],
+    ]
+
+
+def test_planner_global_handoffs_invalid_query_returns_422(client):
+    for query in [
+        "status=blocked",
+        "reason=unknown",
+        "sort=created",
+    ]:
+        response = client.get(f"/goals/planner/handoffs?{query}")
+
+        assert response.status_code == 422


### PR DESCRIPTION
﻿## Summary
- add `attention_reason` to planner global handoff items
- add API filters for handoff status/reason and sort modes
- add UI triage controls and reason badges for the Planner Handoff Queue

## Test Plan
- `python -m py_compile goal_ops_console\models.py goal_ops_console\routers\goals.py`
- `node --check goal_ops_console\static\app.js`
- `git diff --check`
- targeted pytest: `tests/test_planner_global_handoffs.py tests/test_goal_ops.py -k "planner_global_handoffs or 272o4"`
- broader pytest: `tests/test_planner_global_handoffs.py tests/test_goal_ops.py`
- full local pytest: `python -m pytest` (369 passed)
- local Playwright browser smoke against Planner Handoff Queue filters
