### PR TITLE
Add planner handoff follow-up actions

### DIFF
--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -228,6 +228,20 @@ class PlannerReviewHandoffResponse(BaseModel):
     pending_suggestions: list[PlannerHandoffSuggestionItem]
 
 
+class PlannerGlobalHandoffFollowUpAction(BaseModel):
+    id: Literal[
+        "review_pending_suggestion",
+        "resolve_deferred_followup",
+        "monitor_created_tasks",
+        "no_action_required",
+    ]
+    label: str
+    description: str
+    action_type: Literal["open_plan_preview", "select_goal_tasks", "none"]
+    target: dict[str, Any] = Field(default_factory=dict)
+    mutates: bool = False
+
+
 class PlannerGlobalHandoffItem(BaseModel):
     goal_id: str
     goal_title: str
@@ -250,6 +264,7 @@ class PlannerGlobalHandoffItem(BaseModel):
     next_pending_suggestion: PlannerHandoffSuggestionItem | None = None
     latest_deferred_suggestion: PlannerHandoffSuggestionItem | None = None
     created_task_statuses: dict[str, int] = Field(default_factory=dict)
+    follow_up_actions: list[PlannerGlobalHandoffFollowUpAction] = Field(default_factory=list)
 
 
 class PlannerGlobalHandoffSummary(BaseModel):

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -365,6 +365,16 @@ def _created_task_statuses(handoff: dict) -> dict[str, int]:
     return statuses
 
 
+def _non_terminal_created_task_statuses(handoff: dict) -> dict[str, int]:
+    statuses: dict[str, int] = {}
+    for task in handoff["created_tasks"]:
+        status = task["task_status"]
+        if status == "succeeded":
+            continue
+        statuses[status] = statuses.get(status, 0) + 1
+    return statuses
+
+
 def _created_tasks_need_attention(handoff: dict) -> bool:
     return any(task["task_status"] != "succeeded" for task in handoff["created_tasks"])
 
@@ -380,11 +390,85 @@ def _planner_global_attention_reason(handoff: dict) -> str:
     return "ready"
 
 
+def _planner_global_follow_up_actions(handoff: dict) -> list[dict]:
+    actions = []
+    goal_id = handoff["goal_id"]
+    pending_suggestions = handoff["pending_suggestions"]
+    if pending_suggestions:
+        suggestion = pending_suggestions[0]
+        actions.append(
+            {
+                "id": "review_pending_suggestion",
+                "label": "Review next pending",
+                "description": (
+                    "Open the next pending planner suggestion and explicitly choose create, defer, or reject."
+                ),
+                "action_type": "open_plan_preview",
+                "target": {
+                    "goal_id": goal_id,
+                    "suggestion_index": suggestion["suggestion_index"],
+                    "focus_next_pending": True,
+                },
+                "mutates": False,
+            }
+        )
+    deferred_suggestion = _latest_deferred_suggestion(handoff)
+    if deferred_suggestion is not None:
+        actions.append(
+            {
+                "id": "resolve_deferred_followup",
+                "label": "Resolve deferred follow-up",
+                "description": (
+                    "Open the latest deferred suggestion and decide whether to reopen it or leave it deferred."
+                ),
+                "action_type": "open_plan_preview",
+                "target": {
+                    "goal_id": goal_id,
+                    "suggestion_index": deferred_suggestion["suggestion_index"],
+                },
+                "mutates": False,
+            }
+        )
+    non_terminal_statuses = _non_terminal_created_task_statuses(handoff)
+    if non_terminal_statuses:
+        actions.append(
+            {
+                "id": "monitor_created_tasks",
+                "label": "Inspect created tasks",
+                "description": "Open this goal's task list and monitor created planner tasks without changing status.",
+                "action_type": "select_goal_tasks",
+                "target": {
+                    "goal_id": goal_id,
+                    "task_ids": [
+                        task["task_id"]
+                        for task in handoff["created_tasks"]
+                        if task["task_status"] != "succeeded"
+                    ],
+                    "status_counts": non_terminal_statuses,
+                },
+                "mutates": False,
+            }
+        )
+    if not actions:
+        actions.append(
+            {
+                "id": "no_action_required",
+                "label": "No immediate action",
+                "description": "This planner handoff is clear; continue monitoring or open the preview if context is needed.",
+                "action_type": "none",
+                "target": {"goal_id": goal_id},
+                "mutates": False,
+            }
+        )
+    return actions
+
+
 def _planner_global_handoff_item(goal: dict, services: AppServices) -> dict:
     handoff = _planner_review_handoff(goal["goal_id"], services)
     reviews = _planner_reviews_by_index(goal["goal_id"], services).values()
     summary = handoff["summary"]
     attention_reason = _planner_global_attention_reason(handoff)
+    latest_deferred_suggestion = _latest_deferred_suggestion(handoff)
     return {
         "goal_id": handoff["goal_id"],
         "goal_title": handoff["goal_title"],
@@ -404,8 +488,9 @@ def _planner_global_handoff_item(goal: dict, services: AppServices) -> dict:
             if handoff["pending_suggestions"]
             else None
         ),
-        "latest_deferred_suggestion": _latest_deferred_suggestion(handoff),
+        "latest_deferred_suggestion": latest_deferred_suggestion,
         "created_task_statuses": _created_task_statuses(handoff),
+        "follow_up_actions": _planner_global_follow_up_actions(handoff),
     }
 
 

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -1042,6 +1042,59 @@ function plannerGlobalHandoffReasonLabel(reason) {
   return labels[reason] || "Needs attention";
 }
 
+function plannerGlobalHandoffActions(item) {
+  if (Array.isArray(item?.follow_up_actions) && item.follow_up_actions.length) {
+    return item.follow_up_actions;
+  }
+  const pendingSuggestion = firstPlannerHandoffSuggestion(item, "next_pending_suggestion", "next_pending");
+  const deferredSuggestion = firstPlannerHandoffSuggestion(
+    item,
+    "latest_deferred_suggestion",
+    "first_deferred_suggestion",
+    "first_deferred",
+  );
+  const pendingIndex = plannerHandoffSuggestionIndex(pendingSuggestion);
+  const deferredIndex = plannerHandoffSuggestionIndex(deferredSuggestion);
+  if (pendingSuggestion) {
+    return [{
+      id: "review_pending_suggestion",
+      label: "Review next pending",
+      description: "Open the next pending planner suggestion and explicitly choose create, defer, or reject.",
+      action_type: "open_plan_preview",
+      target: { goal_id: item.goal_id, suggestion_index: pendingIndex, focus_next_pending: true },
+      mutates: false,
+    }];
+  }
+  if (deferredSuggestion) {
+    return [{
+      id: "resolve_deferred_followup",
+      label: "Resolve deferred follow-up",
+      description: "Open the latest deferred suggestion and decide whether to reopen it or leave it deferred.",
+      action_type: "open_plan_preview",
+      target: { goal_id: item.goal_id, suggestion_index: deferredIndex },
+      mutates: false,
+    }];
+  }
+  if (plannerGlobalHandoffNeedsAttention(item) && ((item?.summary?.created || 0) > 0 || (item?.created || 0) > 0)) {
+    return [{
+      id: "monitor_created_tasks",
+      label: "Inspect created tasks",
+      description: "Open this goal's task list and monitor created planner tasks without changing status.",
+      action_type: "select_goal_tasks",
+      target: { goal_id: item.goal_id },
+      mutates: false,
+    }];
+  }
+  return [{
+    id: "no_action_required",
+    label: "No immediate action",
+    description: "This planner handoff is clear; continue monitoring or open the preview if context is needed.",
+    action_type: "none",
+    target: { goal_id: item.goal_id },
+    mutates: false,
+  }];
+}
+
 function plannerGlobalHandoffVisibleItems(payload) {
   return filterRows(plannerGlobalHandoffItems(payload), (item) => [
     item.goal_id,
@@ -1057,6 +1110,12 @@ function plannerGlobalHandoffVisibleItems(payload) {
     item.latest_deferred_suggestion?.title || "",
     item.first_deferred_suggestion?.title || "",
     item.first_deferred?.title || "",
+    ...plannerGlobalHandoffActions(item).flatMap((action) => [
+      action.id,
+      action.label,
+      action.description,
+      action.action_type,
+    ]),
   ]);
 }
 
@@ -1089,6 +1148,55 @@ function firstPlannerHandoffSuggestion(item, key, fallbackKey, alternateKey = nu
 function plannerHandoffSuggestionIndex(item) {
   const index = Number.parseInt(item?.suggestion_index, 10);
   return Number.isInteger(index) && index >= 0 ? index : null;
+}
+
+function renderPlannerFollowUpActionButton(action, item) {
+  const target = action?.target || {};
+  const goalId = target.goal_id || item.goal_id;
+  if (action.action_type === "open_plan_preview") {
+    const suggestionIndex = Number.parseInt(target.suggestion_index, 10);
+    const suggestionValue = Number.isInteger(suggestionIndex) && suggestionIndex >= 0 ? String(suggestionIndex) : "";
+    const focusNextPending = target.focus_next_pending ? ' data-plan-focus-next-pending="true"' : "";
+    return `
+      <button
+        type="button"
+        class="secondary"
+        data-plan-goal="${escapeHtml(goalId)}"
+        data-plan-focus-suggestion="${escapeHtml(suggestionValue)}"${focusNextPending}
+      >${escapeHtml(action.label || "Open Plan Preview")}</button>
+    `;
+  }
+  if (action.action_type === "select_goal_tasks") {
+    return `
+      <button
+        type="button"
+        class="secondary"
+        data-plan-handoff-task-goal="${escapeHtml(goalId)}"
+      >${escapeHtml(action.label || "Inspect tasks")}</button>
+    `;
+  }
+  return `<button type="button" class="secondary" disabled>${escapeHtml(action.label || "No action")}</button>`;
+}
+
+function renderPlannerFollowUpActions(item) {
+  const actions = plannerGlobalHandoffActions(item);
+  if (!actions.length) {
+    return "";
+  }
+  return `
+    <div class="planner-handoff-actions">
+      <div class="meta"><strong>Suggested follow-up actions</strong> &middot; read-only</div>
+      ${actions.map((action) => `
+        <div class="planner-handoff-action">
+          <div>
+            <div class="entity-title">${escapeHtml(action.label || "Follow-up action")}</div>
+            <p class="meta">${escapeHtml(action.description || "Review this planner handoff before taking action.")}</p>
+          </div>
+          ${renderPlannerFollowUpActionButton(action, item)}
+        </div>
+      `).join("")}
+    </div>
+  `;
 }
 
 function renderPlannerGlobalHandoffs(payload) {
@@ -1125,36 +1233,6 @@ function renderPlannerGlobalHandoffs(payload) {
   const itemMarkup = items.length
     ? items.map((item) => {
       const itemSummary = item.summary || {};
-      const pendingSuggestion = firstPlannerHandoffSuggestion(item, "next_pending_suggestion", "next_pending");
-      const deferredSuggestion = firstPlannerHandoffSuggestion(
-        item,
-        "latest_deferred_suggestion",
-        "first_deferred_suggestion",
-        "first_deferred",
-      );
-      const pendingIndex = plannerHandoffSuggestionIndex(pendingSuggestion);
-      const deferredIndex = plannerHandoffSuggestionIndex(deferredSuggestion);
-      const pendingAction = pendingSuggestion
-        ? `
-          <button
-            type="button"
-            class="secondary"
-            data-plan-goal="${escapeHtml(item.goal_id)}"
-            data-plan-focus-suggestion="${escapeHtml(String(pendingIndex ?? ""))}"
-            data-plan-focus-next-pending="true"
-          >Open next pending</button>
-        `
-        : "";
-      const deferredAction = deferredSuggestion
-        ? `
-          <button
-            type="button"
-            class="secondary"
-            data-plan-goal="${escapeHtml(item.goal_id)}"
-            data-plan-focus-suggestion="${escapeHtml(String(deferredIndex ?? ""))}"
-          >Open deferred follow-up</button>
-        `
-        : "";
       const needsAttention = plannerGlobalHandoffNeedsAttention(item);
       const attentionLabel = needsAttention ? "Needs attention" : "Ready";
       const attentionReason = plannerGlobalHandoffReason(item);
@@ -1185,10 +1263,9 @@ function renderPlannerGlobalHandoffs(payload) {
             <div class="entity-metric"><span class="meta">Rejected</span><strong>${itemSummary.rejected || 0}</strong></div>
             <div class="entity-metric"><span class="meta">Pending</span><strong>${itemSummary.pending || 0}</strong></div>
           </div>
+          ${renderPlannerFollowUpActions(item)}
           <div class="actions" style="margin-top:0.75rem;">
             <button type="button" class="secondary" data-plan-goal="${escapeHtml(item.goal_id)}">Open Plan Preview</button>
-            ${pendingAction}
-            ${deferredAction}
           </div>
         </article>
       `;
@@ -2920,6 +2997,7 @@ document.addEventListener("click", async (event) => {
   const planBulkReviewDecision = event.target.dataset.planBulkReviewDecision;
   const planInboxStatus = event.target.dataset.planInboxStatus;
   const planHandoffsStatus = event.target.dataset.planHandoffsStatus;
+  const planHandoffTaskGoal = event.target.dataset.planHandoffTaskGoal;
   const planFollowupsRefresh = event.target.dataset.planFollowupsRefresh;
   const planHandoffsRefresh = event.target.dataset.planHandoffsRefresh;
   const planFocusSuggestion = event.target.dataset.planFocusSuggestion;
@@ -2980,6 +3058,17 @@ document.addEventListener("click", async (event) => {
     if (planHandoffsStatus) {
       plannerHandoffStatus = planHandoffsStatus;
       await refreshPlannerGlobalHandoffs();
+    }
+
+    if (planHandoffTaskGoal) {
+      selectedGoalId = planHandoffTaskGoal;
+      document.getElementById("task-goal-id").value = planHandoffTaskGoal;
+      document.getElementById("event-correlation-id").value = planHandoffTaskGoal;
+      document.getElementById("trace-goal-id").value = planHandoffTaskGoal;
+      document.getElementById("fault-goal-id").value = planHandoffTaskGoal;
+      setActiveJump("tasks-section");
+      await refreshTasks();
+      updateSelectedGoalLabel();
     }
 
     if (planFollowupsRefresh) {
@@ -3082,7 +3171,8 @@ document.addEventListener("click", async (event) => {
       ? "system-feedback"
       : workflowStart || workflowCancel
         ? "workflow-error"
-        : goalAction || planGoal || planInboxStatus || planHandoffsStatus || planFollowupsRefresh || planHandoffsRefresh
+        : goalAction || planGoal || planInboxStatus || planHandoffsStatus || planHandoffTaskGoal
+          || planFollowupsRefresh || planHandoffsRefresh
           || planFollowupReopenGoal || planNextReview
           ? "goal-error"
           : "task-error";

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -645,6 +645,28 @@
       background: rgba(35, 102, 173, 0.12);
       color: var(--ink);
     }
+    .planner-handoff-actions {
+      display: grid;
+      gap: 0.55rem;
+      margin-top: 0.75rem;
+      padding-top: 0.7rem;
+      border-top: 1px solid rgba(31, 27, 23, 0.08);
+    }
+    .planner-handoff-action {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 0.75rem;
+      align-items: center;
+      padding: 0.65rem;
+      border: 1px solid rgba(35, 102, 173, 0.12);
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.54);
+    }
+    @media (max-width: 720px) {
+      .planner-handoff-action {
+        grid-template-columns: 1fr;
+      }
+    }
     .planner-handoff-attention strong {
       color: var(--warn);
     }

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -16284,6 +16284,9 @@ def test_272o4_planner_review_inbox_open_next_review_focus_contract():
     assert "function plannerGlobalHandoffNeedsAttention(item)" in app_js
     assert "function plannerGlobalHandoffReason(item)" in app_js
     assert "function plannerGlobalHandoffReasonLabel(reason)" in app_js
+    assert "function plannerGlobalHandoffActions(item)" in app_js
+    assert "function renderPlannerFollowUpActions(item)" in app_js
+    assert "function renderPlannerFollowUpActionButton(action, item)" in app_js
     assert "nextReviewItem?.next_suggestion?.suggestion_index" in app_js
     assert "runPlannerPreview(nextGoalId, { focusSuggestionIndex, focusNextPending: true })" in app_js
     assert "runPlannerPreview(goalId, { focusNextPending: true })" in app_js
@@ -16291,7 +16294,10 @@ def test_272o4_planner_review_inbox_open_next_review_focus_contract():
     assert "data-plan-handoffs-status" in app_js
     assert "data-plan-handoffs-reason" in app_js
     assert "data-plan-handoffs-sort" in app_js
+    assert "data-plan-handoff-task-goal" in app_js
     assert "attention_reason" in app_js
+    assert "follow_up_actions" in app_js
+    assert "Suggested follow-up actions" in app_js
     assert "/plan/handoff" in app_js
     assert "Planner Handoff Summary" in app_js
     assert "Planner Handoff Queue" in app_js
@@ -16310,6 +16316,8 @@ def test_272o4_planner_review_inbox_open_next_review_focus_contract():
     assert ".planner-global-handoff-item" in template
     assert ".planner-handoff-controls" in template
     assert ".planner-handoff-reason" in template
+    assert ".planner-handoff-actions" in template
+    assert ".planner-handoff-action" in template
     assert 'src="/static/app.js?v={{ static_asset_version }}"' in template
     assert '"static_asset_version": _static_asset_version()' in system_router
 

--- a/tests/test_planner_global_handoffs.py
+++ b/tests/test_planner_global_handoffs.py
@@ -73,17 +73,51 @@ def test_planner_global_handoffs_mixed_goals_rollup(client):
     assert items_by_goal[pending_goal["goal_id"]]["last_reviewed_at"] is None
     assert items_by_goal[pending_goal["goal_id"]]["pending"] == pending_total
     assert items_by_goal[pending_goal["goal_id"]]["next_pending_suggestion"]["suggestion_index"] == 0
+    assert items_by_goal[pending_goal["goal_id"]]["follow_up_actions"][0]["id"] == "review_pending_suggestion"
+    assert items_by_goal[pending_goal["goal_id"]]["follow_up_actions"][0]["action_type"] == "open_plan_preview"
+    assert items_by_goal[pending_goal["goal_id"]]["follow_up_actions"][0]["target"] == {
+        "goal_id": pending_goal["goal_id"],
+        "suggestion_index": 0,
+        "focus_next_pending": True,
+    }
     assert items_by_goal[deferred_goal["goal_id"]]["needs_operator_attention"] is True
     assert items_by_goal[deferred_goal["goal_id"]]["attention_reason"] == "deferred_followup"
     assert items_by_goal[deferred_goal["goal_id"]]["deferred"] == deferred_total
     assert items_by_goal[deferred_goal["goal_id"]]["latest_deferred_suggestion"]["comment"] == "Needs owner."
     assert items_by_goal[deferred_goal["goal_id"]]["last_reviewed_at"] is not None
+    assert items_by_goal[deferred_goal["goal_id"]]["follow_up_actions"][0]["id"] == "resolve_deferred_followup"
+    assert (
+        items_by_goal[deferred_goal["goal_id"]]["follow_up_actions"][0]["target"]["suggestion_index"]
+        == items_by_goal[deferred_goal["goal_id"]]["latest_deferred_suggestion"]["suggestion_index"]
+    )
     assert items_by_goal[created_goal["goal_id"]]["needs_operator_attention"] is True
     assert items_by_goal[created_goal["goal_id"]]["attention_reason"] == "created_task_not_terminal"
     assert items_by_goal[created_goal["goal_id"]]["created_task_statuses"] == {"pending": created_total}
+    assert items_by_goal[created_goal["goal_id"]]["follow_up_actions"][0]["id"] == "monitor_created_tasks"
+    assert items_by_goal[created_goal["goal_id"]]["follow_up_actions"][0]["action_type"] == "select_goal_tasks"
+    assert items_by_goal[created_goal["goal_id"]]["follow_up_actions"][0]["target"]["status_counts"] == {
+        "pending": created_total,
+    }
     assert items_by_goal[rejected_goal["goal_id"]]["needs_operator_attention"] is False
     assert items_by_goal[rejected_goal["goal_id"]]["attention_reason"] == "ready"
     assert items_by_goal[rejected_goal["goal_id"]]["rejected"] == rejected_total
+    assert items_by_goal[rejected_goal["goal_id"]]["follow_up_actions"] == [
+        {
+            "id": "no_action_required",
+            "label": "No immediate action",
+            "description": (
+                "This planner handoff is clear; continue monitoring or open the preview if context is needed."
+            ),
+            "action_type": "none",
+            "target": {"goal_id": rejected_goal["goal_id"]},
+            "mutates": False,
+        }
+    ]
+    assert all(
+        action["mutates"] is False
+        for item in items_by_goal.values()
+        for action in item["follow_up_actions"]
+    )
 
 
 def test_planner_global_handoffs_read_only(client):


### PR DESCRIPTION
﻿## Summary
- add read-only `follow_up_actions` to planner global handoff items
- render suggested follow-up action cards in the Planner Handoff Queue
- support navigation-only follow-ups for pending reviews, deferred follow-ups, and created task monitoring

## Test Plan
- `python -m py_compile goal_ops_console\models.py goal_ops_console\routers\goals.py`
- `node --check goal_ops_console\static\app.js`
- `git diff --check`
- targeted pytest: `tests/test_planner_global_handoffs.py tests/test_goal_ops.py -k "planner_global_handoffs or 272o4"`
- broader pytest: `tests/test_planner_global_handoffs.py tests/test_goal_ops.py` (348 passed)
- full local pytest: `python -m pytest` (369 passed)
- local Playwright browser smoke for follow-up action rendering and navigation
