### PR TITLE
Add planner handoff task drilldown

### DIFF
--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -264,6 +264,7 @@ class PlannerGlobalHandoffItem(BaseModel):
     next_pending_suggestion: PlannerHandoffSuggestionItem | None = None
     latest_deferred_suggestion: PlannerHandoffSuggestionItem | None = None
     created_task_statuses: dict[str, int] = Field(default_factory=dict)
+    created_tasks_preview: list[PlannerHandoffCreatedTaskItem] = Field(default_factory=list)
     follow_up_actions: list[PlannerGlobalHandoffFollowUpAction] = Field(default_factory=list)
 
 

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -35,6 +35,7 @@ _PLANNER_REVIEW_AUDIT_EVENT_TYPES = (
     "planner.suggestion_reviewed",
     "planner.suggestion_review_reopened",
 )
+_PLANNER_GLOBAL_CREATED_TASK_PREVIEW_LIMIT = 3
 
 
 @router.get("")
@@ -365,6 +366,18 @@ def _created_task_statuses(handoff: dict) -> dict[str, int]:
     return statuses
 
 
+def _planner_created_tasks_preview(handoff: dict) -> list[dict]:
+    sorted_tasks = sorted(
+        handoff["created_tasks"],
+        key=lambda task: (
+            task["task_status"] == "succeeded",
+            task["suggestion_index"],
+            task["task_id"],
+        ),
+    )
+    return sorted_tasks[:_PLANNER_GLOBAL_CREATED_TASK_PREVIEW_LIMIT]
+
+
 def _non_terminal_created_task_statuses(handoff: dict) -> dict[str, int]:
     statuses: dict[str, int] = {}
     for task in handoff["created_tasks"]:
@@ -490,6 +503,7 @@ def _planner_global_handoff_item(goal: dict, services: AppServices) -> dict:
         ),
         "latest_deferred_suggestion": latest_deferred_suggestion,
         "created_task_statuses": _created_task_statuses(handoff),
+        "created_tasks_preview": _planner_created_tasks_preview(handoff),
         "follow_up_actions": _planner_global_follow_up_actions(handoff),
     }
 

--- a/goal_ops_console/static/app.js
+++ b/goal_ops_console/static/app.js
@@ -1209,6 +1209,12 @@ function plannerGlobalHandoffVisibleItems(payload) {
     item.latest_deferred_suggestion?.title || "",
     item.first_deferred_suggestion?.title || "",
     item.first_deferred?.title || "",
+    ...plannerCreatedTaskPreviewItems(item).flatMap((task) => [
+      task.task_id,
+      task.task_title,
+      task.task_status,
+      task.title,
+    ]),
     ...plannerGlobalHandoffActions(item).flatMap((action) => [
       action.id,
       action.label,
@@ -1247,6 +1253,39 @@ function firstPlannerHandoffSuggestion(item, key, fallbackKey, alternateKey = nu
 function plannerHandoffSuggestionIndex(item) {
   const index = Number.parseInt(item?.suggestion_index, 10);
   return Number.isInteger(index) && index >= 0 ? index : null;
+}
+
+function plannerCreatedTaskPreviewItems(item) {
+  return Array.isArray(item?.created_tasks_preview) ? item.created_tasks_preview : [];
+}
+
+function renderPlannerCreatedTaskPreview(item) {
+  const tasks = plannerCreatedTaskPreviewItems(item);
+  if (!tasks.length) {
+    return "";
+  }
+  const createdTotal = item?.summary?.created ?? item?.created ?? tasks.length;
+  const remainingCount = Math.max(0, createdTotal - tasks.length);
+  const remainingLabel = remainingCount
+    ? ` &middot; ${remainingCount} more in task list`
+    : "";
+  return `
+    <div class="planner-created-task-preview">
+      <div class="meta"><strong>Created planner tasks</strong> &middot; read-only${remainingLabel}</div>
+      ${tasks.map((task) => `
+        <div class="planner-created-task-preview-item">
+          <div>
+            <div class="entity-title">${escapeHtml(task.task_title || task.title || task.task_id)}</div>
+            <div class="meta">
+              #${Number(task.suggestion_index) + 1}
+              &middot; ${escapeHtml(task.task_id || "unknown task")}
+            </div>
+          </div>
+          <span class="pill ${stateClass(task.task_status)}">${escapeHtml(task.task_status || "unknown")}</span>
+        </div>
+      `).join("")}
+    </div>
+  `;
 }
 
 function renderPlannerFollowUpActionButton(action, item) {
@@ -1370,6 +1409,7 @@ function renderPlannerGlobalHandoffs(payload) {
             <div class="entity-metric"><span class="meta">Rejected</span><strong>${itemSummary.rejected || 0}</strong></div>
             <div class="entity-metric"><span class="meta">Pending</span><strong>${itemSummary.pending || 0}</strong></div>
           </div>
+          ${renderPlannerCreatedTaskPreview(item)}
           ${renderPlannerFollowUpActions(item)}
           <div class="actions" style="margin-top:0.75rem;">
             <button type="button" class="secondary" data-plan-goal="${escapeHtml(item.goal_id)}">Open Plan Preview</button>

--- a/goal_ops_console/templates/index.html
+++ b/goal_ops_console/templates/index.html
@@ -677,8 +677,27 @@
       color: var(--ok);
       font-weight: 600;
     }
+    .planner-created-task-preview {
+      display: grid;
+      gap: 0.5rem;
+      margin-top: 0.75rem;
+      padding: 0.65rem;
+      border: 1px solid rgba(31, 27, 23, 0.08);
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.5);
+    }
+    .planner-created-task-preview-item {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 0.75rem;
+      align-items: center;
+      padding: 0.55rem;
+      border-radius: 12px;
+      background: rgba(35, 102, 173, 0.06);
+    }
     @media (max-width: 720px) {
-      .planner-handoff-action {
+      .planner-handoff-action,
+      .planner-created-task-preview-item {
         grid-template-columns: 1fr;
       }
     }

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -16157,6 +16157,65 @@ def test_272n4_goal_plan_handoff_unknown_goal_returns_404(client):
     assert response.json()["detail"] == "Goal missing-goal not found"
 
 
+def test_272n5_goal_planner_global_handoffs_exposes_created_task_preview(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Global handoff created task drilldown", "urgency": 0.6, "value": 0.7, "deadline_score": 0.2},
+    ).json()
+    preview = client.post(f"/goals/{goal['goal_id']}/plan").json()
+    total = len(preview["suggestions"])
+    created = client.post(
+        f"/goals/{goal['goal_id']}/plan/tasks/bulk",
+        json={
+            "suggestion_indexes": list(range(total)),
+            "overrides": {
+                0: {"title": "Succeeded planner task"},
+                1: {"title": "Failed planner task"},
+                2: {"title": "Pending planner task"},
+                3: {"title": "Later pending planner task"},
+            },
+        },
+    ).json()
+    created_by_index = {item["suggestion_index"]: item for item in created["created"]}
+
+    client.post(f"/tasks/{created_by_index[0]['task']['task_id']}/success")
+    client.post(
+        f"/tasks/{created_by_index[1]['task']['task_id']}/fail",
+        json={"failure_type": "SkillFailure", "error_message": "Preview this task first"},
+    )
+    before_tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    response = client.get("/goals/planner/handoffs?status=all")
+    payload = response.json()
+    item = next(entry for entry in payload["items"] if entry["goal_id"] == goal["goal_id"])
+    after_tasks = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+
+    assert response.status_code == 200
+    assert len(before_tasks) == total
+    assert after_tasks == before_tasks
+    assert item["attention_reason"] == "created_task_not_terminal"
+    assert item["created_task_statuses"] == {
+        "succeeded": 1,
+        "failed": 1,
+        "pending": total - 2,
+    }
+    assert item["summary"]["created"] == total
+    assert [task["suggestion_index"] for task in item["created_tasks_preview"]] == [1, 2, 3]
+    assert [task["task_status"] for task in item["created_tasks_preview"]] == ["failed", "pending", "pending"]
+    assert [task["task_title"] for task in item["created_tasks_preview"]] == [
+        "Failed planner task",
+        "Pending planner task",
+        "Later pending planner task",
+    ]
+    assert item["created_tasks_preview"][0]["task_id"] == created_by_index[1]["task"]["task_id"]
+    assert item["follow_up_actions"][0]["id"] == "monitor_created_tasks"
+    assert item["follow_up_actions"][0]["target"]["task_ids"] == [
+        created_by_index[1]["task"]["task_id"],
+        created_by_index[2]["task"]["task_id"],
+        created_by_index[3]["task"]["task_id"],
+    ]
+
+
 def test_272o_goal_planner_review_inbox_returns_goal_rollup(client):
     pending_goal = client.post(
         "/goals",
@@ -16285,6 +16344,8 @@ def test_272o4_planner_review_inbox_open_next_review_focus_contract():
     assert "function plannerGlobalHandoffReason(item)" in app_js
     assert "function plannerGlobalHandoffReasonLabel(reason)" in app_js
     assert "function plannerGlobalHandoffActions(item)" in app_js
+    assert "function plannerCreatedTaskPreviewItems(item)" in app_js
+    assert "function renderPlannerCreatedTaskPreview(item)" in app_js
     assert "function renderPlannerFollowUpActions(item)" in app_js
     assert "function renderPlannerFollowUpActionButton(action, item)" in app_js
     assert "function loadPlannerFollowUpContinuity()" in app_js
@@ -16306,7 +16367,9 @@ def test_272o4_planner_review_inbox_open_next_review_focus_contract():
     assert "data-plan-follow-up-goal-title" in app_js
     assert "attention_reason" in app_js
     assert "follow_up_actions" in app_js
+    assert "created_tasks_preview" in app_js
     assert "Suggested follow-up actions" in app_js
+    assert "Created planner tasks" in app_js
     assert "Last opened follow-up" in app_js
     assert "Follow-up continuity" in app_js
     assert "/plan/handoff" in app_js
@@ -16331,6 +16394,8 @@ def test_272o4_planner_review_inbox_open_next_review_focus_contract():
     assert ".planner-handoff-actions" in template
     assert ".planner-handoff-action" in template
     assert ".planner-handoff-action-continuity" in template
+    assert ".planner-created-task-preview" in template
+    assert ".planner-created-task-preview-item" in template
     assert 'src="/static/app.js?v={{ static_asset_version }}"' in template
     assert '"static_asset_version": _static_asset_version()' in system_router
 


### PR DESCRIPTION
﻿## Summary
- add a read-only `created_tasks_preview` to global planner handoff items
- prioritize non-terminal created planner tasks before succeeded tasks in the preview
- render the created-task drilldown in the Planner Handoff Queue without adding mutations

## Test plan
- `node --check goal_ops_console\static\app.js`
- `git diff --check` (CRLF warnings only)
- `python -m pytest tests\test_goal_ops.py -k "272n5 or 272o4"`
- `python -m pytest tests\test_goal_ops.py -k "272n or 272o or 272u"`
- `python -m pytest`
- Browser smoke against temporary local DB: created planner task preview shows failed task before pending tasks and omits succeeded task from the limited preview
