### PR TITLE
[codex] Add SQLite retention contract health signals

### DIFF
--- a/goal_ops_console/database.py
+++ b/goal_ops_console/database.py
@@ -1,3 +1,16 @@
+"""SQLite persistence boundary for the supervised desktop runtime.
+
+Concurrency contract:
+- Open a fresh SQLite connection for each operation/transaction; the only
+  long-lived keeper connection is for shared in-memory test databases.
+- Enable foreign keys and a 5s busy timeout on every connection.
+- Use `BEGIN IMMEDIATE` for mutating transactions so write contention is
+  explicit and retried at the database boundary.
+- Retry transient SQLite lock errors with a short bounded backoff.
+- Do not force WAL mode yet. The runtime is Windows/desktop oriented and may
+  run from synced folders, so journal-mode changes must be deliberate.
+"""
+
 import contextlib
 import shutil
 import sqlite3
@@ -261,6 +274,7 @@ CREATE INDEX IF NOT EXISTS idx_metrics_updated_at ON metrics_counters(updated_at
 SQLITE_BUSY_TIMEOUT_MS = 5_000
 LOCK_RETRY_ATTEMPTS = 8
 LOCK_RETRY_BASE_SECONDS = 0.01
+SQLITE_TRANSACTION_BEGIN_MODE = "BEGIN IMMEDIATE"
 SQLITE_CORRUPTION_SIGNATURES = (
     "database disk image is malformed",
     "file is not a database",
@@ -486,6 +500,41 @@ class Database:
         conn.execute("PRAGMA foreign_keys = ON")
         conn.execute(f"PRAGMA busy_timeout = {SQLITE_BUSY_TIMEOUT_MS}")
         return conn
+
+    def sqlite_contract_snapshot(self) -> dict[str, object]:
+        conn = self._connect()
+        try:
+            observed_busy_timeout = int(conn.execute("PRAGMA busy_timeout").fetchone()[0])
+            observed_foreign_keys = int(conn.execute("PRAGMA foreign_keys").fetchone()[0])
+            observed_journal_mode = str(conn.execute("PRAGMA journal_mode").fetchone()[0])
+        finally:
+            conn.close()
+
+        return {
+            "ok": bool(
+                observed_busy_timeout == SQLITE_BUSY_TIMEOUT_MS
+                and observed_foreign_keys == 1
+            ),
+            "connection_scope": (
+                "fresh_connection_per_operation_with_shared_memory_keeper_for_tests"
+            ),
+            "check_same_thread": False,
+            "isolation_level": None,
+            "foreign_keys": "ON",
+            "busy_timeout_ms": SQLITE_BUSY_TIMEOUT_MS,
+            "lock_retry_attempts": LOCK_RETRY_ATTEMPTS,
+            "lock_retry_base_seconds": LOCK_RETRY_BASE_SECONDS,
+            "transaction_begin_mode": SQLITE_TRANSACTION_BEGIN_MODE,
+            "wal_forced": False,
+            "journal_mode_note": (
+                "Uses SQLite default journal mode unless an operator changes it explicitly."
+            ),
+            "observed": {
+                "busy_timeout_ms": observed_busy_timeout,
+                "foreign_keys": bool(observed_foreign_keys),
+                "journal_mode": observed_journal_mode,
+            },
+        }
 
     def _is_lock_error(self, error: sqlite3.OperationalError) -> bool:
         message = str(error).lower()
@@ -804,7 +853,7 @@ WHERE idempotency_key IS NOT NULL;
             for attempt in range(LOCK_RETRY_ATTEMPTS):
                 trial = self._connect()
                 try:
-                    trial.execute("BEGIN IMMEDIATE")
+                    trial.execute(SQLITE_TRANSACTION_BEGIN_MODE)
                     conn = trial
                     break
                 except sqlite3.OperationalError as error:

--- a/goal_ops_console/event_bus.py
+++ b/goal_ops_console/event_bus.py
@@ -10,6 +10,16 @@ from goal_ops_console.models import BackpressureError
 if TYPE_CHECKING:
     from goal_ops_console.observability import ObservabilityService
 
+RETENTION_DELETE_METRICS = {
+    "events": "maintenance.retention.events_deleted",
+    "event_processing": "maintenance.retention.event_processing_deleted",
+    "failure_log": "maintenance.retention.failure_log_deleted",
+    "audit_integrity": "maintenance.retention.audit_integrity_deleted",
+    "audit_log": "maintenance.retention.audit_log_deleted",
+    "idempotency_keys": "maintenance.retention.idempotency_deleted",
+}
+RETENTION_CLEANUP_RUNS_METRIC = "maintenance.retention.cleanup_runs"
+
 
 def make_payload(data: dict[str, Any] | None = None) -> str:
     return json.dumps({"schema_version": 1, "data": data or {}})
@@ -184,6 +194,7 @@ class EventBus:
                 self._metric("maintenance.retention.audit_log_deleted", audit_log_deleted, tx=tx)
             if idempotency_deleted:
                 self._metric("maintenance.retention.idempotency_deleted", idempotency_deleted, tx=tx)
+            self._metric(RETENTION_CLEANUP_RUNS_METRIC, tx=tx)
         return {
             "events_deleted": events_deleted,
             "event_processing_deleted": event_processing_deleted,
@@ -191,6 +202,44 @@ class EventBus:
             "audit_integrity_deleted": audit_integrity_deleted,
             "audit_log_deleted": audit_log_deleted,
             "idempotency_deleted": idempotency_deleted,
+        }
+
+    def retention_snapshot(self) -> dict[str, Any]:
+        metric_names = [RETENTION_CLEANUP_RUNS_METRIC, *RETENTION_DELETE_METRICS.values()]
+        placeholders = ", ".join("?" for _ in metric_names)
+        rows = self.db.fetch_all(
+            f"""SELECT metric_name, value, updated_at
+                FROM metrics_counters
+                WHERE metric_name IN ({placeholders})""",
+            *metric_names,
+        )
+        metrics = {str(row["metric_name"]): dict(row) for row in rows}
+
+        deleted_by_store: dict[str, int] = {}
+        last_delete_at_by_store: dict[str, str | None] = {}
+        for store, metric_name in RETENTION_DELETE_METRICS.items():
+            row = metrics.get(metric_name) or {}
+            deleted_by_store[store] = int(row.get("value") or 0)
+            last_delete_at_by_store[store] = (
+                str(row["updated_at"]) if row.get("updated_at") is not None else None
+            )
+
+        cleanup_row = metrics.get(RETENTION_CLEANUP_RUNS_METRIC) or {}
+        return {
+            "events_days": self.events_retention_days,
+            "event_processing_days": self.event_processing_retention_days,
+            "failure_log_days": self.failure_log_retention_days,
+            "audit_log_days": self.audit_log_retention_days,
+            "idempotency_keys_days": self.idempotency_retention_days,
+            "cleanup_runs_total": int(cleanup_row.get("value") or 0),
+            "last_cleanup_at_utc": (
+                str(cleanup_row["updated_at"])
+                if cleanup_row.get("updated_at") is not None
+                else None
+            ),
+            "deleted_rows_total": sum(deleted_by_store.values()),
+            "deleted_rows_by_store_total": deleted_by_store,
+            "last_delete_at_utc_by_store": last_delete_at_by_store,
         }
 
     def list_events(

--- a/goal_ops_console/routers/system.py
+++ b/goal_ops_console/routers/system.py
@@ -51,12 +51,9 @@ def _build_health_payload(services: AppServices) -> dict[str, Any]:
             "tasks": int(total_tasks),
         },
         "backpressure": backpressure,
-        "retention": {
-            "events_days": services.settings.events_retention_days,
-            "event_processing_days": services.settings.event_processing_retention_days,
-            "failure_log_days": services.settings.failure_log_retention_days,
-            "audit_log_days": services.settings.audit_log_retention_days,
-            "idempotency_keys_days": services.settings.idempotency_retention_days,
+        "retention": services.event_bus.retention_snapshot(),
+        "database": {
+            "concurrency": services.db.sqlite_contract_snapshot(),
         },
         "metrics": services.observability.metrics_summary(),
         "audit": {

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -16,7 +16,14 @@ import pytest
 from fastapi.testclient import TestClient
 
 from goal_ops_console.config import Settings
-from goal_ops_console.database import Database, new_id, now_utc
+from goal_ops_console.database import (
+    LOCK_RETRY_ATTEMPTS,
+    SQLITE_BUSY_TIMEOUT_MS,
+    SQLITE_TRANSACTION_BEGIN_MODE,
+    Database,
+    new_id,
+    now_utc,
+)
 from goal_ops_console.failure_intelligence import compute_error_hash
 from goal_ops_console.main import create_app
 from goal_ops_console.models import OptimisticLockError, RetryBudgetExceeded
@@ -567,6 +574,68 @@ def test_29_retention_cleanup_deletes_old_records(client):
     assert services.db.fetch_scalar("SELECT COUNT(*) FROM audit_log WHERE audit_id = ?", old_audit_id) == 0
     assert services.db.fetch_scalar("SELECT COUNT(*) FROM audit_log_integrity WHERE audit_id = ?", old_audit_id) == 0
 
+    retention = client.get("/system/health").json()["retention"]
+    assert retention["cleanup_runs_total"] >= 1
+    assert retention["last_cleanup_at_utc"] is not None
+    assert retention["deleted_rows_by_store_total"]["events"] >= 1
+    assert retention["deleted_rows_by_store_total"]["event_processing"] >= 1
+    assert retention["deleted_rows_by_store_total"]["failure_log"] >= 1
+    assert retention["deleted_rows_by_store_total"]["audit_log"] >= 1
+    assert retention["deleted_rows_by_store_total"]["audit_integrity"] >= 1
+    assert retention["deleted_rows_total"] >= 5
+
+
+def test_29a_database_sqlite_contract_reports_pragmas_and_retry_policy(client):
+    services = client.app.state.services
+
+    contract = services.db.sqlite_contract_snapshot()
+
+    assert contract["ok"] is True
+    assert contract["busy_timeout_ms"] == SQLITE_BUSY_TIMEOUT_MS
+    assert contract["lock_retry_attempts"] == LOCK_RETRY_ATTEMPTS
+    assert contract["transaction_begin_mode"] == SQLITE_TRANSACTION_BEGIN_MODE
+    assert contract["wal_forced"] is False
+    assert contract["observed"]["busy_timeout_ms"] == SQLITE_BUSY_TIMEOUT_MS
+    assert contract["observed"]["foreign_keys"] is True
+    assert contract["observed"]["journal_mode"]
+
+    health = client.get("/system/health").json()
+    assert health["database"]["concurrency"]["ok"] is True
+    assert health["database"]["concurrency"]["transaction_begin_mode"] == SQLITE_TRANSACTION_BEGIN_MODE
+
+
+def test_29b_database_parallel_write_storm_uses_bounded_lock_retries(tmp_path):
+    db = Database(str(tmp_path / "write-storm.sqlite3"))
+    db.initialize()
+    barrier = threading.Barrier(12)
+    errors: list[str] = []
+
+    def writer(index: int) -> None:
+        try:
+            barrier.wait(timeout=2)
+            with db.transaction() as tx:
+                tx.execute(
+                    "INSERT INTO events "
+                    "(event_id, event_type, entity_id, correlation_id, payload, emitted_at) "
+                    "VALUES (?, ?, ?, ?, '{}', ?)",
+                    new_id(),
+                    "storm.write",
+                    f"entity-{index}",
+                    "storm",
+                    now_utc(),
+                )
+        except Exception as exc:
+            errors.append(str(exc))
+
+    threads = [threading.Thread(target=writer, args=(index,)) for index in range(12)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert errors == []
+    assert db.fetch_scalar("SELECT COUNT(*) FROM events WHERE event_type = 'storm.write'") == 12
+
 
 def test_30_backpressure_endpoint_and_health_include_limits(client):
     snapshot = client.get("/system/backpressure")
@@ -576,6 +645,9 @@ def test_30_backpressure_endpoint_and_health_include_limits(client):
     assert snapshot.json()["max_pending_events"] == client.app.state.services.settings.max_pending_events
     assert "backpressure" in health.json()
     assert "retention" in health.json()
+    assert health.json()["retention"]["cleanup_runs_total"] == 0
+    assert health.json()["retention"]["last_cleanup_at_utc"] is None
+    assert health.json()["retention"]["deleted_rows_total"] == 0
 
 
 def test_31_metrics_endpoint_exposes_hook_counters(client):


### PR DESCRIPTION
﻿## Summary
- document the SQLite desktop concurrency contract at the persistence boundary
- expose a `/system/health` database concurrency snapshot with observed SQLite PRAGMAs
- expose retention cleanup activity counters in `/system/health`
- add focused tests for SQLite PRAGMA contract, parallel write contention, and retention health signals

## Why
The external review correctly called out SQLite-on-Windows/desktop concurrency and retention visibility as likely future ghost-bug territory. This PR keeps the scope deliberately small: no schema migration, no UI panel, no planner behavior change, and no Guard workflow restructuring.

## Validation
- `python -m py_compile goal_ops_console\database.py goal_ops_console\event_bus.py goal_ops_console\routers\system.py`
- `git diff --check` (CRLF warnings only)
- `python -m pytest tests\test_goal_ops.py -k "test_29 or test_30"`
- `python -m pytest` -> 374 passed
