### PR TITLE
[codex] Persist planner suggestions

### DIFF
--- a/goal_ops_console/database.py
+++ b/goal_ops_console/database.py
@@ -406,6 +406,39 @@ VALUES (5, 'planner_suggestion_reviews', datetime('now'));
 COMMIT;
 """,
     ),
+    (
+        6,
+        """
+BEGIN IMMEDIATE;
+CREATE TABLE IF NOT EXISTS planner_suggestions (
+  suggestion_id       TEXT PRIMARY KEY,
+  goal_id             TEXT NOT NULL,
+  suggestion_index    INTEGER NOT NULL,
+  planner_source      TEXT NOT NULL,
+  title               TEXT NOT NULL,
+  description         TEXT NOT NULL,
+  rationale           TEXT NOT NULL,
+  priority_hint       TEXT NOT NULL,
+  created_at          TEXT NOT NULL,
+  updated_at          TEXT NOT NULL,
+  FOREIGN KEY(goal_id) REFERENCES goals(goal_id),
+  UNIQUE(goal_id, suggestion_index)
+);
+ALTER TABLE tasks ADD COLUMN planner_suggestion_id TEXT;
+ALTER TABLE planner_suggestion_reviews ADD COLUMN suggestion_id TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_planner_suggestions_goal_index
+ON planner_suggestions(goal_id, suggestion_index);
+CREATE INDEX IF NOT EXISTS idx_planner_suggestions_goal_created
+ON planner_suggestions(goal_id, created_at ASC);
+CREATE INDEX IF NOT EXISTS idx_tasks_planner_suggestion_id
+ON tasks(planner_suggestion_id);
+CREATE INDEX IF NOT EXISTS idx_planner_suggestion_reviews_suggestion_id
+ON planner_suggestion_reviews(suggestion_id);
+INSERT INTO schema_migrations (version, name, applied_at)
+VALUES (6, 'planner_suggestions', datetime('now'));
+COMMIT;
+""",
+    ),
 )
 T = TypeVar("T")
 
@@ -675,6 +708,14 @@ class Database:
 CREATE UNIQUE INDEX IF NOT EXISTS idx_workflow_runs_idempotency
 ON workflow_runs(workflow_id, idempotency_key)
 WHERE idempotency_key IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_planner_suggestions_goal_index
+ON planner_suggestions(goal_id, suggestion_index);
+CREATE INDEX IF NOT EXISTS idx_planner_suggestions_goal_created
+ON planner_suggestions(goal_id, created_at ASC);
+CREATE INDEX IF NOT EXISTS idx_tasks_planner_suggestion_id
+ON tasks(planner_suggestion_id);
+CREATE INDEX IF NOT EXISTS idx_planner_suggestion_reviews_suggestion_id
+ON planner_suggestion_reviews(suggestion_id);
 """
         )
 

--- a/goal_ops_console/execution_layer.py
+++ b/goal_ops_console/execution_layer.py
@@ -35,6 +35,7 @@ class ExecutionLayer:
         goal_id: str,
         title: str,
         planner_source: str | None = None,
+        planner_suggestion_id: str | None = None,
         planner_suggestion_index: int | None = None,
         planner_priority_hint: str | None = None,
         planner_suggestion_description: str | None = None,
@@ -52,6 +53,7 @@ class ExecutionLayer:
         if planner_source is not None:
             event_payload["planner"] = {
                 "source": planner_source,
+                "suggestion_id": planner_suggestion_id,
                 "suggestion_index": planner_suggestion_index,
                 "priority_hint": planner_priority_hint,
                 "rationale": planner_suggestion_rationale,
@@ -66,15 +68,16 @@ class ExecutionLayer:
         with self.db.transaction() as tx:
             tx.execute(
                 "INSERT INTO tasks "
-                "(task_id, goal_id, title, planner_source, planner_suggestion_index, "
+                "(task_id, goal_id, title, planner_source, planner_suggestion_id, planner_suggestion_index, "
                 "planner_priority_hint, planner_suggestion_description, planner_suggestion_rationale, "
                 "planner_operator_overrides, "
                 "created_at, updated_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 task_id,
                 goal_id,
                 title,
                 planner_source,
+                planner_suggestion_id,
                 planner_suggestion_index,
                 planner_priority_hint,
                 planner_suggestion_description,
@@ -114,6 +117,7 @@ class ExecutionLayer:
                        ts.goal_id,
                        t.title,
                        t.planner_source,
+                       t.planner_suggestion_id,
                        t.planner_suggestion_index,
                        t.planner_priority_hint,
                        t.planner_suggestion_description,
@@ -141,6 +145,7 @@ class ExecutionLayer:
                       ts.goal_id,
                       t.title,
                       t.planner_source,
+                      t.planner_suggestion_id,
                       t.planner_suggestion_index,
                       t.planner_priority_hint,
                       t.planner_suggestion_description,

--- a/goal_ops_console/models.py
+++ b/goal_ops_console/models.py
@@ -71,6 +71,7 @@ class GoalCreateRequest(BaseModel):
 
 
 class PlannerTaskSuggestion(BaseModel):
+    suggestion_id: str | None = None
     title: str
     description: str
     rationale: str
@@ -113,6 +114,7 @@ class PlannerSuggestionReview(BaseModel):
     decision: Literal["created", "deferred", "rejected"]
     comment: str | None = None
     task_id: str | None = None
+    suggestion_id: str | None = None
     planner_source: str
     suggestion_title: str
     suggestion_description: str

--- a/goal_ops_console/routers/goals.py
+++ b/goal_ops_console/routers/goals.py
@@ -3,7 +3,7 @@ from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, Query
 
-from goal_ops_console.database import now_utc
+from goal_ops_console.database import new_id, now_utc
 from goal_ops_console.models import (
     ConflictError,
     DomainError,
@@ -62,9 +62,80 @@ def get_goal(goal_id: str, services: AppServices = Depends(get_services)) -> dic
     return services.state_manager.get_goal(goal_id)
 
 
-def _preview_goal_plan(goal_id: str, services: AppServices) -> dict:
+def _planner_suggestion_from_row(row: Any) -> dict:
+    return {
+        "suggestion_id": str(row["suggestion_id"]),
+        "title": str(row["title"]),
+        "description": str(row["description"]),
+        "rationale": str(row["rationale"]),
+        "priority_hint": str(row["priority_hint"]),
+        "source": str(row["planner_source"]),
+    }
+
+
+def _planner_suggestions_by_index(goal_id: str, services: AppServices) -> dict[int, dict]:
+    rows = services.db.fetch_all(
+        """SELECT suggestion_id,
+                  suggestion_index,
+                  planner_source,
+                  title,
+                  description,
+                  rationale,
+                  priority_hint
+           FROM planner_suggestions
+           WHERE goal_id = ?
+           ORDER BY suggestion_index ASC""",
+        goal_id,
+    )
+    return {int(row["suggestion_index"]): _planner_suggestion_from_row(row) for row in rows}
+
+
+def _persist_plan_suggestions(goal_id: str, plan: dict, services: AppServices) -> dict[int, dict]:
+    timestamp = now_utc()
+    with services.db.transaction() as tx:
+        for suggestion_index, suggestion in enumerate(plan["suggestions"]):
+            tx.execute(
+                """INSERT OR IGNORE INTO planner_suggestions
+                   (suggestion_id, goal_id, suggestion_index, planner_source, title,
+                    description, rationale, priority_hint, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                new_id(),
+                goal_id,
+                suggestion_index,
+                suggestion["source"],
+                suggestion["title"],
+                suggestion["description"],
+                suggestion["rationale"],
+                suggestion["priority_hint"],
+                timestamp,
+                timestamp,
+            )
+    return _planner_suggestions_by_index(goal_id, services)
+
+
+def _attach_persisted_suggestions(plan: dict, persisted_by_index: dict[int, dict]) -> None:
+    for suggestion_index, suggestion in enumerate(plan["suggestions"]):
+        persisted = persisted_by_index.get(suggestion_index)
+        if persisted is None:
+            suggestion["suggestion_id"] = None
+            continue
+        suggestion.update(persisted)
+
+
+def _preview_goal_plan(
+    goal_id: str,
+    services: AppServices,
+    *,
+    persist_suggestions: bool = False,
+) -> dict:
     goal = services.state_manager.get_goal(goal_id)
     plan = services.planner.create_plan(goal)
+    persisted_by_index = (
+        _persist_plan_suggestions(goal_id, plan, services)
+        if persist_suggestions
+        else _planner_suggestions_by_index(goal_id, services)
+    )
+    _attach_persisted_suggestions(plan, persisted_by_index)
     existing_by_title = _existing_tasks_by_title(goal_id, services)
     existing_by_index = _existing_tasks_by_suggestion_index(goal_id, services)
     reviews_by_index = _planner_reviews_by_index(goal_id, services)
@@ -138,6 +209,7 @@ def _create_task_from_suggestion(
         goal_id=goal_id,
         title=applied_suggestion["title"],
         planner_source=original_suggestion["source"],
+        planner_suggestion_id=original_suggestion.get("suggestion_id"),
         planner_suggestion_index=suggestion_index,
         planner_priority_hint=original_suggestion["priority_hint"],
         planner_suggestion_description=original_suggestion["description"],
@@ -163,6 +235,7 @@ def _planner_reviews_by_index(goal_id: str, services: AppServices) -> dict[int, 
                   decision,
                   comment,
                   task_id,
+                  suggestion_id,
                   planner_source,
                   suggestion_title,
                   suggestion_description,
@@ -690,6 +763,7 @@ def _get_planner_review(goal_id: str, suggestion_index: int, services: AppServic
                   decision,
                   comment,
                   task_id,
+                  suggestion_id,
                   planner_source,
                   suggestion_title,
                   suggestion_description,
@@ -751,15 +825,16 @@ def _create_planner_review(
     with services.db.transaction() as tx:
         tx.execute(
             """INSERT INTO planner_suggestion_reviews
-               (goal_id, suggestion_index, decision, comment, task_id, planner_source,
+               (goal_id, suggestion_index, decision, comment, task_id, suggestion_id, planner_source,
                 suggestion_title, suggestion_description, suggestion_rationale,
                 suggestion_priority_hint, operator_override, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             goal_id,
             suggestion_index,
             decision,
             normalized_comment,
             task_id,
+            suggestion.get("suggestion_id"),
             suggestion["source"],
             suggestion["title"],
             suggestion["description"],
@@ -779,6 +854,7 @@ def _create_planner_review(
                 "decision": decision,
                 "comment": normalized_comment,
                 "task_id": task_id,
+                "suggestion_id": suggestion.get("suggestion_id"),
                 "source": suggestion["source"],
             },
             tx=tx,
@@ -802,15 +878,16 @@ def _create_planner_reviews(
         for suggestion_index, suggestion in resolved_suggestions:
             tx.execute(
                 """INSERT INTO planner_suggestion_reviews
-                   (goal_id, suggestion_index, decision, comment, task_id, planner_source,
+                   (goal_id, suggestion_index, decision, comment, task_id, suggestion_id, planner_source,
                     suggestion_title, suggestion_description, suggestion_rationale,
                     suggestion_priority_hint, operator_override, created_at, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 goal_id,
                 suggestion_index,
                 decision,
                 normalized_comment,
                 None,
+                suggestion.get("suggestion_id"),
                 suggestion["source"],
                 suggestion["title"],
                 suggestion["description"],
@@ -830,6 +907,7 @@ def _create_planner_reviews(
                     "decision": decision,
                     "comment": normalized_comment,
                     "task_id": None,
+                    "suggestion_id": suggestion.get("suggestion_id"),
                     "source": suggestion["source"],
                 },
                 tx=tx,
@@ -874,6 +952,7 @@ def _reopen_planner_review(goal_id: str, suggestion_index: int, services: AppSer
             {
                 "goal_id": goal_id,
                 "suggestion_index": suggestion_index,
+                "suggestion_id": existing_review.get("suggestion_id"),
                 "cleared_decision": existing_review["decision"],
                 "cleared_comment": existing_review["comment"],
                 "source": existing_review["planner_source"],
@@ -886,7 +965,7 @@ def _reopen_planner_review(goal_id: str, suggestion_index: int, services: AppSer
 
 @router.post("/{goal_id}/plan", response_model=PlannerPreviewResponse)
 def preview_goal_plan(goal_id: str, services: AppServices = Depends(get_services)) -> dict:
-    return _preview_goal_plan(goal_id, services)
+    return _preview_goal_plan(goal_id, services, persist_suggestions=True)
 
 
 @router.get("/{goal_id}/plan/reviews", response_model=PlannerReviewListResponse)
@@ -952,7 +1031,7 @@ def review_plan_suggestion(
     request: PlannerReviewDecisionRequest,
     services: AppServices = Depends(get_services),
 ) -> dict:
-    plan = _preview_goal_plan(goal_id, services)
+    plan = _preview_goal_plan(goal_id, services, persist_suggestions=True)
     suggestion = _get_plan_suggestion(plan, request.suggestion_index, goal_id)
     if suggestion["task_exists"]:
         raise ConflictError(
@@ -982,7 +1061,7 @@ def review_plan_suggestions_bulk(
     request: PlannerBulkReviewDecisionRequest,
     services: AppServices = Depends(get_services),
 ) -> dict:
-    plan = _preview_goal_plan(goal_id, services)
+    plan = _preview_goal_plan(goal_id, services, persist_suggestions=True)
     _ensure_unique_suggestion_indexes(goal_id, request.suggestion_indexes)
     existing_reviews_by_index = _planner_reviews_by_index(goal_id, services)
     resolved_suggestions = []
@@ -1027,7 +1106,7 @@ def reopen_plan_suggestion_review(
     suggestion_index: int,
     services: AppServices = Depends(get_services),
 ) -> dict:
-    plan = _preview_goal_plan(goal_id, services)
+    plan = _preview_goal_plan(goal_id, services, persist_suggestions=True)
     _get_plan_suggestion(plan, suggestion_index, goal_id)
     cleared_review = _reopen_planner_review(goal_id, suggestion_index, services)
     refreshed_plan = _preview_goal_plan(goal_id, services)
@@ -1046,7 +1125,7 @@ def create_task_from_plan_suggestion(
     request: PlannerTaskCreateRequest,
     services: AppServices = Depends(get_services),
 ) -> dict:
-    plan = _preview_goal_plan(goal_id, services)
+    plan = _preview_goal_plan(goal_id, services, persist_suggestions=True)
     suggestion = _get_plan_suggestion(plan, request.suggestion_index, goal_id)
     _ensure_suggestion_can_be_created(goal_id, request.suggestion_index, services)
     if suggestion["task_exists"]:
@@ -1094,7 +1173,7 @@ def create_tasks_from_plan_suggestions(
     request: PlannerBulkTaskCreateRequest,
     services: AppServices = Depends(get_services),
 ) -> dict:
-    plan = _preview_goal_plan(goal_id, services)
+    plan = _preview_goal_plan(goal_id, services, persist_suggestions=True)
     for suggestion_index in request.suggestion_indexes:
         _get_plan_suggestion(plan, suggestion_index, goal_id)
     requested_indexes = set(request.suggestion_indexes)

--- a/goal_ops_console/routers/system.py
+++ b/goal_ops_console/routers/system.py
@@ -558,6 +558,21 @@ def _planner_task_rows_by_goal_index(services: AppServices) -> dict[tuple[str, i
     return tasks_by_index
 
 
+def _planner_suggestion_rows(services: AppServices) -> list[dict[str, Any]]:
+    rows = services.db.fetch_all(
+        """SELECT s.suggestion_id,
+                  s.goal_id,
+                  g.title AS goal_title,
+                  s.suggestion_index,
+                  s.planner_source,
+                  s.created_at
+           FROM planner_suggestions s
+           JOIN goals g ON g.goal_id = s.goal_id
+           ORDER BY s.created_at ASC, s.suggestion_index ASC"""
+    )
+    return [dict(row) for row in rows]
+
+
 def _planner_reopened_counts_by_source(services: AppServices) -> dict[str, int]:
     rows = services.db.fetch_all(
         "SELECT payload FROM events WHERE event_type = 'planner.suggestion_review_reopened'"
@@ -590,6 +605,7 @@ def _planner_created_task_statuses(services: AppServices) -> dict[str, int]:
 def _build_planner_metrics_payload(services: AppServices) -> dict[str, Any]:
     now = datetime.now(UTC)
     goals = services.state_manager.list_goals()
+    suggestion_rows = _planner_suggestion_rows(services)
     reviews_by_index = _planner_review_rows_by_goal_index(services)
     tasks_by_index = _planner_task_rows_by_goal_index(services)
     reopened_by_source = _planner_reopened_counts_by_source(services)
@@ -612,46 +628,45 @@ def _build_planner_metrics_payload(services: AppServices) -> dict[str, Any]:
     for source, reopened_count in reopened_by_source.items():
         source_bucket(source)["reopened"] += reopened_count
 
-    for goal in goals:
-        plan = services.planner.create_plan(goal)
-        goal_id = str(goal["goal_id"])
-        goal_created_at = goal.get("created_at")
-        goal_pending_age = _age_seconds(now, goal_created_at)
-        for suggestion_index, _suggestion in enumerate(plan["suggestions"]):
-            review = reviews_by_index.get((goal_id, suggestion_index))
-            task = tasks_by_index.get((goal_id, suggestion_index))
-            source = str(
-                (review or {}).get("planner_source")
-                or (task or {}).get("planner_source")
-                or plan["source"]
-            )
-            bucket = source_bucket(source)
-            bucket["total_suggestions"] += 1
-            if review is not None:
-                decision = str(review["decision"])
-            elif task is not None:
-                decision = "created"
-            else:
-                decision = "pending"
-            counts_by_decision[decision] += 1
-            bucket[decision] += 1
-            if decision == "pending" and goal_pending_age is not None:
-                pending_ages.append(goal_pending_age)
-                if oldest_pending is None or goal_pending_age > oldest_pending["age_seconds"]:
-                    oldest_pending = {
-                        "goal_id": goal_id,
-                        "goal_title": goal.get("title"),
-                        "suggestion_index": suggestion_index,
-                        "age_seconds": goal_pending_age,
-                    }
-            if review is not None and decision == "deferred":
-                deferred_age = _age_seconds(now, review.get("updated_at"))
-                if deferred_age is None:
-                    continue
-                if deferred_age >= 7 * 24 * 60 * 60:
-                    deferred_over_7d += 1
-                if oldest_deferred_age_seconds is None or deferred_age > oldest_deferred_age_seconds:
-                    oldest_deferred_age_seconds = deferred_age
+    for suggestion in suggestion_rows:
+        goal_id = str(suggestion["goal_id"])
+        suggestion_index = int(suggestion["suggestion_index"])
+        review = reviews_by_index.get((goal_id, suggestion_index))
+        task = tasks_by_index.get((goal_id, suggestion_index))
+        source = str(
+            (review or {}).get("planner_source")
+            or (task or {}).get("planner_source")
+            or suggestion["planner_source"]
+        )
+        bucket = source_bucket(source)
+        bucket["total_suggestions"] += 1
+        if review is not None:
+            decision = str(review["decision"])
+        elif task is not None:
+            decision = "created"
+        else:
+            decision = "pending"
+        counts_by_decision[decision] += 1
+        bucket[decision] += 1
+        suggestion_age = _age_seconds(now, suggestion.get("created_at"))
+        if decision == "pending" and suggestion_age is not None:
+            pending_ages.append(suggestion_age)
+            if oldest_pending is None or suggestion_age > oldest_pending["age_seconds"]:
+                oldest_pending = {
+                    "goal_id": goal_id,
+                    "goal_title": suggestion.get("goal_title"),
+                    "suggestion_id": suggestion.get("suggestion_id"),
+                    "suggestion_index": suggestion_index,
+                    "age_seconds": suggestion_age,
+                }
+        if review is not None and decision == "deferred":
+            deferred_age = _age_seconds(now, review.get("updated_at"))
+            if deferred_age is None:
+                continue
+            if deferred_age >= 7 * 24 * 60 * 60:
+                deferred_over_7d += 1
+            if oldest_deferred_age_seconds is None or deferred_age > oldest_deferred_age_seconds:
+                oldest_deferred_age_seconds = deferred_age
 
     return {
         "timestamp_utc": _utc_iso(),
@@ -659,7 +674,7 @@ def _build_planner_metrics_payload(services: AppServices) -> dict[str, Any]:
         "semantics": {
             "current_decisions": ["pending", "created", "deferred", "rejected"],
             "historical_event_counts": ["reopened"],
-            "pending_age_basis": "goal_created_at",
+            "pending_age_basis": "planner_suggestion_created_at",
         },
         "goals_total": len(goals),
         "suggestions_total": (
@@ -671,12 +686,13 @@ def _build_planner_metrics_payload(services: AppServices) -> dict[str, Any]:
         "counts_by_decision": counts_by_decision,
         "counts_by_source": counts_by_source,
         "pending_age": {
-            "basis": "goal_created_at",
+            "basis": "planner_suggestion_created_at",
             "sample_count": len(pending_ages),
             "median_seconds": _median(pending_ages),
             "oldest_seconds": oldest_pending["age_seconds"] if oldest_pending is not None else None,
             "oldest_goal_id": oldest_pending["goal_id"] if oldest_pending is not None else None,
             "oldest_goal_title": oldest_pending["goal_title"] if oldest_pending is not None else None,
+            "oldest_suggestion_id": oldest_pending["suggestion_id"] if oldest_pending is not None else None,
             "oldest_suggestion_index": oldest_pending["suggestion_index"] if oldest_pending is not None else None,
         },
         "deferred_followups": {

--- a/tests/test_goal_ops.py
+++ b/tests/test_goal_ops.py
@@ -1299,6 +1299,7 @@ def test_53d_planner_review_decisions_schema_migration(services):
     assert {
         "goal_id",
         "suggestion_index",
+        "suggestion_id",
         "decision",
         "comment",
         "task_id",
@@ -1308,6 +1309,38 @@ def test_53d_planner_review_decisions_schema_migration(services):
         "suggestion_priority_hint",
         "operator_override",
     }.issubset(columns)
+
+
+def test_53e_planner_suggestions_schema_migration(services):
+    row = services.db.fetch_one(
+        "SELECT version, name FROM schema_migrations WHERE version = 6"
+    )
+    suggestion_columns = {
+        column["name"]
+        for column in services.db.fetch_all("PRAGMA table_info(planner_suggestions)")
+    }
+    task_columns = {column["name"] for column in services.db.fetch_all("PRAGMA table_info(tasks)")}
+    review_columns = {
+        column["name"]
+        for column in services.db.fetch_all("PRAGMA table_info(planner_suggestion_reviews)")
+    }
+
+    assert row is not None
+    assert row["name"] == "planner_suggestions"
+    assert {
+        "suggestion_id",
+        "goal_id",
+        "suggestion_index",
+        "planner_source",
+        "title",
+        "description",
+        "rationale",
+        "priority_hint",
+        "created_at",
+        "updated_at",
+    }.issubset(suggestion_columns)
+    assert "planner_suggestion_id" in task_columns
+    assert "suggestion_id" in review_columns
 
 
 def test_54_workflow_start_is_idempotent_with_idempotency_key(client):
@@ -15723,6 +15756,7 @@ def test_268_goal_plan_preview_returns_deterministic_suggestions(client):
     assert payload["goal_title"] == "Launch supervised planner"
     assert payload["source"] == "deterministic_planner"
     assert 3 <= len(payload["suggestions"]) <= 5
+    assert all(suggestion["suggestion_id"] for suggestion in payload["suggestions"])
     assert all(suggestion["task_exists"] is False for suggestion in payload["suggestions"])
     assert all(suggestion["existing_task_id"] is None for suggestion in payload["suggestions"])
 
@@ -15737,6 +15771,7 @@ def test_269_goal_plan_preview_suggestions_have_expected_fields(client):
 
     for suggestion in payload["suggestions"]:
         assert set(suggestion) == {
+            "suggestion_id",
             "title",
             "description",
             "rationale",
@@ -15749,6 +15784,7 @@ def test_269_goal_plan_preview_suggestions_have_expected_fields(client):
             "review_task_id",
             "reviewed_at",
         }
+        assert suggestion["suggestion_id"]
         assert suggestion["title"]
         assert suggestion["description"]
         assert suggestion["rationale"]
@@ -15798,12 +15834,42 @@ def test_271_goal_plan_preview_does_not_create_tasks(client):
 
     response = client.post(f"/goals/{goal['goal_id']}/plan")
     after = client.get(f"/tasks?goal_id={goal['goal_id']}").json()
+    persisted_suggestions = client.app.state.services.db.fetch_scalar(
+        "SELECT COUNT(*) FROM planner_suggestions WHERE goal_id = ?",
+        goal["goal_id"],
+    )
 
     assert response.status_code == 200
     assert before == []
     assert after == []
+    assert persisted_suggestions == len(response.json()["suggestions"])
     assert all(suggestion["task_exists"] is False for suggestion in response.json()["suggestions"])
     assert all(suggestion["existing_task_id"] is None for suggestion in response.json()["suggestions"])
+
+
+def test_271b_goal_plan_preview_persists_suggestions_idempotently(client):
+    goal = client.post(
+        "/goals",
+        json={"title": "Persist planner suggestions", "urgency": 0.6, "value": 0.4, "deadline_score": 0.1},
+    ).json()
+
+    first = client.post(f"/goals/{goal['goal_id']}/plan").json()
+    second = client.post(f"/goals/{goal['goal_id']}/plan").json()
+    rows = client.app.state.services.db.fetch_all(
+        """SELECT suggestion_id, suggestion_index, title, planner_source
+           FROM planner_suggestions
+           WHERE goal_id = ?
+           ORDER BY suggestion_index ASC""",
+        goal["goal_id"],
+    )
+
+    assert first == second
+    assert len(rows) == len(first["suggestions"])
+    assert [row["suggestion_id"] for row in rows] == [
+        suggestion["suggestion_id"] for suggestion in first["suggestions"]
+    ]
+    assert [row["title"] for row in rows] == [suggestion["title"] for suggestion in first["suggestions"]]
+    assert {row["planner_source"] for row in rows} == {"deterministic_planner"}
 
 
 def test_272_goal_plan_preview_suggestion_endpoint_creates_one_task(client):
@@ -15827,18 +15893,21 @@ def test_272_goal_plan_preview_suggestion_endpoint_creates_one_task(client):
     assert payload["suggestion"]["existing_task_id"] is None
     assert payload["task"]["title"] == selected["title"]
     assert payload["task"]["planner_source"] == selected["source"]
+    assert payload["task"]["planner_suggestion_id"] == selected["suggestion_id"]
     assert payload["task"]["planner_suggestion_index"] == 0
     assert payload["task"]["planner_priority_hint"] == selected["priority_hint"]
     assert payload["task"]["planner_suggestion_description"] == selected["description"]
     assert payload["task"]["planner_suggestion_rationale"] == selected["rationale"]
     assert payload["review"]["decision"] == "created"
     assert payload["review"]["task_id"] == payload["task"]["task_id"]
+    assert payload["review"]["suggestion_id"] == selected["suggestion_id"]
     assert payload["review"]["suggestion_rationale"] == selected["rationale"]
     assert len(tasks) == 1
     assert tasks[0]["goal_id"] == goal["goal_id"]
     assert tasks[0]["title"] == selected["title"]
     assert tasks[0]["title"] not in other_titles
     assert tasks[0]["planner_source"] == selected["source"]
+    assert tasks[0]["planner_suggestion_id"] == selected["suggestion_id"]
     assert tasks[0]["planner_suggestion_index"] == 0
     assert tasks[0]["planner_priority_hint"] == selected["priority_hint"]
     assert tasks[0]["planner_suggestion_description"] == selected["description"]
@@ -15895,12 +15964,14 @@ def test_272c_goal_plan_task_create_applies_operator_override_with_original_prov
     assert payload["operator_override"] == override
     assert payload["task"]["title"] == override["title"]
     assert payload["task"]["planner_source"] == selected["source"]
+    assert payload["task"]["planner_suggestion_id"] == selected["suggestion_id"]
     assert payload["task"]["planner_suggestion_index"] == 0
     assert payload["task"]["planner_priority_hint"] == selected["priority_hint"]
     assert payload["task"]["planner_suggestion_description"] == selected["description"]
     assert payload["task"]["planner_suggestion_rationale"] == selected["rationale"]
     assert payload["task"]["planner_operator_overrides"] == override
     assert payload["review"]["decision"] == "created"
+    assert payload["review"]["suggestion_id"] == selected["suggestion_id"]
     assert payload["review"]["operator_override"] == override
     assert len(tasks) == 1
     assert tasks[0]["title"] == override["title"]
@@ -15924,6 +15995,7 @@ def test_272d_goal_plan_review_defer_persists_decision_without_creating_task(cli
     assert response.status_code == 201
     payload = response.json()
     assert payload["review"]["decision"] == "deferred"
+    assert payload["review"]["suggestion_id"] == after["suggestions"][0]["suggestion_id"]
     assert payload["review"]["comment"] == "Wait for owner input."
     assert payload["review"]["task_id"] is None
     assert tasks == []
@@ -16974,7 +17046,7 @@ def test_272zd_system_planner_metrics_empty_state(client):
     assert payload["semantics"] == {
         "current_decisions": ["pending", "created", "deferred", "rejected"],
         "historical_event_counts": ["reopened"],
-        "pending_age_basis": "goal_created_at",
+        "pending_age_basis": "planner_suggestion_created_at",
     }
     assert payload["goals_total"] == 0
     assert payload["suggestions_total"] == 0
@@ -16987,12 +17059,13 @@ def test_272zd_system_planner_metrics_empty_state(client):
     }
     assert payload["counts_by_source"] == {}
     assert payload["pending_age"] == {
-        "basis": "goal_created_at",
+        "basis": "planner_suggestion_created_at",
         "sample_count": 0,
         "median_seconds": None,
         "oldest_seconds": None,
         "oldest_goal_id": None,
         "oldest_goal_title": None,
+        "oldest_suggestion_id": None,
         "oldest_suggestion_index": None,
     }
     assert payload["deferred_followups"] == {"over_7d": 0, "oldest_age_seconds": None}
@@ -17028,7 +17101,7 @@ def test_272ze_system_planner_metrics_counts_decisions_and_remains_read_only(cli
 
     services = client.app.state.services
     services.db.execute(
-        "UPDATE goals SET created_at = ? WHERE goal_id IN (?, ?)",
+        "UPDATE planner_suggestions SET created_at = ? WHERE goal_id IN (?, ?)",
         "2026-01-01 00:00:00",
         primary_goal["goal_id"],
         secondary_goal["goal_id"],
@@ -17041,6 +17114,7 @@ def test_272ze_system_planner_metrics_counts_decisions_and_remains_read_only(cli
     before_tasks = services.db.fetch_scalar("SELECT COUNT(*) FROM tasks")
     before_reviews = services.db.fetch_scalar("SELECT COUNT(*) FROM planner_suggestion_reviews")
     before_events = services.db.fetch_scalar("SELECT COUNT(*) FROM events")
+    before_suggestions = services.db.fetch_scalar("SELECT COUNT(*) FROM planner_suggestions")
 
     response = client.get("/system/planner_metrics")
     payload = response.json()
@@ -17049,6 +17123,7 @@ def test_272ze_system_planner_metrics_counts_decisions_and_remains_read_only(cli
     assert services.db.fetch_scalar("SELECT COUNT(*) FROM tasks") == before_tasks
     assert services.db.fetch_scalar("SELECT COUNT(*) FROM planner_suggestion_reviews") == before_reviews
     assert services.db.fetch_scalar("SELECT COUNT(*) FROM events") == before_events
+    assert services.db.fetch_scalar("SELECT COUNT(*) FROM planner_suggestions") == before_suggestions
     assert payload["goals_total"] == 2
     assert payload["suggestions_total"] == primary_total + secondary_total
     assert payload["counts_by_decision"] == {
@@ -17066,7 +17141,7 @@ def test_272ze_system_planner_metrics_counts_decisions_and_remains_read_only(cli
         "rejected": 1,
         "reopened": 1,
     }
-    assert payload["pending_age"]["basis"] == "goal_created_at"
+    assert payload["pending_age"]["basis"] == "planner_suggestion_created_at"
     assert payload["pending_age"]["sample_count"] == primary_total + secondary_total - 3
     assert payload["pending_age"]["median_seconds"] > 0
     assert payload["pending_age"]["oldest_seconds"] > 0
@@ -17300,6 +17375,7 @@ def test_277_manual_task_create_has_no_planner_provenance(client):
 
     assert response.status_code == 201
     assert task["planner_source"] is None
+    assert task["planner_suggestion_id"] is None
     assert task["planner_suggestion_index"] is None
     assert task["planner_priority_hint"] is None
     assert task["planner_suggestion_description"] is None
@@ -17307,6 +17383,7 @@ def test_277_manual_task_create_has_no_planner_provenance(client):
     assert task["planner_operator_overrides"] is None
     assert len(tasks) == 1
     assert tasks[0]["planner_source"] is None
+    assert tasks[0]["planner_suggestion_id"] is None
     assert tasks[0]["planner_suggestion_index"] is None
     assert tasks[0]["planner_priority_hint"] is None
     assert tasks[0]["planner_suggestion_description"] is None


### PR DESCRIPTION
﻿## Summary
- Adds a `planner_suggestions` persistence migration with stable suggestion ids per goal/index.
- Links planner-created tasks and planner reviews back to the persisted `suggestion_id` while keeping existing denormalized provenance fields for compatibility.
- Updates planner metrics to aggregate from persisted suggestions, keeping the metrics endpoint read-only.

## Why
This is the backend foundation recommended by the independent review: planner suggestions should become first-class persisted records before we add more planner UI or consider future external/LLM sources.

## User/Developer Impact
- `POST /goals/{goal_id}/plan` now persists deterministic preview suggestions idempotently.
- Planner task creation/review responses include `suggestion_id`.
- Manual tasks remain unlinked to planner suggestions.
- No UI expansion and no CI/guard workflow changes.

## Validation
- `python -m py_compile goal_ops_console\database.py goal_ops_console\execution_layer.py goal_ops_console\routers\goals.py goal_ops_console\routers\system.py goal_ops_console\models.py`
- `python -m pytest tests\test_goal_ops.py -k "53e or 268 or 269 or 271 or 272 or 273 or 274 or 275 or 276 or 277"` -> 59 passed
- `python -m pytest` -> 376 passed
- `git diff --check` -> clean except expected Windows LF/CRLF warnings
